### PR TITLE
Improve performance of identity checks in the revalidation service

### DIFF
--- a/src/Server.UI/Services/IdentityRevalidatingAuthenticationStateProvider.cs
+++ b/src/Server.UI/Services/IdentityRevalidatingAuthenticationStateProvider.cs
@@ -1,8 +1,8 @@
 ﻿using System.Security.Claims;
-using Cfo.Cats.Domain.Identity;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Cfo.Cats.Server.UI.Services;
@@ -16,39 +16,39 @@ internal sealed class IdentityRevalidatingAuthenticationStateProvider(
     IOptions<IdentityOptions> options
 ) : RevalidatingServerAuthenticationStateProvider(loggerFactory)
 {
-    protected override TimeSpan RevalidationInterval => TimeSpan.FromMinutes(1);
+    protected override TimeSpan RevalidationInterval => TimeSpan.FromMinutes(10);
 
     protected override async Task<bool> ValidateAuthenticationStateAsync(
         AuthenticationState authenticationState,
         CancellationToken cancellationToken
     )
     {
-        // Get the user manager from a new scope to ensure it fetches fresh data
         await using var scope = scopeFactory.CreateAsyncScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-        return await ValidateSecurityStampAsync(userManager, authenticationState.User);
+        return await ValidateSecurityStampAsync(scope.ServiceProvider, authenticationState.User);
     }
 
     private async Task<bool> ValidateSecurityStampAsync(
-        UserManager<ApplicationUser> userManager,
+        IServiceProvider serviceProvider,
         ClaimsPrincipal principal
     )
     {
-        var user = await userManager.GetUserAsync(principal);
-        if (user is null)
+        var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
         {
             return false;
         }
-
-        if (!userManager.SupportsUserSecurityStamp)
-        {
-            return true;
-        }
-
+            
         var principalStamp = principal.FindFirstValue(
             options.Value.ClaimsIdentity.SecurityStampClaimType
         );
-        var userStamp = await userManager.GetSecurityStampAsync(user);
+        
+        // Only fetch the security stamp field
+        var context = serviceProvider.GetRequiredService<IApplicationDbContext>();
+        var userStamp = await context.Users
+            .Where(u => u.Id == userId)
+            .Select(u => u.SecurityStamp)
+            .FirstOrDefaultAsync();
+        
         return principalStamp == userStamp;
     }
 }


### PR DESCRIPTION
>[!Tip]
Note to test this I would manually change the refresh rate in the file to TimeSpan.FromSeconds(30) or some other short period.


This provider checks the security stamp against what is in the database based on the timestamp you gave it.

It was loading the full User (including notes and tenants) every 60 seconds.

It now checks every 10 minutes and only loads the security stamp to check.

If we ever have an emergency where we need to block someone immediatley, we can block them and recycle the site.