### PR TITLE
Fix PQA Activity Exports

### DIFF
--- a/src/Application/Features/Activities/Queries/ActivityPqaQueueWithPagination.cs
+++ b/src/Application/Features/Activities/Queries/ActivityPqaQueueWithPagination.cs
@@ -4,7 +4,7 @@ using Cfo.Cats.Application.Features.Activities.DTOs;
 using Cfo.Cats.Application.Features.Activities.Specifications;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Entities.Activities;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Cfo.Cats.Application.Features.Activities.Queries;
 


### PR DESCRIPTION
The PQA activity export was broken due to it having a reference to System.Text.Json instead of Newtonsoft.Json.

This meant the JsonIgnore attribute was not honoured and the system was trying to serialize the specification, which has a circular reference to the Query.
