### PR TITLE
Uses fixed ports for RabbitMQ

### DIFF
--- a/src/Aspire/Aspire.AppHost/Program.cs
+++ b/src/Aspire/Aspire.AppHost/Program.cs
@@ -16,9 +16,10 @@ var catsDb = sql.AddDatabase("CatsDb");
 
 var rabbit = builder.AddRabbitMQ("rabbit",
         userName: rabbitUser,
-        password: rabbitPassword)
+        password: rabbitPassword,
+        port: 5672)
     .WithDataVolume("cats-aspire-rabbit")
-    .WithManagementPlugin()
+    .WithManagementPlugin(port: 15672)
     .WithLifetime(ContainerLifetime.Persistent);
 
 builder.AddProject<Projects.Server_UI>("cats")


### PR DESCRIPTION
Ensures RabbitMQ uses fixed ports.

This prevents potential port conflicts and allows for more predictable network configuration. Specifically, it sets the main port to 5672 and the management plugin port to 15672.