### PR TITLE
Dependabot is ignoring the weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "04:00"
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 1


### PR DESCRIPTION
This change adds a specific day and time for the checks to take place this will hopefully stop dependabot generating a pull request the minute a package is updated on nuget