### PR TITLE
Don't log the sending of emails.

### DIFF
--- a/src/Application/Features/Identity/Notifications/SendTwoFactorCode/SendTwoFactorEmailCodeNotificationHandler.cs
+++ b/src/Application/Features/Identity/Notifications/SendTwoFactorCode/SendTwoFactorEmailCodeNotificationHandler.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cfo.Cats.Application.Features.Identity.Notifications.SendTwoFactorCode;
 
-public class SendTwoFactorEmailCodeNotificationHandler(
-    ILogger<SendTwoFactorEmailCodeNotificationHandler> logger,
-    ICommunicationsService communicationsService
-) : INotificationHandler<SendTwoFactorEmailCodeNotification>
+public class SendTwoFactorEmailCodeNotificationHandler(ICommunicationsService communicationsService) : INotificationHandler<SendTwoFactorEmailCodeNotification>
 {
     public async Task Handle(SendTwoFactorEmailCodeNotification notification, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
This is a hangover from development. We don't need to log this (and it is clogging up sentry.io)