### PR TITLE
Add supports for new targets. Feature can be toggled on and off via a configuration setting.

### DIFF
--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -1,7 +1,9 @@
 ﻿
+using Cfo.Cats.Application.Common.Interfaces;
 using Cfo.Cats.Application.Features.ManagementInformation;
 using Cfo.Cats.Application.Pipeline;
 using Cfo.Cats.Application.Pipeline.PreProcessors;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cfo.Cats.Application;
@@ -38,8 +40,21 @@ public static class DependencyInjection
                 return scope.ServiceProvider.GetRequiredService<IMediator>();
             };
         });
+        services.AddSingleton<InMemoryTargetsProvider>();
+        services.AddSingleton<InMemoryTargetsProviderReprofiled>();
         
-        services.AddSingleton<ITargetsProvider, InMemoryTargetsProvider>();
+        services.AddSingleton<ITargetsProvider>(sp =>
+        {
+            var configuration = sp.GetRequiredService<IConfiguration>();
+
+            if (Convert.ToBoolean(configuration["Features:InMemoryTargetsProviderReprofiled"]))
+            {
+                var inMemory = sp.GetRequiredService<InMemoryTargetsProvider>();
+                return new InMemoryTargetsProviderReprofiled(inMemory);
+            }
+
+            return sp.GetRequiredService<InMemoryTargetsProvider>();
+        });
 
         services.AddLazyCache();
 

--- a/src/Application/Features/ManagementInformation/ITargetsProvider.cs
+++ b/src/Application/Features/ManagementInformation/ITargetsProvider.cs
@@ -6,32 +6,3 @@ public interface ITargetsProvider
 {
     public ContractTargetDto GetTarget(string contract, int month, int year);
 }
-
-public class InMemoryTargetsProvider : ITargetsProvider
-{
-
-    private Dictionary<string, ContractTargetDto> targets;
-
-    public InMemoryTargetsProvider()
-    {
-        targets = AddTargets();
-    }
-
-    private Dictionary<string, ContractTargetDto> AddTargets()
-    {
-        return new Dictionary<string, ContractTargetDto> {
-            { "East Midlands",      new ContractTargetDto("East Midlands",          102,    65, 5,  50, 82, 57, 501,    48, 90, 5,  15, 42)},
-            { "East Of England",        new ContractTargetDto("East Of England",        108,    80, 5,  50, 86, 60, 564,    48, 90, 5,  17, 47)},
-            { "London",             new ContractTargetDto("London",             96, 64, 5,  50, 77, 54, 480,    48, 90, 5,  14, 40)},
-            { "North East",         new ContractTargetDto("North East",         78, 98, 10, 100,    62, 43, 528,    95, 180,    10, 16, 44)},
-            { "North West",         new ContractTargetDto("North West",         162,    166,    10, 150,    130,    91, 984,    143,    270,    15, 30, 82)},
-            { "South East",         new ContractTargetDto("South East",         144,    89, 5,  50, 115,    81, 699,    48, 90, 5,  21, 58)},
-            { "South West",         new ContractTargetDto("South West",         111,    82, 3,  50, 89, 63, 579,    48, 90, 5,  17, 48)},
-            { "West Midlands",      new ContractTargetDto("South West",         126,    112,    8,  100,    101,    71, 714,    95, 180,    10, 21, 60)},
-            { "Yorkshire and Humberside",   new ContractTargetDto("Yorkshire and Humberside",   144,    161,    15, 150,    115,    81, 915,    143,    270,    15, 27, 76)},
-
-        };
-    }
-
-    public ContractTargetDto GetTarget(string contract, int month, int year) => targets[contract];
-}

--- a/src/Application/Features/ManagementInformation/InMemoryTargetsProvider.cs
+++ b/src/Application/Features/ManagementInformation/InMemoryTargetsProvider.cs
@@ -1,0 +1,45 @@
+using Cfo.Cats.Application.Features.ManagementInformation.DTOs;
+
+namespace Cfo.Cats.Application.Features.ManagementInformation;
+
+public class InMemoryTargetsProvider : ITargetsProvider
+{
+    private readonly Dictionary<string, ContractTargetDto> _targets;
+
+    public InMemoryTargetsProvider()
+    {
+        _targets = AddTargets();
+    }
+
+    public ContractTargetDto GetTarget(string contract, int month, int year)
+    {
+        return _targets[contract];
+    }
+
+    private Dictionary<string, ContractTargetDto> AddTargets()
+    {
+        return new Dictionary<string, ContractTargetDto>()
+        {
+            { "East Midlands", new ContractTargetDto("East Midlands", 102, 65, 5, 50, 82, 57, 501, 48, 90, 5, 15, 42) },
+            {
+                "East Of England",
+                new ContractTargetDto("East Of England", 108, 80, 5, 50, 86, 60, 564, 48, 90, 5, 17, 47)
+            },
+            { "London", new ContractTargetDto("London", 96, 64, 5, 50, 77, 54, 480, 48, 90, 5, 14, 40) },
+            { "North East", new ContractTargetDto("North East", 78, 98, 10, 100, 62, 43, 528, 95, 180, 10, 16, 44) },
+            {
+                "North West", new ContractTargetDto("North West", 162, 166, 10, 150, 130, 91, 984, 143, 270, 15, 30, 82)
+            },
+            { "South East", new ContractTargetDto("South East", 144, 89, 5, 50, 115, 81, 699, 48, 90, 5, 21, 58) },
+            { "South West", new ContractTargetDto("South West", 111, 82, 3, 50, 89, 63, 579, 48, 90, 5, 17, 48) },
+            {
+                "West Midlands",
+                new ContractTargetDto("South West", 126, 112, 8, 100, 101, 71, 714, 95, 180, 10, 21, 60)
+            },
+            {
+                "Yorkshire and Humberside",
+                new ContractTargetDto("Yorkshire and Humberside", 144, 161, 15, 150, 115, 81, 915, 143, 270, 15, 27, 76)
+            }
+        };
+    }
+}

--- a/src/Application/Features/ManagementInformation/InMemoryTargetsProviderReprofiled.cs
+++ b/src/Application/Features/ManagementInformation/InMemoryTargetsProviderReprofiled.cs
@@ -1,0 +1,56 @@
+using Cfo.Cats.Application.Features.ManagementInformation.DTOs;
+
+namespace Cfo.Cats.Application.Features.ManagementInformation;
+
+public class InMemoryTargetsProviderReprofiled : ITargetsProvider
+{
+    private readonly ITargetsProvider _legacyTargetsProvider;
+    private readonly Dictionary<string, ContractTargetDto> _targets;
+
+    public InMemoryTargetsProviderReprofiled(ITargetsProvider legacyTargetsProvider)
+    {
+        _legacyTargetsProvider = legacyTargetsProvider;
+        _targets = AddTargets();
+    }
+
+    public ContractTargetDto GetTarget(string contract, int month, int year)
+    {
+        var useLegacyTargetsProvider = IsBeforeReprofile(month, year);
+        return useLegacyTargetsProvider ? _legacyTargetsProvider.GetTarget(contract, month, year) : _targets[contract];
+    }
+
+    private Dictionary<string, ContractTargetDto> AddTargets()
+    {
+        return new Dictionary<string, ContractTargetDto>
+        {
+            { "East Midlands", new ContractTargetDto("East Midlands", 102, 65, 5, 50, 56, 45, 501, 48, 90, 5, 15, 42) },
+            {
+                "East Of England",
+                new ContractTargetDto("East Of England", 108, 80, 5, 50, 59, 47, 564, 48, 90, 5, 17, 47)
+            },
+            { "London", new ContractTargetDto("London", 96, 64, 5, 50, 53, 42, 480, 48, 90, 5, 14, 40) },
+            { "North East", new ContractTargetDto("North East", 78, 98, 10, 100, 43, 34, 528, 95, 180, 10, 16, 44) },
+            {
+                "North West", new ContractTargetDto("North West", 162, 166, 10, 150, 89, 71, 984, 143, 270,
+                    15, 30, 82)
+            },
+            { "South East", new ContractTargetDto("South East", 144, 89, 5, 50, 79, 63, 699, 48, 90, 5, 21, 58) },
+            { "South West", new ContractTargetDto("South West", 111, 82, 3, 50, 61, 49, 579, 48, 90, 5, 17, 48) },
+            {
+                "West Midlands",
+                new ContractTargetDto("South West", 126, 112, 8, 100, 69, 55, 714, 95, 180, 10, 21, 60)
+            },
+            {
+                "Yorkshire and Humberside",
+                new ContractTargetDto("Yorkshire and Humberside", 144, 161, 15, 150, 79, 63, 915, 143, 270, 15, 27, 76)
+            }
+        };
+    }
+
+    private bool IsBeforeReprofile(int month, int year)
+    {
+        DateTime cutOff = new(2025, 6, 1);
+        DateTime askedFor = new(year, month, 1);
+        return askedFor < cutOff;
+    }
+}

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -133,5 +133,8 @@
       "ApiKey": "",
       "ApplicationUrl": ""
     }
+  },
+  "Features": {
+    "InMemoryTargetsProviderReprofiled": true
   }
 }


### PR DESCRIPTION
This provides new targets for PRI for JUNE 2025 onwards.

The feature only works if the configuration flag is set, if it is false then we will continue to use the old figures.