### PR TITLE
Remove ConfigureAwait from blazor components.

### DIFF
--- a/src/Server.UI/Pages/Candidates/Components/CandidateFinderComponent.razor
+++ b/src/Server.UI/Pages/Candidates/Components/CandidateFinderComponent.razor
@@ -63,7 +63,7 @@
 
     public async Task Search()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate();
         if (_form.IsValid)
         {
             var result = await CandidateService.SearchAsync(Query!);

--- a/src/Server.UI/Pages/Candidates/Components/MatchFound.razor.cs
+++ b/src/Server.UI/Pages/Candidates/Components/MatchFound.razor.cs
@@ -62,7 +62,7 @@ public partial class MatchFound
         {
             loading = true;
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate();
 
             if (_form!.IsValid)
             {

--- a/src/Server.UI/Pages/Dashboard/Components/CaseWorkload.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/Components/CaseWorkload.razor.cs
@@ -29,7 +29,7 @@ public partial class CaseWorkload
     private async Task OnRefresh()
     {
         Query.CurrentUser = UserProfile;
-        Result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+        Result = await GetNewMediator().Send(Query);
     }
 
     private Result<CaseSummaryDto[]>? Result { get; set; }

--- a/src/Server.UI/Pages/Dashboard/Components/MyNotifications.razor
+++ b/src/Server.UI/Pages/Dashboard/Components/MyNotifications.razor
@@ -110,7 +110,7 @@
         Query.CurrentUser = UserProfile;
         Query.OrderBy = "NotificationDate";
         Query.SortDirection = SortDirection.Descending.ToString();
-        Results = await GetNewMediator().Send(Query).ConfigureAwait(false);
+        Results = await GetNewMediator().Send(Query);
     }
 
     PaginatedData<NotificationDto>? Results { get; set; }

--- a/src/Server.UI/Pages/Enrolments/Components/Location.razor
+++ b/src/Server.UI/Pages/Enrolments/Components/Location.razor
@@ -107,7 +107,7 @@
                 Model.JustificationReason = null;
             }
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate();
 
             if (_form.IsValid)
             {                

--- a/src/Server.UI/Pages/Identity/Users/Components/UserAuditDialog.razor.cs
+++ b/src/Server.UI/Pages/Identity/Users/Components/UserAuditDialog.razor.cs
@@ -27,7 +27,7 @@ public partial class UserAuditDialog
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query);
             if (result is { Succeeded: true, Data: not null })
             {
                 return new GridData<IdentityAuditTrailDto> { TotalItems = result.Data.TotalItems, Items = result.Data.Items };    

--- a/src/Server.UI/Pages/Identity/Users/LoginAudit.razor.cs
+++ b/src/Server.UI/Pages/Identity/Users/LoginAudit.razor.cs
@@ -45,7 +45,7 @@ public partial class LoginAudit : CatsComponentBase
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query);
             if (result is { Succeeded: true, Data: not null })
             {
                 return new GridData<IdentityAuditTrailDto> { TotalItems = result.Data.TotalItems, Items = result.Data.Items };    

--- a/src/Server.UI/Pages/PRIs/ActivePRIs.razor.cs
+++ b/src/Server.UI/Pages/PRIs/ActivePRIs.razor.cs
@@ -46,7 +46,7 @@ namespace Cfo.Cats.Server.UI.Pages.PRIs
                 Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
                 Query.PageNumber = state.Page + 1;
                 Query.PageSize = state.PageSize;
-                var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+                var result = await GetNewMediator().Send(Query)
                 return new GridData<PRIPaginationDto> { TotalItems = result.TotalItems, Items = result.Items };
             }
             finally

--- a/src/Server.UI/Pages/PRIs/Components/AbandonPriDialog.razor
+++ b/src/Server.UI/Pages/PRIs/Components/AbandonPriDialog.razor
@@ -53,7 +53,7 @@
         try
         {
             saving = true;
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (form.IsValid is false)
             {

--- a/src/Server.UI/Pages/PRIs/Components/AddActualReleaseDateDialog.razor
+++ b/src/Server.UI/Pages/PRIs/Components/AddActualReleaseDateDialog.razor
@@ -48,7 +48,7 @@
         try
         {
             saving = true;
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (form.IsValid is false)
             {

--- a/src/Server.UI/Pages/PRIs/Components/PriGenerateCodeDialog.razor.cs
+++ b/src/Server.UI/Pages/PRIs/Components/PriGenerateCodeDialog.razor.cs
@@ -19,7 +19,7 @@ namespace Cfo.Cats.Server.UI.Pages.PRIs.Components
 
         public async Task GeneratePriCode()
         {
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (form.IsValid is false)
             {

--- a/src/Server.UI/Pages/PRIs/PRI.razor
+++ b/src/Server.UI/Pages/PRIs/PRI.razor
@@ -268,7 +268,7 @@
 
     async Task<bool> IsValid(MudForm form)
     {
-        await form.Validate().ConfigureAwait(false);
+        await form.Validate()
         return form.IsValid;
     }
 }

--- a/src/Server.UI/Pages/Participants/Components/AbandonPhaseDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AbandonPhaseDialog.razor
@@ -79,7 +79,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if(form!.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/AddHubInductionDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AddHubInductionDialog.razor
@@ -63,7 +63,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate();
 
             if(form!.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/AddInductionPhaseDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AddInductionPhaseDialog.razor
@@ -55,7 +55,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if(form!.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/AddNoteDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AddNoteDialog.razor
@@ -58,7 +58,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (!form!.IsValid)
             {

--- a/src/Server.UI/Pages/Participants/Components/AddWingInductionDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AddWingInductionDialog.razor
@@ -62,7 +62,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if(form!.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/AddressDialog.razor.cs
+++ b/src/Server.UI/Pages/Participants/Components/AddressDialog.razor.cs
@@ -40,7 +40,7 @@ public partial class AddressDialog(IAddressLookupService addressLookupService)
         {
             _saving = true;
 
-            await _form.Validate().ConfigureAwait(false);
+            await _form.Validate()
 
             if (!_form.IsValid)
             {

--- a/src/Server.UI/Pages/Participants/Components/AdjustEnrolmentLocationDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/AdjustEnrolmentLocationDialog.razor
@@ -92,7 +92,7 @@
         {
             _saving = true;
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
 
             if (_form.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/CompletePhaseDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/CompletePhaseDialog.razor
@@ -68,7 +68,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if(form!.IsValid == false)
             {

--- a/src/Server.UI/Pages/Participants/Components/EditSupervisorDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/EditSupervisorDialog.razor
@@ -70,7 +70,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (!form!.IsValid)
             {

--- a/src/Server.UI/Pages/Participants/Components/ParticipantAudit.razor
+++ b/src/Server.UI/Pages/Participants/Components/ParticipantAudit.razor
@@ -239,7 +239,7 @@
             Query.PageSize = state.PageSize;
             Query.PrimaryKey ??= _entries.First().PrimaryKey;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<AuditTrailDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/Participants/Components/ReassignParticipantDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/ReassignParticipantDialog.razor
@@ -68,7 +68,7 @@
     {
         try
         {
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
             if (_form.IsValid)
             {
                 var result = await GetNewMediator().Send(Model!);

--- a/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor
@@ -62,7 +62,7 @@
         {
             _saving = true;
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
 
             if (_form!.IsValid == false)
             {                

--- a/src/Server.UI/Pages/Participants/Participants.razor.cs
+++ b/src/Server.UI/Pages/Participants/Participants.razor.cs
@@ -95,7 +95,7 @@ public partial class Participants
                 : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query);
 
             if (result is {Succeeded: true, Data: not null})
             {

--- a/src/Server.UI/Pages/Participants/ReassignParticipant.razor
+++ b/src/Server.UI/Pages/Participants/ReassignParticipant.razor
@@ -250,7 +250,7 @@
             Query.PageSize = state.PageSize;
             Query.JustMyCases = false;
             
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query);
             if (result is {Succeeded: true, Data: not null})
             {
                 return new GridData<ParticipantPaginationDto> { TotalItems = result.Data.TotalItems, Items = result.Data.Items };

--- a/src/Server.UI/Pages/QA/Activities/Components/EscalationList.razor
+++ b/src/Server.UI/Pages/QA/Activities/Components/EscalationList.razor
@@ -201,7 +201,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<ActivityQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Activities/Components/QA1List.razor
+++ b/src/Server.UI/Pages/QA/Activities/Components/QA1List.razor
@@ -188,7 +188,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<ActivityQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Activities/Components/QA2List.razor
+++ b/src/Server.UI/Pages/QA/Activities/Components/QA2List.razor
@@ -200,7 +200,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<ActivityQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Activities/Escalation.razor
+++ b/src/Server.UI/Pages/QA/Activities/Escalation.razor
@@ -161,7 +161,7 @@
 
     protected async Task SubmitToQa()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate()
         if (_form.IsValid is false)
         {
             return;

--- a/src/Server.UI/Pages/QA/Activities/PQA.razor
+++ b/src/Server.UI/Pages/QA/Activities/PQA.razor
@@ -125,7 +125,7 @@
 
     protected async Task SubmitToQa()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate()
         if (_form.IsValid)
         {
             var result = await GetNewMediator().Send(Command);

--- a/src/Server.UI/Pages/QA/Activities/PqaList.razor
+++ b/src/Server.UI/Pages/QA/Activities/PqaList.razor
@@ -206,7 +206,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<ActivityQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Activities/QA1.razor
+++ b/src/Server.UI/Pages/QA/Activities/QA1.razor
@@ -160,7 +160,7 @@
 
     protected async Task SubmitToQa()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate()
 
         if (_form.IsValid is false)
         {

--- a/src/Server.UI/Pages/QA/Activities/QA2.razor
+++ b/src/Server.UI/Pages/QA/Activities/QA2.razor
@@ -177,7 +177,7 @@
 
     protected async Task SubmitToQa()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate()
 
         if (_form.IsValid is false)
         {

--- a/src/Server.UI/Pages/QA/Enrolments/Components/EscalationList.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/EscalationList.razor
@@ -156,7 +156,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<EnrolmentQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Enrolments/Components/QA1List.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/QA1List.razor
@@ -148,7 +148,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<EnrolmentQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Enrolments/Components/QA2List.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/QA2List.razor
@@ -147,7 +147,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<EnrolmentQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Enrolments/Escalation.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/Escalation.razor.cs
@@ -80,7 +80,7 @@ public partial class Escalation
         {
             _saving = true;
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
             if (_form.IsValid is false)
             {
                 return;

--- a/src/Server.UI/Pages/QA/Enrolments/PQA.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/PQA.razor.cs
@@ -95,7 +95,7 @@ public partial class PQA
         try
         {
             _saving = true;
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
             if (_form.IsValid)
             {
                 var result = await GetNewMediator().Send(Command);

--- a/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
@@ -161,7 +161,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await GetNewMediator().Send(Query).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(Query)
             return new GridData<EnrolmentQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/QA/Enrolments/QA1.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/QA1.razor.cs
@@ -84,7 +84,7 @@ public partial class QA1
         {
             _saving = true;
 
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
 
             if (_form.IsValid is false)
             {

--- a/src/Server.UI/Pages/QA/Enrolments/QA2.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/QA2.razor.cs
@@ -79,7 +79,7 @@ public partial class QA2
         try
         {
             _saving = true;
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
 
             if (_form.IsValid is false)
             {

--- a/src/Server.UI/Pages/SystemManagement/Components/CreatePicklistDialog.razor
+++ b/src/Server.UI/Pages/SystemManagement/Components/CreatePicklistDialog.razor
@@ -57,7 +57,7 @@
         try
         {
             _saving = true;
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
             if (!_form!.IsValid)
             {
                 return;

--- a/src/Server.UI/Pages/SystemManagement/Components/DocumentAuditTrails.razor.cs
+++ b/src/Server.UI/Pages/SystemManagement/Components/DocumentAuditTrails.razor.cs
@@ -38,7 +38,7 @@ public partial class DocumentAuditTrails(IMediator mediator)
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await mediator.Send(Query).ConfigureAwait(false);
+            var result = await mediator.Send(Query)
             return new GridData<DocumentAuditTrailDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/SystemManagement/Components/SystemAuditTrails.razor
+++ b/src/Server.UI/Pages/SystemManagement/Components/SystemAuditTrails.razor
@@ -150,7 +150,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await Mediator.Send(Query).ConfigureAwait(false);
+            var result = await Mediator.Send(Query)
             return new GridData<AuditTrailDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/SystemManagement/Dictionaries.razor
+++ b/src/Server.UI/Pages/SystemManagement/Dictionaries.razor
@@ -235,7 +235,7 @@
                 PageNumber = state.Page + 1,
                 PageSize = state.PageSize
             };
-            var result = await GetNewMediator().Send(request).ConfigureAwait(false);
+            var result = await GetNewMediator().Send(request)
             return new GridData<KeyValueDto>
             {
                 TotalItems = result.TotalItems,

--- a/src/Server.UI/Pages/SystemManagement/Outbox.razor
+++ b/src/Server.UI/Pages/SystemManagement/Outbox.razor
@@ -211,7 +211,7 @@
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
 
-            var result = await Mediator.Send(Query).ConfigureAwait(false);
+            var result = await Mediator.Send(Query)
             return new GridData<OutboxMessageDto> { TotalItems = result.TotalItems, Items = result.Items };
         }
         finally

--- a/src/Server.UI/Pages/Tenants/AddDomainDialog.razor
+++ b/src/Server.UI/Pages/Tenants/AddDomainDialog.razor
@@ -50,7 +50,7 @@
         {
             saving = true;
 
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (!form!.IsValid)
             {

--- a/src/Server.UI/Pages/Tenants/RenameTenantDialog.razor
+++ b/src/Server.UI/Pages/Tenants/RenameTenantDialog.razor
@@ -43,7 +43,7 @@
         try
         {
             saving = true;
-            await _form!.Validate().ConfigureAwait(false);
+            await _form!.Validate()
 
             if (!_form!.IsValid)
             {

--- a/src/Server.UI/Pages/Tenants/TenantFormDialog.razor
+++ b/src/Server.UI/Pages/Tenants/TenantFormDialog.razor
@@ -50,7 +50,7 @@
         try
         {
             saving = true;
-            await form!.Validate().ConfigureAwait(false);
+            await form!.Validate()
 
             if (!form!.IsValid)
             {


### PR DESCRIPTION
This removes ConfigureAwait(false) calls from blazor component calls as this is bad practice. Can result in threading errors