### PR TITLE
Clean up consent & rtw screens in QA Process

### DIFF
--- a/src/Application/Features/Participants/DTOs/ConsentDto.cs
+++ b/src/Application/Features/Participants/DTOs/ConsentDto.cs
@@ -9,6 +9,8 @@ public class ConsentDto
     public DateTime ConsentDate { get; set; }
     public Guid? DocumentId { get; set; } 
     
+    public DateTime Created { get; set; }
+    
     public string? FileName { get; set; }
 
     private class Mapping : Profile
@@ -18,7 +20,8 @@ public class ConsentDto
             CreateMap<Consent, ConsentDto>()
                 .ForMember(c => c.DocumentId, options => options.MapFrom(source => source.Document!.Id))
                 .ForMember(c => c.FileName, options => options.MapFrom(source => source.Document!.Title))
-                .ForMember(c => c.ConsentDate, options => options.MapFrom(source => source.Lifetime.StartDate));
+                .ForMember(c => c.ConsentDate, options => options.MapFrom(source => source.Lifetime.StartDate))
+                .ForMember(c => c.Created, options => options.MapFrom(source => source.Created!));
         }
     }
 }

--- a/src/Application/Features/Participants/DTOs/RightToWorkDto.cs
+++ b/src/Application/Features/Participants/DTOs/RightToWorkDto.cs
@@ -6,10 +6,12 @@ public class RightToWorkDto
 {
     public DateTime ValidFrom { get; set; }
     public DateTime ValidTo { get; set; }
-    
-    public Guid? DocumentId { get; set; } 
-    
+
+    public Guid? DocumentId { get; set; }
+
     public string? FileName { get; set; }
+
+    public DateTime Created { get; set; }
 
     private class Mapping : Profile
     {
@@ -18,13 +20,14 @@ public class RightToWorkDto
             CreateMap<RightToWork, RightToWorkDto>()
                 .ForMember(rtw => rtw.DocumentId,
                     options => options.MapFrom(source => source.Document!.Id))
-                .ForMember(c => c.FileName, 
+                .ForMember(c => c.FileName,
                     options => options.MapFrom(source => source.Document!.Title))
                 .ForMember(c => c.ValidFrom,
                     options => options.MapFrom(source => source.Lifetime.StartDate))
                 .ForMember(c => c.ValidTo,
-                options => options.MapFrom(source => source.Lifetime.EndDate));
-
+                    options => options.MapFrom(source => source.Lifetime.EndDate))
+                .ForMember(o => o.Created, 
+                    options => options.MapFrom(source => source.Created));
         }
     }
 }

--- a/src/Server.UI/Pages/QA/Enrolments/Components/ConsentTabPanel.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/ConsentTabPanel.razor
@@ -11,13 +11,33 @@
     }
 
     <MudRadioGroup T="Guid" @bind-Value="_selectedDocument">
-        
-    @foreach (var consent in ParticipantDto.Consents.OrderByDescending(c => c.ConsentDate))
-    {
-        <MudRadio T="Guid" Color="Color.Primary" Value="@consent.DocumentId!.Value">
-            @consent.FileName (@consent.ConsentDate.ToShortDateString())
-        </MudRadio>
-    }
+        <MudTable Items="@ParticipantDto.Consents.OrderByDescending(x => x.Created)" Hover="true" Striped="true" Dense="true" Class="ma-3" Style="width: 100%">
+            <HeaderContent>
+                <MudTh>View</MudTh>
+                <MudTh>File Name</MudTh>
+                <MudTh>Consent Date</MudTh>
+                <MudTh>Upload Date</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>
+                    <MudRadio Value="@context.DocumentId!.Value" Color="Color.Primary"/>
+                </MudTd>
+                <MudTd DataLabel="File Name">@context.FileName</MudTd>
+                <MudTd DataLabel="Consent">@context.ConsentDate.ToShortDateString()</MudTd>
+                <MudTd DataLabel="Uploaded By">@context.Created</MudTd>
+                <MudTd>
+                    @if (ParticipantDto.Consents.OrderByDescending(x => x.Created).First() == context)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Star"></MudIcon>
+                    }
+                    else
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Cancel"></MudIcon>
+                    }
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
     </MudRadioGroup>
     
     @if (_selectedDocument != Guid.Empty)

--- a/src/Server.UI/Pages/QA/Enrolments/Components/RightToWorkTabPanel.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/RightToWorkTabPanel.razor
@@ -13,12 +13,42 @@
 }
 
 <MudRadioGroup T="Guid" @bind-Value="_selectedDocument">
-    @foreach (var rtw in ParticipantDto.RightToWorks.OrderByDescending(c => c.ValidFrom))
-    {
-        <MudRadio T="Guid" Color="Color.Primary" Value="@rtw.DocumentId!.Value">
-            @rtw.FileName (@rtw.ValidFrom.ToShortDateString() - @rtw.ValidTo.ToShortDateString())
-        </MudRadio>
-    }
+    
+    <MudTable Items="@ParticipantDto.RightToWorks" Hover="true" Striped="true" Dense="true" Class="ma-3" Style="width: 100%">
+        <HeaderContent>
+            <MudTh>View</MudTh>
+            <MudTh>File Name</MudTh>
+            <MudTh>Valid From</MudTh>
+            <MudTh>Valid To</MudTh>
+            <MudTh>Upload Date</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>
+                <MudRadio T="Guid" Color="Color.Primary" Value="@context.DocumentId!.Value" />
+            </MudTd>
+            <MudTd DataLabel="File Name">
+                @context.FileName
+            </MudTd>
+            <MudTd DataLabel="Valid From">
+                @context.ValidFrom.ToShortDateString()
+            </MudTd>
+            <MudTd DataLabel="Valid To">
+                @if (context.ValidTo == DateTime.MaxValue)
+                {
+                    <MudText>
+                        Indefinite 
+                    </MudText>   
+                }
+                else
+                {
+                    @context.ValidTo.ToShortDateString()    
+                }
+            </MudTd>
+            <MudTd>
+                @context.Created
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 </MudRadioGroup>
 
 @if (_selectedDocument != Guid.Empty)


### PR DESCRIPTION
This changes the radio button to include a table so that it's clearer which file is the latest consent form.

Made RTW consistent with this new screen