### PR TITLE
Fixes the participant blank screen issue.

### DIFF
--- a/src/Application/Features/Participants/MessageBus/SyncParticipantCommandHandler.cs
+++ b/src/Application/Features/Participants/MessageBus/SyncParticipantCommandHandler.cs
@@ -24,7 +24,7 @@ public class SyncParticipantCommandHandler(
 
         try
         {
-            using var scope = logger.BeginScope("Sync for Participant: {Id}", [participant.Id]);
+            using var scope = logger.BeginScope("Sync for Participant: {ParticipantId}", participant.Id);
 
             var result = await candidateService.GetByUpciAsync(participant.Id);
 
@@ -89,7 +89,7 @@ public class SyncParticipantCommandHandler(
             // Dispatch events and commit transaction
             await domainEventDispatcher.DispatchEventsAsync(unitOfWork.DbContext, CancellationToken.None);
             await unitOfWork.CommitTransactionAsync();
-            logger.LogDebug($"Finished syncing {participant.Id}");
+            logger.LogDebug("Finished syncing {ParticipantId}", participant.Id);
         }
 
         catch (Exception e)

--- a/src/Application/Outbox/OutboxExtensions.cs
+++ b/src/Application/Outbox/OutboxExtensions.cs
@@ -2,7 +2,7 @@
 
 public static class OutboxExtensions
 {
-    internal static async Task InsertOutboxMessage<T>(
+    public static async Task InsertOutboxMessage<T>(
         this IApplicationDbContext context,
         T message)
         where T : notnull

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -477,69 +477,86 @@ public static class DependencyInjection
                         .WithDescription(SyncParticipantsJob.Description)
                 );
 
-                quartz.AddTrigger(opts => opts
-                    .ForJob(SyncParticipantsJob.Key)
-                    .WithIdentity($"{SyncParticipantsJob.Key}-trigger")
-                    .WithDescription(SyncParticipantsJob.Description)
-                    .WithCronSchedule(syncParticipantsJobOptions.CronSchedule));
+               foreach(var schedule in syncParticipantsJobOptions.CronSchedules)
+               {
+                   quartz.AddTrigger(opts => opts
+                       .ForJob(SyncParticipantsJob.Key)
+                       .WithDescription(schedule.Description)
+                       .WithCronSchedule(schedule.Chron));
+               }
+
             }
-
-            if (options.GetSection(DisableDormantAccountsJob.Key.Name).Get<JobOptions>() is
-                { Enabled: true } disableDormantAccountsJobOptions)
-            {
-                quartz.AddJob<DisableDormantAccountsJob>(opts => 
-                    opts.WithIdentity(DisableDormantAccountsJob.Key)
-                        .WithDescription(DisableDormantAccountsJob.Description));
-
-                quartz.AddTrigger(opts => opts
-                    .ForJob(DisableDormantAccountsJob.Key)
-                    .WithIdentity($"{DisableDormantAccountsJob.Key}-trigger")
-                    .WithDescription(DisableDormantAccountsJob.Description)
-                    .WithCronSchedule(disableDormantAccountsJobOptions.CronSchedule));
-            }
-
-            if (options.GetSection(NotifyAccountDeactivationJob.Key.Name).Get<JobOptions>() is
-                { Enabled: true } notifyAccountDeactivationJobOptions)
-            {
-                quartz.AddJob<NotifyAccountDeactivationJob>(opts => 
-                    opts.WithIdentity(NotifyAccountDeactivationJob.Key)
-                        .WithDescription(NotifyAccountDeactivationJob.Description));
-
-                quartz.AddTrigger(opts => opts
-                    .ForJob(NotifyAccountDeactivationJob.Key)
-                    .WithIdentity($"{NotifyAccountDeactivationJob.Key}-trigger")
-                    .WithDescription(NotifyAccountDeactivationJob.Description)
-                    .WithCronSchedule(notifyAccountDeactivationJobOptions.CronSchedule));
-            }
-
-            if (options.GetSection(PublishOutboxMessagesJob.Key.Name).Get<JobOptions>() is
-                { Enabled: true } publishOutboxMessagesOptions)
+            
+            if (options.GetSection(PublishOutboxMessagesJob.Key.Name).Get<JobOptions>() is 
+                { Enabled: true } publishOutboxMessagesJob)
             {
                 quartz.AddJob<PublishOutboxMessagesJob>(opts => 
                     opts.WithIdentity(PublishOutboxMessagesJob.Key)
-                        .WithDescription(PublishOutboxMessagesJob.Description));
+                        .WithDescription(PublishOutboxMessagesJob.Description)
+                );
 
-                quartz.AddTrigger(opts => opts
-                    .ForJob(PublishOutboxMessagesJob.Key)
-                    .WithIdentity($"{PublishOutboxMessagesJob.Key}-trigger")
-                    .WithDescription(PublishOutboxMessagesJob.Description)
-                    .WithCronSchedule(publishOutboxMessagesOptions.CronSchedule));
+                foreach(var schedule in publishOutboxMessagesJob.CronSchedules)
+                {
+                    quartz.AddTrigger(opts => opts
+                        .ForJob(PublishOutboxMessagesJob.Key)
+                        .WithDescription(schedule.Description)
+                        .WithCronSchedule(schedule.Chron));
+                }
+
+            }
+            
+            if (options.GetSection(DisableDormantAccountsJob.Key.Name).Get<JobOptions>() is 
+                { Enabled: true } disableDormantAccountsJob)
+            {
+                quartz.AddJob<DisableDormantAccountsJob>(opts => 
+                    opts.WithIdentity(DisableDormantAccountsJob.Key)
+                        .WithDescription(DisableDormantAccountsJob.Description)
+                );
+
+                foreach(var schedule in disableDormantAccountsJob.CronSchedules)
+                {
+                    quartz.AddTrigger(opts => opts
+                        .ForJob(DisableDormantAccountsJob.Key)
+                        .WithDescription(schedule.Description)
+                        .WithCronSchedule(schedule.Chron));
+                }
+
+            }
+            
+            if (options.GetSection(NotifyAccountDeactivationJob.Key.Name).Get<JobOptions>() is 
+                { Enabled: true } notifyAccountDeactivationJob)
+            {
+                quartz.AddJob<NotifyAccountDeactivationJob>(opts => 
+                    opts.WithIdentity(NotifyAccountDeactivationJob.Key)
+                        .WithDescription(NotifyAccountDeactivationJob.Description)
+                );
+
+                foreach(var schedule in notifyAccountDeactivationJob.CronSchedules)
+                {
+                    quartz.AddTrigger(opts => opts
+                        .ForJob(NotifyAccountDeactivationJob.Key)
+                        .WithDescription(schedule.Description)
+                        .WithCronSchedule(schedule.Chron));
+                }
+
             }
 
             if (options.GetSection(GenerateOutcomeQualityDipSamplesJob.Key.Name).Get<JobOptions>() is
-                { Enabled: true } generateDipSamplesJobOptions)
+                { Enabled: true } generateOutcomeQualityDipSamplesJob)
             {
                 quartz.AddJob<GenerateOutcomeQualityDipSamplesJob>(opts =>
                     opts.WithIdentity(GenerateOutcomeQualityDipSamplesJob.Key)
-                        .WithDescription(GenerateOutcomeQualityDipSamplesJob.Description));
+                        .WithDescription(GenerateOutcomeQualityDipSamplesJob.Description)
+                );
 
-                quartz.AddTrigger(opts => opts
-                    .ForJob(GenerateOutcomeQualityDipSamplesJob.Key)
-                    .WithIdentity($"{GenerateOutcomeQualityDipSamplesJob.Key}-trigger")
-                    .WithDescription(GenerateOutcomeQualityDipSamplesJob.Description)
-                    .WithCronSchedule(generateDipSamplesJobOptions.CronSchedule));
+                foreach (var schedule in generateOutcomeQualityDipSamplesJob.CronSchedules)
+                {
+                    quartz.AddTrigger(opts => opts
+                        .ForJob(GenerateOutcomeQualityDipSamplesJob.Key)
+                        .WithDescription(schedule.Description)
+                        .WithCronSchedule(schedule.Chron));
+                }
             }
-
         });
 
         services.AddQuartzServer(options =>

--- a/src/Infrastructure/Jobs/JobOptions.cs
+++ b/src/Infrastructure/Jobs/JobOptions.cs
@@ -3,5 +3,11 @@
 public class JobOptions
 {
     public bool Enabled { get; set; }
-    public string CronSchedule { get; set; } = string.Empty;
+    public Schedule[] CronSchedules { get; set; } = [];
+}
+
+public class Schedule
+{
+    public string Chron { get; set; } = default!;
+    public string Description { get; set; } = default!;
 }

--- a/src/Server.UI/Pages/Dashboard/Components/JobManagement.razor
+++ b/src/Server.UI/Pages/Dashboard/Components/JobManagement.razor
@@ -1,5 +1,14 @@
 ﻿
+<style>
+    .mud-table-cell-custom-group {
+        font-weight: 500;
+    }
 
+    .mud-table-cell-custom-group-footer {
+        padding-bottom: 50px;
+        text-align: right;
+    }
+</style>
 
 <MudItem xs="12">
     <MudCard style="height:100%">
@@ -18,23 +27,22 @@
         </MudCardHeader>
         <MudCardContent>
 
-            <MudTable Items="JobDetails" Hover="true" Breakpoint="Breakpoint.Sm">
+            <MudTable 
+                Items="JobDetails" 
+                Hover="true" 
+                Breakpoint="Breakpoint.Sm"
+                GroupBy="@_groupDefinition"
+                GroupHeaderStyle="background-color:var(--mud-palette-background-gray)">
                 <HeaderContent>
-                    <MudTh>Name</MudTh>
-                    <MudTh>Description</MudTh>
+                    <MudTh>Trigger</MudTh>
                     <MudTh>State</MudTh>
                     <MudTh>Next Scheduled</MudTh>
                     <MudTh>Last Scheduled</MudTh>
-                    <MudTh>Actions</MudTh>
                 </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Name">@context.JobName</MudTd>
-                    <MudTd DataLabel="Description">@context.Description</MudTd>
-                    <MudTd DataLabel="State">@context.TriggerState</MudTd>
-                    <MudTd DataLabel="Next Scheduled">@context.NextFireTime</MudTd>
-                    <MudTd DataLabel="Last Scheduled">@context.PreviousFireTime</MudTd>
-                    <MudTd DataLabel="Actions"> 
-                        <MudButton Disabled="@(_isTriggering || (_scheduler?.InStandbyMode ?? false))" Variant="Variant.Outlined" Color="Color.Primary" OnClick="() => TriggerJob(context.JobName!)">
+                <GroupHeaderTemplate>
+                    <MudTh Class="mud-table-cell-custom-group" colspan="3">@context.Key: @context.Items.First().Description</MudTh>
+                    <MudTh Class="mud-table-cell-custom-group">
+                        <MudButton Disabled="@(_isTriggering || (_scheduler?.InStandbyMode ?? false))" Variant="Variant.Outlined" Color="Color.Primary" OnClick="() => TriggerJob(context.Key!.ToString()!)">
                             @if(_isTriggering)
                             {
                                 <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true"/>
@@ -45,7 +53,13 @@
                                 <MudText>Trigger</MudText>
                             }
                         </MudButton>
-                    </MudTd>
+                    </MudTh>
+                </GroupHeaderTemplate>
+                <RowTemplate>
+                    <MudTd DataLabel="Trigger">@context.TriggerDescription</MudTd>
+                    <MudTd DataLabel="State">@context.TriggerState</MudTd>
+                    <MudTd DataLabel="Next Scheduled">@context.NextFireTime</MudTd>
+                    <MudTd DataLabel="Last Scheduled">@context.PreviousFireTime</MudTd>
                 </RowTemplate>
             </MudTable>
         </MudCardContent>

--- a/src/Server.UI/Pages/Dashboard/Components/JobManagement.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/Components/JobManagement.razor.cs
@@ -13,6 +13,13 @@ public partial class JobManagement
     private bool _isTriggering = false;
     private string? _message = string.Empty;
     private IScheduler? _scheduler;
+    private TableGroupDefinition<JobDetailInfo>? _groupDefinition = new()
+    {
+        GroupName="Job",
+        Indentation = false,
+        Expandable = false,
+        Selector = (e) => e.JobName
+    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -75,6 +82,7 @@ public partial class JobManagement
                             TriggerState = triggerState.ToString(),
                             NextFireTime = trigger.GetNextFireTimeUtc()?.DateTime,
                             PreviousFireTime = trigger.GetPreviousFireTimeUtc()?.DateTime,
+                            TriggerDescription = trigger.Description ?? string.Empty,
                         });
                     }
                 }
@@ -135,6 +143,9 @@ public partial class JobManagement
         public string Group { get; set; } = default!;
         public string Description { get; set; } = default!;
         public string TriggerState { get; set; } = default!;
+
+        public string TriggerDescription { get; set; } = default!;
+
         public DateTime? NextFireTime { get; set; } = default!;
         public DateTime? PreviousFireTime { get; set; } = default!;
     }

--- a/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
+++ b/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
@@ -3,13 +3,11 @@
 @using Cfo.Cats.Application.Features.Participants.DTOs
 @using Cfo.Cats.Application.Features.Participants.MessageBus
 @using Cfo.Cats.Application.Features.QualityAssurance.Commands
-@using Rebus.Bus
+@using Cfo.Cats.Application.Outbox
 @using Cfo.Cats.Application.SecurityConstants
 
 @inherits CatsComponentBase
-@inject IDialogService DialogService
-@inject NavigationManager NavigationManager
-@inject IBus Bus;
+
 
 <MudMenu ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomLeft">
     <ActivatorContent>
@@ -58,7 +56,8 @@
     </ChildContent>
 </MudMenu>
 
-@code {
+@code
+{
     private bool _canForceUpdate;
 
     [CascadingParameter]
@@ -248,11 +247,12 @@
         var dialog = await DialogService.ShowAsync<ConfirmationDialog>("Force data sync", parameters, options);
         var result = await dialog.Result;
 
-        if (!result!.Canceled)
+        if (result!.Canceled == false)
         {
             var sync = new SyncParticipantCommand(Participant.Id);
-            await Bus.Publish(sync);
-            await OnUpdate.InvokeAsync();
+            var unitOfWork = GetNewUnitOfWork();
+            await unitOfWork.DbContext.InsertOutboxMessage(sync);
+            await unitOfWork.SaveChangesAsync();
         }
     }
 

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -71,23 +71,38 @@
     "quartz.scheduler.instanceName": "CATS Job Scheduler",
     "SyncParticipantsJob": {
       "Enabled": true,
-      "CronSchedule": "0 0 0 30 11 ? 2099"
+      "CronSchedules": [
+        { 
+          "Chron": "0 0 22 * * ? *",
+          "Description": "Every night at 22:00"
+        }  
+      ]
     },
     "DisableDormantAccountsJob": {
       "Enabled": true,
-      "CronSchedule": "0 0 0 30 11 ? 2099"
+      "CronSchedules": [
+        { "Chron":  "0 0 19 * * ? *", "Description": "Every night at 19:00" } 
+      ]
     },
     "NotifyAccountDeactivationJob": {
       "Enabled": true,
-      "CronSchedule": "0 0 0 30 11 ? 2099"
+      "CronSchedules": [ 
+        { "Chron": "0 0 0 30 11 ? 2099", "Description":  "Runs in the evening" } 
+      ]
     },
     "PublishOutboxMessagesJob": {
       "Enabled": true,
-      "CronSchedule": "0/5 * 7-17 * * ?"
+      "CronSchedules": [
+        { "Chron": "0 5 0-6 * * ?", "Description": "00:00 till 06:00 every 10 minutes" },
+        { "Chron": "0/30 * 7-19 * * ?", "Description": "07:00 till 19:00 every 30 seconds" },
+        { "Chron": "0 5 20-23 * * ?", "Description": "20:00 till 00:00 every 10 minutes" }
+      ]
     },
     "GenerateOutcomeQualityDipSamplesJob": {
       "Enabled": true,
-      "CronSchedule": "0 0 0 30 11 ? 2099"
+      "CronSchedules": [
+        { "Chron":  "0 0 3 1 * ?", "Description": "Runs on the first of the month at 03:00" }
+      ]
     }
   },
   "RightToWorkSettings": {


### PR DESCRIPTION
The problem was caused by the IBus being created at the point
of injection into the participant screen. This was a locking
method and crashed the UI thread silently.

The fix is to not use the IBus directly in UI but to publish an
outbox message first and let the service handle it.

Also tidied up the job scheduling, this allows us to limit the
number of jobs run, and have a different schedule during the night
and early morning
