### PR TITLE
Risk due date is now reset to 70 days...

### DIFF
--- a/src/Application/Features/Participants/EventHandlers/RiskInformationReviewed.cs
+++ b/src/Application/Features/Participants/EventHandlers/RiskInformationReviewed.cs
@@ -1,0 +1,20 @@
+﻿using Cfo.Cats.Domain.Events;
+
+namespace Cfo.Cats.Application.Features.Participants.EventHandlers;
+
+public class RiskInformationReviewed(IUnitOfWork unitOfWork) : INotificationHandler<RiskInformationReviewedDomainEvent>
+{
+    public async Task Handle(RiskInformationReviewedDomainEvent notification, CancellationToken cancellationToken)
+    {
+        var participant = await unitOfWork.DbContext.Participants
+            .Where(p => p.Id == notification.Item.ParticipantId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (participant is not null)
+        {
+            participant.SetRiskDue(DateTime.UtcNow.AddDays(70));
+            unitOfWork.DbContext.Participants.Update(participant);
+        }
+
+    }
+}

--- a/src/Domain/Entities/Participants/Risk.cs
+++ b/src/Domain/Entities/Participants/Risk.cs
@@ -41,7 +41,10 @@ public class Risk : BaseAuditableEntity<Guid>
         from.Completed = null;
         from.CompletedBy = null;
         from.RegistrationDetailsJson = null;
-        from.AddDomainEvent(new RiskInformationReviewedDomainEvent(from));
+        if (reason == RiskReviewReason.NoChange || reason ==RiskReviewReason.NoRiskInformationAvailable)
+        {
+            from.AddDomainEvent(new RiskInformationReviewedDomainEvent(from));
+        }
         return from;
     }
 


### PR DESCRIPTION
Risk due date is now reset to 70 days when user reviews the Risk with options ‘No risk information available’ or ‘No change’