### PR TITLE
allow additional characters in the username field to support genuine email addresses

### DIFF
--- a/src/Infrastructure/Configurations/IdentitySettings.cs
+++ b/src/Infrastructure/Configurations/IdentitySettings.cs
@@ -51,4 +51,6 @@ public class IdentitySettings : IIdentitySettings
     /// </summary>
     public int MaxFailedAccessAttempts { get; set; } = 5;
 
+    public string AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+'";
+
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -230,6 +230,7 @@ public static class DependencyInjection
 
             // User settings
             options.User.RequireUniqueEmail = true;
+            options.User.AllowedUserNameCharacters = identitySettings.AllowedUserNameCharacters;
             //options.Tokens.EmailConfirmationTokenProvider = "Email";
         });
 

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -72,7 +72,8 @@
     "RequireLowerCase": true,
     "DefaultLockoutTimeSpan": 30,
     "MaxFailedAccessAttempts": 5,
-    "SecureCookies": true
+    "SecureCookies": true,
+    "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+'"
   },
   "Notify": {
     "ApiKey": "",


### PR DESCRIPTION
The microsoft identity platform needs to allow additional characters. These are in addition to the validation we have on the DTOs.

users with apostrophies in their emails can now be registered.