### PR TITLE
This change allows logs to go to the telemetry page in aspire.

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -43,6 +43,7 @@
         <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
         <PackageReference Include="ZiggyCreatures.FusionCache" Version="1.4.1" />
         <PackageReference Include="Hmpps.Cfo.Matching.Core" Version="1.0.0" />
     </ItemGroup>

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -33,23 +33,7 @@
         "Name": "Console"
       },
       {
-        "Name": "File",
-        "Args": {
-          "path": "../../logs/log-.txt",
-          "rollingInterval": "Hour",
-          "restrictedToMinimumLevel": "Verbose"
-        }
-      },
-      {
-        "Name": "Sentry",
-        "Args": {
-          "dsn": "",
-          "minimumBreadcrumbLevel": "Information",
-          "minimumEventLevel": "Error",
-          "sendDefaultPii": true,
-          "Release": "1.0.1-dev",
-          "Environment": "Development"
-        }
+        "Name": "OpenTelemetry"
       }
     ],
     "Enrich": [


### PR DESCRIPTION
Won't be used in live.