### PR TITLE
Sets dialog to full width

### DIFF
--- a/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
+++ b/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
@@ -166,7 +166,8 @@
         {
             BackdropClick = false,
             CloseOnEscapeKey = true,
-            MaxWidth = MaxWidth.Medium
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
         };
 
         var dialog = await DialogService.ShowAsync<ConfirmationWithNotesDialog>("Submit to Provider QA", parameters, options);


### PR DESCRIPTION
Ensures the justification note in the "Submit to Provider QA" confirmation dialog displays in full and is not truncated.