### PR TITLE
Hide the menu by default

### DIFF
--- a/src/Server.UI/Components/Shared/Layout/AppLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/AppLayout.razor
@@ -46,8 +46,8 @@
 @code
 {
     private bool _commandPaletteOpen;
-    private bool _navigationMenuDrawerOpen = true;
-    private bool _themingDrawerOpen;
+    private bool _navigationMenuDrawerOpen = false;
+    private bool _themingDrawerOpen = false;
     private UserProfile? _userProfile;
     private ErrorBoundary? ErrorBoundary { set; get; }
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;


### PR DESCRIPTION
This is a quick fix that ensures the menu is hidden by default.