### PR TITLE
CFODEV-1338: Validates dip sample status for reviews

### DIFF
--- a/src/Application/Features/ManagementInformation/Commands/AddOutcomeQualityDipSampleCso/Validator.cs
+++ b/src/Application/Features/ManagementInformation/Commands/AddOutcomeQualityDipSampleCso/Validator.cs
@@ -1,11 +1,16 @@
+using Cfo.Cats.Application.Common.Interfaces;
 using Cfo.Cats.Application.Common.Validators;
 
 namespace Cfo.Cats.Application.Features.ManagementInformation.Commands.AddOutcomeQualityDipSampleCso;
 
 public class Validator : AbstractValidator<Command>
 {
+    private readonly IUnitOfWork unitOfWork;
+
     public Validator(IUnitOfWork unitOfWork)
     {
+        this.unitOfWork = unitOfWork;
+
         RuleFor(x => x.ParticipantId)
             .NotNull()
             .MaximumLength(9)
@@ -63,34 +68,34 @@ public class Validator : AbstractValidator<Command>
         RuleFor(x => x.ComplianceAnswer)
             .Must(x => x.IsAnswer)
             .WithMessage("Compliance must be answered");
-        
-        RuleSet(ValidationConstants.RuleSet.MediatR, () => {
 
-            RuleFor(x => x)
-                .MustAsync(async (_, answer, context, ct) => {
-                    var dip = await unitOfWork.DbContext.OutcomeQualityDipSampleParticipants
-                        .Where(x => x.ParticipantId == answer.ParticipantId && x.DipSampleId == answer.DipSampleId)
-                        .AsNoTracking()
-                        .Select(x => x.FinalIsCompliant)
-                        .FirstOrDefaultAsync();
+        RuleSet(ValidationConstants.RuleSet.MediatR, () =>
+        {
+            const string message = "Cannot submit CPM review: {0}";
 
-                    if (dip == null)
-                    {
-                        context.MessageFormatter.AppendArgument("Reason", "not found");
-                        return false;
-                    }
-
-                    if (dip.IsAnswer)
-                    {
-                        context.MessageFormatter.AppendArgument("Reason", "Already reviewed");
-                        return false;
-                    }
-
-                    return true;
-
-                }).WithMessage("Cannot review: {Reason}");
-
+            RuleFor(c => c)
+                .Must((c) => Exist(c.DipSampleId, c.ParticipantId))
+                .WithMessage(string.Format(message, "not found"))
+                .Must((c) => BeInAwaitingReviewStatus(c.DipSampleId))
+                .WithMessage(string.Format(message, $"sample must be in '{DipSampleStatus.AwaitingReview}' status"))
+                .Must((c) => NotHaveCpmOrFinalisedAnswer(c.DipSampleId, c.ParticipantId))
+                .WithMessage(string.Format(message, "cannot review a verified/finalised answer"));
         });
-        
+    }
+
+    private bool Exist(Guid dipSampleId, string participantId)
+        => unitOfWork.DbContext.OutcomeQualityDipSampleParticipants.Any(dsp => dsp.DipSampleId == dipSampleId && dsp.ParticipantId == participantId);
+
+    private bool BeInAwaitingReviewStatus(Guid dipSampleId)
+        => unitOfWork.DbContext.OutcomeQualityDipSamples.Any(ds => ds.Id == dipSampleId && ds.Status == DipSampleStatus.AwaitingReview);
+
+    private bool NotHaveCpmOrFinalisedAnswer(Guid dipSampleId, string participantId)
+    {
+        var answers = unitOfWork.DbContext.OutcomeQualityDipSampleParticipants
+            .Where(dsp => dsp.DipSampleId == dipSampleId && dsp.ParticipantId == participantId)
+            .Select(dsp => new { dsp.FinalIsCompliant, dsp.CpmIsCompliant })
+            .First();
+
+        return answers is { CpmIsCompliant.IsAnswer: false, FinalIsCompliant.IsAnswer: false };
     }
 }

--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
@@ -4,7 +4,17 @@
 
 @attribute [Authorize(Policy = SecurityPolicies.OutcomeQualityDipVerification)]
 
-<MudForm @ref="form" Model="Command" Validation="@(Validator.ValidateValue(Command))" Class="ma-2">
+@inject IAuthorizationService AuthorizationService
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+@if (Status != DipSampleStatus.Reviewed)
+{
+    <MudAlert Severity="Severity.Info">
+        This information is now readonly because the sample is at the @Status.Name stage.
+    </MudAlert>
+}
+
+<MudForm @ref="form" Model="Command" Validation="@(Validator.ValidateValue(Command))" Class="ma-2" ReadOnly="ReadOnly">
     <MudGrid>
         <MudItem xs="12" md="3">
             <MudText Typo="Typo.subtitle1">

--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
@@ -1,13 +1,21 @@
 ﻿using Cfo.Cats.Application.Features.ManagementInformation.Commands;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Common.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+using OpenTelemetry.Trace;
 
 namespace Cfo.Cats.Server.UI.Pages.Analytics.Components;
 
 public partial class SubmitCpmResponseComponent
 {
     private MudForm form = new();
+    private bool ReadOnly { get; set; } = true;
 
     [Parameter][EditorRequired] public required EventCallback<AddOutcomeQualityDipSampleCpm.Command> OnFormSubmit { get; set; }
     [Parameter][EditorRequired] public required AddOutcomeQualityDipSampleCpm.Command Command { get; set; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+    [Parameter, EditorRequired] public required DipSampleStatus Status { get; set; }
 
     private async Task OnSubmit()
     {
@@ -19,4 +27,18 @@ public partial class SubmitCpmResponseComponent
         }
     }
 
+    protected override async Task OnInitializedAsync()
+    {
+        if (Status == DipSampleStatus.Reviewed)
+        {
+            var state = await AuthState;
+            var result =
+                await AuthorizationService.AuthorizeAsync(state.User, SecurityPolicies.OutcomeQualityDipVerification);
+            ReadOnly = result is not { Succeeded: true };
+        }
+        else
+        {
+            ReadOnly = true;
+        }
+    }
 }

--- a/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/Index.razor
+++ b/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/Index.razor
@@ -143,10 +143,7 @@
                                     </MudStack>
                                 </TooltipContent>
                                 <ChildContent>
-                                    <MudRating 
-                                        SelectedValue="sample.Score.Value" 
-                                        Disabled="true" 
-                                        Color="Color.Primary" />
+                                    <MudRating SelectedValue="sample.Score.Value" ReadOnly />
                                 </ChildContent>
                             </MudTooltip>
                         }

--- a/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
+++ b/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
@@ -76,7 +76,7 @@
                     </MudTabPanel>
                     <AuthorizeView Policy="@SecurityPolicies.OutcomeQualityDipVerification">
                         <MudTabPanel Text="Verification" Disabled="_participant.CsoAnswer.IsAnswer is false">
-                            <SubmitCpmResponseComponent Command="@SubmitCpmCommand" OnFormSubmit="CpmResponseSubmitted" />
+                            <SubmitCpmResponseComponent Command="@SubmitCpmCommand" OnFormSubmit="CpmResponseSubmitted" Status="_participant.DipSampleStatus" />
                         </MudTabPanel>
                     </AuthorizeView>
 


### PR DESCRIPTION
Ensures that CPM and CSO reviews are only submitted when the dip sample is in the correct status.

This prevents reviews from being submitted prematurely or after a final decision has been made. Also prevents users without the correct permission to edit a reviewed sample.