### PR TITLE
Force output directory (this is needed for when we resync migrations in a later ticket)

### DIFF
--- a/migration.cake
+++ b/migration.cake
@@ -20,6 +20,7 @@ Task("AddMigration")
                     $"--project {infraProject} " +
                     $"--startup-project {startupProject} " + 
                     $"--configuration Debug " + 
+                    $"--output-dir Persistence/Migrations " +
                     "--no-build",
         WorkingDirectory = MakeAbsolute(Directory("./"))
     };


### PR DESCRIPTION
# Fix Migration Output



This pull request adds the output directory to the migration script, in the near future I plan to tear down all migrations and rebuild them into one migration. This should improve build times as the number of .cs files to manage will be greatly reduced.



