### PR TITLE
Adds Risk tab to participant details view on dip sample screen

### DIFF
--- a/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
+++ b/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
@@ -70,6 +70,9 @@
                     <MudTabPanel Text="Assessments">
                         <OutcomeQualityDipSampleAssessmentComponent ParticipantId="@_participant.ParticipantId" />
                     </MudTabPanel>
+                    <MudTabPanel Text="Risk">
+                        <Cfo.Cats.Server.UI.Pages.Risk.RiskComponents.RiskHistory ParticipantId="@_participant.ParticipantId" />
+                    </MudTabPanel>
                     <MudTabPanel Text="Notes">
                         <Cfo.Cats.Server.UI.Pages.Participants.Components.CaseNotes ParticipantId="@_participant.ParticipantId" />
                     </MudTabPanel>


### PR DESCRIPTION
Adds a new "Risk" tab to the participant details view within the Outcome Quality Dip Sample screen, it displays the Risk History component, providing users with access to risk-related information for the participant.