### PR TITLE
This commit addresses two major issues:

### DIFF
--- a/src/Application/Common/Interfaces/Contracts/IContractService.cs
+++ b/src/Application/Common/Interfaces/Contracts/IContractService.cs
@@ -1,11 +1,10 @@
 ﻿using Cfo.Cats.Application.Features.Contracts.DTOs;
-using Cfo.Cats.Application.Features.Locations.DTOs;
 
 namespace Cfo.Cats.Application.Common.Interfaces.Contracts;
 
 public interface IContractService
 {
-    List<ContractDto> DataSource { get; }
+    IReadOnlyList<ContractDto> DataSource { get; }
     event Action? OnChange;
     void Initialize();
     void Refresh();

--- a/src/Application/Common/Interfaces/IPicklistService.cs
+++ b/src/Application/Common/Interfaces/IPicklistService.cs
@@ -4,7 +4,7 @@ namespace Cfo.Cats.Application.Common.Interfaces;
 
 public interface IPicklistService
 {
-    List<KeyValueDto> DataSource { get; }
+    IReadOnlyList<KeyValueDto> DataSource { get; }
     event Action? OnChange;
     void Initialize();
     void Refresh();

--- a/src/Application/Common/Interfaces/Identity/IUserService.cs
+++ b/src/Application/Common/Interfaces/Identity/IUserService.cs
@@ -4,7 +4,7 @@ namespace Cfo.Cats.Application.Common.Interfaces.Identity;
 
 public interface IUserService
 {
-    List<ApplicationUserDto> DataSource { get; }
+    IReadOnlyList<ApplicationUserDto> DataSource { get; }
     event Action? OnChange;
     void Initialize();
     void Refresh();

--- a/src/Application/Common/Interfaces/Locations/ILocationService.cs
+++ b/src/Application/Common/Interfaces/Locations/ILocationService.cs
@@ -4,7 +4,7 @@ namespace Cfo.Cats.Application.Common.Interfaces.Locations;
 
 public interface ILocationService
 {
-    List<LocationDto> DataSource { get; }
+    IReadOnlyList<LocationDto> DataSource { get; }
     event Action? OnChange;
     void Initialize();
     void Refresh();

--- a/src/Application/Common/Interfaces/MultiTenant/ITenantService.cs
+++ b/src/Application/Common/Interfaces/MultiTenant/ITenantService.cs
@@ -4,7 +4,7 @@ namespace Cfo.Cats.Application.Common.Interfaces.MultiTenant;
 
 public interface ITenantService
 {
-    List<TenantDto> DataSource { get; }
+    IReadOnlyList<TenantDto> DataSource { get; }
     event Action? OnChange;
     void Initialize();
     void Refresh();

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -173,7 +173,8 @@ public static class DependencyInjection
         services.AddDbContextFactory<ApplicationDbContext>((serviceProvider, optionsBuilder) =>
         {
             optionsBuilder.AddInterceptors(serviceProvider.GetServices<ISaveChangesInterceptor>());
-            optionsBuilder.UseSqlServer(configuration.GetConnectionString("CatsDb")!);
+            optionsBuilder.UseSqlServer(configuration.GetConnectionString("CatsDb")!,
+                options => options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
         }, ServiceLifetime.Scoped);
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -174,7 +174,10 @@ public static class DependencyInjection
         {
             optionsBuilder.AddInterceptors(serviceProvider.GetServices<ISaveChangesInterceptor>());
             optionsBuilder.UseSqlServer(configuration.GetConnectionString("CatsDb")!,
-                options => options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
+                options =>
+                {
+                    // options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                });
         }, ServiceLifetime.Scoped);
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/src/Server.UI/Components/Autocompletes/PickUserAutocomplete.razor.cs
+++ b/src/Server.UI/Components/Autocompletes/PickUserAutocomplete.razor.cs
@@ -5,7 +5,7 @@ namespace Cfo.Cats.Server.UI.Components.Autocompletes;
 
 public class PickUserAutocomplete : MudAutocomplete<ApplicationUserDto>
 {
-    private List<ApplicationUserDto> _userList = [];
+    private IReadOnlyList<ApplicationUserDto> _userList = [];
 
     [Parameter, EditorRequired]
     public string TenantId { get; set; } = default!;
@@ -41,7 +41,7 @@ public class PickUserAutocomplete : MudAutocomplete<ApplicationUserDto>
         MaxItems = 50;
         _userList = string.IsNullOrEmpty(TenantId)
             ? UserService.DataSource
-            : UserService.DataSource.Where(x => x.TenantId!.StartsWith(TenantId)).ToList();
+            : UserService.DataSource.Where(x => x.TenantId!.StartsWith(TenantId)).ToList().AsReadOnly();
         ToStringFunc = user => user?.DisplayName;
 
         return base.SetParametersAsync(parameters);

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -22,12 +22,15 @@
       "Sentry.Serilog"
     ],
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Debug",
       "Override": {
-        "Microsoft": "Information",
-        "System": "Information",
-        "MudBlazor": "Information",
-        "ActualLab": "Information"
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "MudBlazor": "Warning",
+        "ActualLab": "Warning",
+        "MassTransit": "Warning",
+        "Quartz": "Warning",
+        "ZiggyCreatures": "Warning"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
- The caching was not thread safe, on an app pool reset there was a race condition loading the cache entries
- Query spitting has been applied globally to illeviate large object graphs

Also adjusted the default logging levels for development so you can avoid the noise. Adjust as needed in user secrets to increast log verbosity