### PR TITLE
Fix for missing/broken validation for employment

### DIFF
--- a/src/Server.UI/Pages/Activities/Components/Employment.razor
+++ b/src/Server.UI/Pages/Activities/Components/Employment.razor
@@ -27,12 +27,13 @@
             </MudItem>    
             <MudItem xs="12">
                 <MudAutocomplete
-                Label="@Model.GetMemberDescription(x => x.JobTitle)" 
-                @bind-Value="Model.JobTitle"
-                @bind-Value:after="OnJobTitleValueChange"
-                SearchFunc="@SearchJobTitles"
-                ResetValueOnEmptyText="true" CoerceText="true" CoerceValue="true" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search"
-                AdornmentColor="Color.Primary" MaxItems="null"/>
+                    Label="@Model.GetMemberDescription(x => x.JobTitle)" 
+                    For="() => Model.JobTitle"
+                    @bind-Value="Model.JobTitle"
+                    @bind-Value:after="OnJobTitleValueChange"
+                    SearchFunc="@SearchJobTitles"
+                    ResetValueOnEmptyText="true" CoerceText="true" CoerceValue="true" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search"
+                    AdornmentColor="Color.Primary" MaxItems="null"/>
             </MudItem>
             <MudItem xs="12">
                 <MudItem xs="12">


### PR DESCRIPTION
Added a missing 'For' attribute to the employment template, which caused an exception to be thrown when a job title was not selected.