### PR TITLE
Addresses a performance issue on the dashboard.

### DIFF
--- a/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/Components/SyncComponent.razor.cs
@@ -19,9 +19,12 @@ public partial class SyncComponent
             var query = from p in uow.DbContext.Participants
                 where p.LastSyncDate.HasValue
                 group p by p.LastSyncDate!.Value.Date into g
+                orderby g.Key descending
                 select new SyncRecord(g.Key, g.Count());
                 
-            var results = await query.ToArrayAsync();
+            var results = await query.AsNoTracking()
+                .ToArrayAsync();
+
             if (IsDisposed == false)
             {
                 _records = results;
@@ -34,5 +37,5 @@ public partial class SyncComponent
         
     }
 
-    public record SyncRecord(DateTime TheDate, int RecordCount);
+    private record SyncRecord(DateTime TheDate, int RecordCount);
 }


### PR DESCRIPTION
Using the MI Date table for this query resulted in a cartesian
explosion. The results where correct, but the query plan was awful, it
ended up doing multiple scans (18,000+) of the participant table.

This tweaked query skips the MI table and just scans the converted date.
This is needed to get the full count, but it is better to do it once
rather than tens of thousands of times.
