### PR TITLE
Fix db exception when uploading documentation

### DIFF
--- a/src/Domain/Entities/Documents/Document.cs
+++ b/src/Domain/Entities/Documents/Document.cs
@@ -7,13 +7,15 @@ namespace Cfo.Cats.Domain.Entities.Documents;
 
 public class Document : OwnerPropertyEntity<Guid>, IMayHaveTenant, IAuditTrial
 {
+    
     private Document()
     {
-        Id = Guid.NewGuid();
+        
     }
 
     private Document(string title, string description, DocumentType documentType)
     {
+        Id = Guid.NewGuid();
         Title = title;
         IsPublic = false;
         Description = description;


### PR DESCRIPTION
The Document Id was not being generated when following the new static factory method. This led to a database exception.