### PR TITLE
Use support worker from most recent submission to PQA

### DIFF
--- a/src/Application/Features/ManagementInformation/IntegrationEventHandlers/RecordEnrolmentPaymentConsumer.cs
+++ b/src/Application/Features/ManagementInformation/IntegrationEventHandlers/RecordEnrolmentPaymentConsumer.cs
@@ -46,11 +46,11 @@ public class RecordEnrolmentPaymentConsumer(IUnitOfWork unitOfWork) : IConsumer<
             var supportWorker = await unitOfWork.DbContext.EnrolmentPqaQueue
                 .Where(q => q.ParticipantId == context.Message.ParticipantId)
                 .OrderByDescending(q => q.Created)
-                .Select(p => new
+                .Select(pqa => new
                 {
-                    SupportWorkerId = p.CreatedBy!,
-                    p.TenantId,
-                    SubmissionToPqa = p.Created
+                    SupportWorkerId = pqa.SupportWorkerId!,
+                    pqa.TenantId,
+                    SubmissionToPqa = pqa.Created
                 })
                 .FirstAsync();
 


### PR DESCRIPTION
This pull request changes the MI consumer to use the support worker id from the PQA entry rather than the created by column.

PQA entries that go via CFO return process are created by the CFO user, this results in incorrect MI data.