### PR TITLE
Show activity log.

### DIFF
--- a/src/Application/Features/Dashboard/DTOs/ActivityLogDto.cs
+++ b/src/Application/Features/Dashboard/DTOs/ActivityLogDto.cs
@@ -1,0 +1,37 @@
+using Cfo.Cats.Domain.Entities.Participants;
+
+namespace Cfo.Cats.Application.Features.Dashboard.DTOs;
+
+public class ActivityLogDto
+{
+    public string ParticipantId { get; set; } = default!;
+    public string ParticipantName { get;set; } = default!;
+
+    public TimelineEventType EventType { get;set; } = default!;
+
+    public string Line1 { get;set; } = default!;
+    public string? Line2 {get;set;}
+    public string? Line3 {get;set;}
+    public string CreatedBy {get;set;} = default!;
+    public DateTime Created { get; set;}
+
+    private class Mapper : Profile
+    {
+        public Mapper()
+        {
+            #nullable disable
+            CreateMap<Timeline, ActivityLogDto>(MemberList.None)
+                .ForMember(t => t.ParticipantId, o => o.MapFrom(s => s.ParticipantId))
+                .ForMember(t => t.ParticipantName, o => o.MapFrom(s => s.Participant.FirstName + " " + s.Participant.LastName))
+                .ForMember(t => t.EventType, o => o.MapFrom(s => s.EventType))
+                .ForMember(t => t.Line1, o => o.MapFrom(s => s.Line1))
+                .ForMember(t => t.Line2, o => o.MapFrom(s => s.Line2))
+                .ForMember(t => t.Line3, o => o.MapFrom(s => s.Line3))
+                .ForMember(t => t.CreatedBy, o => o.MapFrom(s => s.CreatedByUser.DisplayName))
+                .ForMember(t => t.Created, o => o.MapFrom(s => s.Created));
+        
+        }
+    }
+
+
+}

--- a/src/Application/Features/Dashboard/Queries/GetActivityLog.cs
+++ b/src/Application/Features/Dashboard/Queries/GetActivityLog.cs
@@ -1,0 +1,41 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Features.Dashboard.DTOs;
+using Cfo.Cats.Application.Features.Dashboard.Specifications;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Entities.Participants;
+using DocumentFormat.OpenXml.Vml.Spreadsheet;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Queries;
+
+public static class GetActivityLog
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Query : ActivityLogFilter, IRequest<PaginatedData<ActivityLogDto>>
+    {
+        public ActivityLogSpecification Specification => new(this);
+        
+    }
+
+    public class Handler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<Query, PaginatedData<ActivityLogDto>>
+    {
+        public async Task<PaginatedData<ActivityLogDto>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var data = await unitOfWork.DbContext.Timelines.AsNoTracking()
+                .OrderBy($"{request.OrderBy} {request.SortDirection}")
+                .ProjectToPaginatedDataAsync<Timeline, ActivityLogDto>(request.Specification, request.PageNumber, request.PageSize, mapper.ConfigurationProvider, cancellationToken );
+
+            return data!;
+        }
+    }
+
+    public class Validator : AbstractValidator<Query>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.CurrentUser)
+                .NotNull();
+        }
+    }
+
+
+}

--- a/src/Application/Features/Dashboard/Specifications/ActivityLogFilter.cs
+++ b/src/Application/Features/Dashboard/Specifications/ActivityLogFilter.cs
@@ -1,0 +1,9 @@
+using Cfo.Cats.Application.Common.Security;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Specifications;
+
+public class ActivityLogFilter : PaginationFilter
+{
+    public UserProfile? CurrentUser { get;set; }
+    public ActivityLogListView ListView { get; set; } = ActivityLogListView.All;
+}

--- a/src/Application/Features/Dashboard/Specifications/ActivityLogListView.cs
+++ b/src/Application/Features/Dashboard/Specifications/ActivityLogListView.cs
@@ -1,0 +1,9 @@
+﻿namespace Cfo.Cats.Application.Features.Dashboard.Specifications;
+
+public enum ActivityLogListView
+{
+    [Description("All")]
+    All,
+    [Description("Created Today")]
+    CreatedToday,
+}

--- a/src/Application/Features/Dashboard/Specifications/ActivityLogSpecification.cs
+++ b/src/Application/Features/Dashboard/Specifications/ActivityLogSpecification.cs
@@ -1,0 +1,24 @@
+using Cfo.Cats.Domain.Entities.Participants;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Specifications;
+
+public class ActivityLogSpecification : Specification<Timeline>
+{
+    public ActivityLogSpecification(ActivityLogFilter filter)
+    {
+        #nullable disable
+        
+        var today = DateTime.Now.ToUniversalTime().Date;
+
+
+
+        Query.Where(t => t.Participant.OwnerId == filter.CurrentUser.UserId, filter.CurrentUser.AssignedRoles is []);
+
+        Query.Where(t => t.Participant.Owner.TenantId.StartsWith(filter.CurrentUser.TenantId));
+        
+        Query.Where(
+            p => p.Created >= DateTime.Now.Date,
+            filter.ListView == ActivityLogListView.CreatedToday
+            );
+    }
+}

--- a/src/Domain/Entities/Participants/Timeline.cs
+++ b/src/Domain/Entities/Participants/Timeline.cs
@@ -37,5 +37,7 @@ public class Timeline : BaseAuditableEntity<int>
     }
 
     public virtual ApplicationUser? CreatedByUser { get; private set; }
+
+    public virtual Participant? Participant { get; private set; }
 }
 

--- a/src/Infrastructure/Persistence/Configurations/Participants/TimelineEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Participants/TimelineEntityTypeConfiguration.cs
@@ -16,7 +16,7 @@ public class TimelineEntityTypeConfiguration : IEntityTypeConfiguration<Timeline
 
         builder.HasKey(t => t.Id);
 
-        builder.HasOne<Domain.Entities.Participants.Participant>()
+        builder.HasOne(t => t.Participant)
             .WithMany()
             .HasForeignKey("ParticipantId");
 

--- a/src/Server.UI/Pages/Dashboard/Components/ActivityLog.razor
+++ b/src/Server.UI/Pages/Dashboard/Components/ActivityLog.razor
@@ -1,0 +1,147 @@
+@using Cfo.Cats.Application.Features.Dashboard.DTOs
+@using Cfo.Cats.Application.Features.Dashboard.Specifications
+@using Cfo.Cats.Application.Features.Dashboard.Queries
+@using Humanizer
+
+<style>
+    .mud-table-toolbar {
+        height: 120px !important;
+    }
+
+    .pointer-cursor {
+        cursor: pointer;
+    }
+
+</style>
+@inherits CatsComponentBase
+
+<MudCard>
+    <MudCardHeader>
+        <CardHeaderContent>
+            <MudText Typo="Typo.h6">Activity Log</MudText>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent>
+        <MudDataGrid ServerData="@(ServerReload)" T="ActivityLogDto" FixedHeader="true" FixedFooter="true"
+                     Virtualize="true" @bind-RowsPerPage="defaultPageSize" Height="500px" Loading="@loading" Hover="true" RowClick="@RowClicked"
+                     RowClass="pointer-cursor" @ref="table">
+            <ToolBarContent>
+               <div class="d-flex align-start flex-grow-1">
+                <div class="d-flex gap-4">
+                    <MudIcon Icon="@Icons.Material.Filled.PendingActions" Size="Size.Large"/>
+                    <div class="d-flex flex-column">
+                        <MudText Typo="Typo.caption" Class="mb-2">Activity Log</MudText>
+                        <MudEnumSelect Style="min-width:160px" TEnum="ActivityLogListView" ValueChanged="OnChangedListView" Value="Query.ListView" Dense="true" Label="List View">
+                        </MudEnumSelect>
+                    </div>
+                </div>
+                <div class="flex-grow-1"/>
+
+                <div class="d-flex flex-column justify-end">
+                    <div class="d-flex">
+                        <MudButton Variant="Variant.Outlined"
+                                Size="Size.Small"
+                                OnClick="@(() => OnRefresh())"
+                                StartIcon="@Icons.Material.Filled.Refresh" IconColor="Color.Surface" Color="Color.Primary"
+                                Style="margin-right: 4px; margin-bottom:4px">
+                            @ConstantString.Refresh
+                        </MudButton>
+                    </div>
+                </div>
+            </div>
+            </ToolBarContent>
+            <Columns>
+                <PropertyColumn Property="x => x.ParticipantId" Title="Participant Id"></PropertyColumn>
+                <PropertyColumn Property="x => x.ParticipantName" Title="Participant" Sortable="false"></PropertyColumn>
+                <PropertyColumn Property="x => x.EventType" Sortable="true"> </PropertyColumn>
+                <PropertyColumn Property="x => x.Line1" Title="Details" Sortable="false">
+                    <CellTemplate>
+                        <div class="d-flex flex-column">
+                            <MudText Typo="Typo.body2">@context.Item.Line1</MudText>
+                            @if (context.Item.Line2 is not null)
+                            {
+                                <MudText Typo="Typo.body2">@context.Item.Line2</MudText>
+                            }
+                            @if (context.Item.Line3 is not null)
+                            {
+                                <MudText Typo="Typo.body2">@context.Item.Line3</MudText>
+                            }
+                        </div>
+                    </CellTemplate>
+                </PropertyColumn>
+                <PropertyColumn Property="x => x.CreatedBy" Title="Created" Sortable="true" SortBy="x => x.Created">
+                    <CellTemplate>
+                        <div class="d-flex flex-column">
+                            <MudText Typo="Typo.body2">@context.Item.CreatedBy</MudText>
+                            <MudText Typo="Typo.body2" Class="mud-text-secondary">@context.Item.Created.Humanize()
+                            </MudText>
+                        </div>
+                    </CellTemplate>
+                </PropertyColumn>
+            </Columns>
+            <NoRecordsContent>
+                <MudText>@ConstantString.NoRecords</MudText>
+            </NoRecordsContent>
+            <LoadingContent>
+                <MudText>@ConstantString.Loading</MudText>
+            </LoadingContent>
+            <PagerContent>
+                <MudDataGridPager PageSizeOptions="@(new[] { 10, 15, 30, 50, 100, 500, 1000 })" />
+            </PagerContent>
+        </MudDataGrid>
+    </MudCardContent>
+</MudCard>
+
+@code
+{
+    [CascadingParameter]
+    public UserProfile? UserProfile { get; set; }
+
+    private GetActivityLog.Query Query { get; } = new();
+
+    private MudDataGrid<ActivityLogDto> table = null!;
+
+    private bool loading;
+
+    private int defaultPageSize = 15;
+
+    private readonly ActivityLogDto currentDto = new();
+
+    private async Task<GridData<ActivityLogDto>> ServerReload(GridState<ActivityLogDto> state)
+    {
+        try
+        {
+            loading = true;
+            Query.CurrentUser = UserProfile;
+            Query.OrderBy = state.SortDefinitions.FirstOrDefault()?.SortBy ?? "Created";
+            Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() :
+            SortDirection.Ascending.ToString();
+            Query.PageNumber = state.Page + 1;
+            Query.PageSize = state.PageSize;
+
+            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            return new GridData<ActivityLogDto> { TotalItems = result.TotalItems, Items = result.Items };
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private async Task OnRefresh()
+    {
+        await table.ReloadServerData();
+    }
+    
+    private async Task OnChangedListView(ActivityLogListView listview)
+    {
+        Query.ListView = listview;
+        await table.ReloadServerData();
+    }
+    
+    private void RowClicked(DataGridRowClickEventArgs<ActivityLogDto> args)
+    {
+        Navigation.NavigateTo($"/pages/participants/{args.Item.ParticipantId}");
+    }
+
+} 

--- a/src/Server.UI/Pages/Dashboard/Dashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/Dashboard.razor
@@ -1,6 +1,10 @@
 ﻿@page "/"
+@using Cfo.Cats.Application.Features.Dashboard.DTOs
 @using Cfo.Cats.Application.Features.Dashboard.Queries
 @using Cfo.Cats.Application.SecurityConstants
+@using Cfo.Cats.Domain.Common.Enums
+@using Cfo.Cats.Server.UI.Pages.Dashboard.Components
+@using Humanizer
 
 @inherits CatsComponentBase
 
@@ -13,90 +17,97 @@
         Dashboard
     </MudText>
     <MudGrid>
-        <MudItem xs="3">
-            <MudCard>
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            Pending Cases
+        
+        @if (UserProfile?.AssignedRoles is [])
+        {
+            <MudItem xs="3">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">
+                                Pending Cases
+                            </MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText>Your cases that are awaiting enrolment confirmation</MudText>
+                        <MudText Typo="Typo.h1" Align="Align.Center">
+                            @_dashboardDto?.PendingCases
                         </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText>Your cases that are awaiting enrolment confirmation</MudText>
-                    <MudText Typo="Typo.h1" Align="Align.Center">
-                        @_dashboardDto?.PendingCases
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <MudItem xs="3">
-            <MudCard>
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            Enrolling Cases
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="3">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">
+                                Enrolling Cases
+                            </MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText>Your cases that are awaiting submission to PQA</MudText>
+                        <MudText Typo="Typo.h1" Align="Align.Center">
+                            @_dashboardDto?.ConfirmedCases
                         </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText>Your cases that are awaiting submission to PQA</MudText>
-                    <MudText Typo="Typo.h1" Align="Align.Center">
-                        @_dashboardDto?.ConfirmedCases
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <MudItem xs="3">
-            <MudCard>
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            Provider QA
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="3">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">
+                                Provider QA
+                            </MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText>Your cases that are sat with Provider QA</MudText>
+                        <MudText Typo="Typo.h1" Align="Align.Center">
+                            @_dashboardDto?.CasesAtPqa
                         </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText>Your cases that are sat with Provider QA</MudText>
-                    <MudText Typo="Typo.h1" Align="Align.Center">
-                        @_dashboardDto?.CasesAtPqa
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <MudItem xs="3">
-            <MudCard>
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            CFO QA
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="3">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">
+                                CFO QA
+                            </MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText>Your cases that are sat with CFO QA</MudText>
+                        <MudText Typo="Typo.h1" Align="Align.Center">
+                            @_dashboardDto?.CasesAtCfo
                         </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText>Your cases that are sat with CFO QA</MudText>
-                    <MudText Typo="Typo.h1" Align="Align.Center">
-                        @_dashboardDto?.CasesAtCfo
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-        <MudItem xs="3">
-            <MudCard>
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            Approved Cases
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+            <MudItem xs="3">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">
+                                Approved Cases
+                            </MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText>Your cases that have been approved</MudText>
+                        <MudText Typo="Typo.h1" Align="Align.Center">
+                            @_dashboardDto?.ApprovedCases
                         </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText>Your cases that have been approved</MudText>
-                    <MudText Typo="Typo.h1" Align="Align.Center">
-                        @_dashboardDto?.ApprovedCases
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+        <MudItem xs="12">
+            <ActivityLog/>
         </MudItem>
     </MudGrid>
 </MudContainer>
@@ -107,17 +118,19 @@
 
     public string Title { get; } = "Dashboard";
 
-    private DashboardDto? _dashboardDto = null; 
-    
+    private DashboardDto? _dashboardDto = null;
+
+
+
     [CascadingParameter]
     public UserProfile? UserProfile { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         var query = new GetDashboard.Query()
-        {
-            CurrentUser = UserProfile!
-        };
+            {
+                CurrentUser = UserProfile!
+            };
 
         var result = await GetNewMediator().Send(query);
 
@@ -125,7 +138,11 @@
         {
             _dashboardDto = result.Data;
         }
-        
+
+      
+
     }
+
+    
 
 }


### PR DESCRIPTION
This should should an activity log on the dashboard.

Non support workers (i.e. people with roles) should not see the default "your" cards, but should see all cases at their tenant and below.

Case workers should only see their cases.