### PR TITLE
Update dependabot to create only one pull request for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget" 
-    directory: "/"             
+  - package-ecosystem: "nuget"
+    directory: "/"
     schedule:
-      interval: "weekly"       
-    open-pull-requests-limit: 5 
+      interval: "weekly"
     commit-message:
-      prefix: "deps"           
-    target-branch: "main"      
-    labels:
-      - "dependencies"          
-    reviewers:
-      - "ministryofjustice/hmpps-co-financing-organisation"             # Request review from a team or user
+      prefix: "deps"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request should force dependabot to create 1 pull request with all nuget packages updated.

Not testable locally.