### PR TITLE
This is a quick addition to show the counts of syncs to date.

### DIFF
--- a/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor
+++ b/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor
@@ -1,0 +1,39 @@
+﻿@inherits CatsComponentBase
+
+@if (_isLoading)
+{
+    <LoadingCard Title="Getting sync data.."  />
+}
+else
+{
+    <MudItem xs="12" md="4">
+        <MudCard style="height:100%">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h5">
+                        Sync Information
+                    </MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                <MudTable T="SyncRecord" Items="_records" Striped="true">
+                    <HeaderContent>
+                        <MudTh>Date</MudTh>
+                        <MudTh>Records</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Date">@context.TheDate.ToShortDateString()</MudTd>
+                        <MudTd DataLabel="Records">@context.RecordCount</MudTd>
+                    </RowTemplate>
+                    <PagerContent>
+                        <MudTablePager PageSizeOptions="[5, 10]" />
+                    </PagerContent>
+                </MudTable>
+            </MudCardContent>
+            <MudCardActions>
+               
+            </MudCardActions>
+        </MudCard>
+    </MudItem>
+}
+

--- a/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Cfo.Cats.Server.UI.Pages.Dashboard.Components;
+
+public partial class SyncComponent
+{
+
+    private bool _isLoading = true;
+    
+    private SyncRecord[] _records = [];
+    
+    protected override async Task OnInitializedAsync()
+    {
+
+        try
+        {
+            var uow = GetNewUnitOfWork();
+
+            var query = from d in uow.DbContext.DateDimensions
+                join p in uow.DbContext.Participants
+                    on true equals true// placeholder for where join is done in `where`
+                where p.LastSyncDate >= d.TheDate &&
+                      p.LastSyncDate < d.TheDate.AddDays(1)
+                group p by d.TheDate
+                into g
+                orderby g.Key
+                select new SyncRecord(g.Key, g.Count());
+                
+        
+            var results = await query.ToArrayAsync();
+            if (IsDisposed == false)
+            {
+                _records = results;
+            }
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+        
+    }
+
+    public record SyncRecord(DateTime TheDate, int RecordCount);
+}

--- a/src/Server.UI/Pages/Dashboard/Dashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/Dashboard.razor
@@ -39,6 +39,12 @@
         @if (_showQaPots)
         {
             <QaPots />
+            
+        }
+        
+        @if (_showSyncComponent)
+        {
+            <SyncComponent />
         }
         
         @if(_showJobManagement)

--- a/src/Server.UI/Pages/Dashboard/Dashboard.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/Dashboard.razor.cs
@@ -15,6 +15,7 @@ public partial class Dashboard
     private bool _showJobManagement;
     private bool _showCaseWorkload;
     private bool _showRiskDueAggregate;
+    private bool _showSyncComponent;
 
     public string Title { get; } = "Dashboard";
 
@@ -34,6 +35,10 @@ public partial class Dashboard
         _showRiskDueAggregate = _showCaseWorkload;
 
         _showQaPots = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.Internal)).Succeeded;
+        
+        // this follows the same check as QA pots
+        _showSyncComponent = _showQaPots;
+        
         _showJobManagement = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.SystemSupportFunctions)).Succeeded;
     }
 


### PR DESCRIPTION
This should let us have quicker visibility of issues with the overnight service.



This displays a group by of last participant sync dates and a count of participants with for that day.

