### PR TITLE
Update AuditibleEntityInterceptor.cs

### DIFF
--- a/src/Infrastructure/Persistence/Interceptors/AuditibleEntityInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditibleEntityInterceptor.cs
@@ -55,8 +55,8 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
             switch (entry.State)
             {
                 case EntityState.Added:
-                    entry.Entity.CreatedBy = userId;
-                    entry.Entity.Created = dateTime.Now;
+                    entry.Entity.CreatedBy ??= userId;
+                    entry.Entity.Created ??= dateTime.Now;
                     if (entry.Entity is IMustHaveTenant mustTenant && string.IsNullOrEmpty(mustTenant.TenantId))
                     {
                         mustTenant.TenantId = tenantId!;


### PR DESCRIPTION
This addresses an issue where a user may manually set the created by, but it is overwritten by the audit.

You need to be able to manually set when working outside the user scope