### PR TITLE
Fix when setting the location of an enrolment

### DIFF
--- a/src/Application/Features/Locations/DTOs/LocationDto.cs
+++ b/src/Application/Features/Locations/DTOs/LocationDto.cs
@@ -5,11 +5,11 @@ namespace Cfo.Cats.Application.Features.Locations.DTOs;
 
 public record LocationDto
 {
-    public int Id { get; init; } 
-    public required string Name { get; init; }
-    public required GenderProvision GenderProvision { get; init; } 
+    public int Id { get; set; } 
+    public required string Name { get; set; }
+    public required GenderProvision GenderProvision { get; set; } 
     
-    public required LocationType LocationType { get; init; }
+    public required LocationType LocationType { get; set; }
     
     /// <summary>
     /// The parent location (currently only supported on community locations)

--- a/src/Application/Features/Participants/Commands/SetEnrolmentLocation.cs
+++ b/src/Application/Features/Participants/Commands/SetEnrolmentLocation.cs
@@ -21,6 +21,7 @@ public static class SetEnrolmentLocation
         /// <summary>
         /// The location to assign the enrolment to
         /// </summary>
+        [Description("Current Location")]
         public LocationDto CurrentLocation { get; set; } = currentLocation;
 
         /// <summary>
@@ -32,8 +33,10 @@ public static class SetEnrolmentLocation
         /// A justification for enrolling a participant in a location
         /// other than where we think they are
         /// </summary>
+        [Description("Justification reason for alternative enrolment location")]
         public string? JustificationReason { get; set; } = justificationReason;
 
+        [Description("Enrol at an alternative location enrolment")]
         public bool EnrolFromOtherLocation { get; set; } = enrolmentLocation.Id != currentLocation.Id;
         
         public string CacheKey => ParticipantCacheKey.GetCacheKey($"Id:{this.Identifier}");
@@ -72,10 +75,18 @@ public static class SetEnrolmentLocation
 
             RuleFor(x => x.EnrolmentLocation)
                 .NotNull();
+
+            When(x => x.EnrolFromOtherLocation, () => {
+                RuleFor(x => x.EnrolmentLocation)
+                    .Must((model, enrolmentLocation) => model.CurrentLocation != enrolmentLocation)
+                    .WithMessage("Enrolment location must be different when Enrol from another location is selected");
+            });
+            
             
             When(x => x.CurrentLocation != x.EnrolmentLocation, () => {
                 RuleFor(x => x.JustificationReason)
                     .NotNull()
+                    .WithMessage("Justification reason is mandatory when enrolling in a different location")
                     .NotEmpty()
                     .WithMessage("Justification reason is mandatory when enrolling in a different location");
             });

--- a/src/Server.UI/Pages/Enrolments/Components/Location.razor
+++ b/src/Server.UI/Pages/Enrolments/Components/Location.razor
@@ -1,22 +1,53 @@
 ﻿@using Cfo.Cats.Application.Features.Locations.DTOs
 @using Cfo.Cats.Application.Features.Participants.Commands
+@inject IStringLocalizer<Location> L
 
 @if (Model is not null && Locations is not [])
 {
-    <MudForm @ref="_form" Validation="@(Validator.ValidateValue(Model))">
-        <MudTextField T="string" Label="Location" Value="@Model.CurrentLocation.Name" Disabled/>
+    <MudForm Model="Model" @ref="_form" Validation="@(Validator.ValidateValue(Model))">
 
-        <MudCheckBox T="bool" @bind-Value="Model.EnrolFromOtherLocation" Label="Enrol at alternative location"/>
-
-        <MudSelect T="LocationDto" @bind-Value="Model.EnrolmentLocation" Label="Alternative Location" AnchorOrigin="Origin.BottomCenter" Disabled="!Model.EnrolFromOtherLocation">
-            @foreach (var location in Locations!)
+        <MudGrid>
+            <MudItem xs="12">
+                <MudTextField Label="@L[Model.GetMemberDescription(x => x.CurrentLocation)]" 
+                              @bind-Value="Model.CurrentLocation.Name" 
+                              ReadOnly="true"
+                              Variant="Variant.Text">
+                </MudTextField>
+            </MudItem>
+            <MudItem xs="12">
+                <MudCheckBox T="bool" @bind-Value="Model.EnrolFromOtherLocation"
+                             Label="@L[Model.GetMemberDescription(x => x.EnrolFromOtherLocation)]">
+                </MudCheckBox>
+            </MudItem>
+            @if (Model.EnrolFromOtherLocation)
             {
-                <MudSelectItem Value="location">
-                    @location.Name
-                </MudSelectItem>
+                <MudItem xs="12">
+                    <MudSelect T="LocationDto"
+                               Label="@L["Alternative Location"]"
+                               Required="true"
+                               @bind-Value="@Model.EnrolmentLocation"
+                               For="@(()=>Model.EnrolmentLocation)">
+                        @foreach (var item in Locations!)
+                        {
+                            <MudSelectItem T="LocationDto" Value="@item">
+                                @item.Name
+                            </MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField Label="@L[Model.GetMemberDescription(x => x.JustificationReason)]"
+                                  @bind-Value="Model.JustificationReason"
+                                  For="@(()=>Model.JustificationReason)">
+                    </MudTextField>
+                </MudItem>
             }
-        </MudSelect>
-        <MudTextFieldExtended T="string" @bind-Value="Model.JustificationReason" Label="Reason for alternative location enrolment" Disabled="!Model.EnrolFromOtherLocation"/>
+        </MudGrid>
+
+        @* 
+
+       
+        <MudTextFieldExtended T="string" @bind-Value="Model.JustificationReason" Label="" Disabled="!Model.EnrolFromOtherLocation"/> *@
     </MudForm>
 }
 

--- a/src/Server.UI/Pages/Enrolments/Enrolment.razor
+++ b/src/Server.UI/Pages/Enrolments/Enrolment.razor
@@ -144,7 +144,7 @@
 
             Locations = await Mediator.Send(new GetAllLocationsQuery()
             {
-                UserProfile = this.UserProfile!
+                UserProfile = UserProfile!
             });
 
         }


### PR DESCRIPTION
- An validation error is now displayed when you don't justify alternative location
- You cannot select use another location and then select the same location
- hide controls when not needed
- fix grammar on some labels.