### PR TITLE
Adding Tasks/Launch settings for vscode support.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Blazor Server App",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build (UI)",
+            "program": "${workspaceFolder}/src/Server.UI/bin/Debug/net8.0/Cfo.Cats.Server.UI.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Server.UI/",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/src/Server.UI/Views"
+            }
+        },
+        {
+            "name": "Launch Build Console App",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build (Build Project)",
+            "program": "${workspaceFolder}/build/bin/Debug/net8.0/Build.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/build",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build (UI)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Server.UI/Server.UI.csproj"
+            ],
+            "problemMatcher": "$msCompile",
+            "group":{
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Build (Build Project)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/build/Build.csproj"
+            ],
+            "problemMatcher": "$msCompile",
+            "group":{
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This commit sets up the default task and launch settings for when using visual studio code.

- it setups a build and run configuration for the blazor app
- it adds a secondary task that will launch the build project (build and test)