### PR TITLE
Quick fix to block archive from Submitted to Provider status

### DIFF
--- a/src/Domain/Common/Enums/EnrolmentStatus.cs
+++ b/src/Domain/Common/Enums/EnrolmentStatus.cs
@@ -76,7 +76,7 @@ public abstract class EnrolmentStatus : SmartEnum<EnrolmentStatus>
 
     private sealed class SubmittedToProvider() : EnrolmentStatus("Submitted to Provider", 1)
     {
-        protected override EnrolmentStatus[] GetAllowedTransitions() => [ArchivedStatus, EnrollingStatus, SubmittedToAuthorityStatus];
+        protected override EnrolmentStatus[] GetAllowedTransitions() => [EnrollingStatus, SubmittedToAuthorityStatus];
         public override bool SupportsReassessment() => false;
 
         public override bool AllowEnrolmentLocationChange() => true;


### PR DESCRIPTION
This prevents you from archiving a case that is in Submitted to Provider Status so that the queue's don't get messy