### PR TITLE
Extend period for checking PRI date validations

### DIFF
--- a/src/Application/Features/ManagementInformation/IntegrationEventHandlers/RecordThroughTheGatePaymentConsumer.cs
+++ b/src/Application/Features/ManagementInformation/IntegrationEventHandlers/RecordThroughTheGatePaymentConsumer.cs
@@ -206,7 +206,7 @@ public class RecordThroughTheGatePaymentConsumer(IUnitOfWork unitOfWork)
                 bool beenInCommunityAfter = false;
 
                 foreach (var h in Locations.Where(h => h.From < ActualReleaseDate!.ToDateTime(TimeOnly.MinValue)
-                                 .AddDays(28)) // add 14 days to allow for DMS sync issues
+                                 .AddDays(28)) // add 28 days to allow for DMS sync issues
                              .OrderBy(h => h.From))
                 {
                     if (h.LocationId == CustodyLocationId)


### PR DESCRIPTION
## Increase PRI date period

Increases the allowance period for DMS synchronization from 14 to 28 days, it mirrors the timeframe permitted for someone to appear at the community location when they go TTG