### PR TITLE
Only add the security policy headers to requests that have not been terminated.

### DIFF
--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -160,7 +160,12 @@ public static class DependencyInjection
 
         app.Use(async (context, next) =>
         {
-            context.Response.Headers.Append("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; object-src 'self' data:; frame-src 'self' data:;"); 
+            if (context.Response.Headers.IsReadOnly == false)
+            {
+                context.Response.Headers.Append("Content-Security-Policy",
+                    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; object-src 'self' data:; frame-src 'self' data:;");
+            }
+
             await next();
         });
         


### PR DESCRIPTION

This addresses an issue where the headers are readonly (due to the session time out middleware).

This check means the headers will only be appended if they are not readonly (i.e. we are still in transit.)