### PR TITLE
CFODEV-1402:  Fix dip sample screen

### DIFF
--- a/src/Application/Features/PerformanceManagement/Queries/GetOutcomeQualityDipSamplePathwayPlan.cs
+++ b/src/Application/Features/PerformanceManagement/Queries/GetOutcomeQualityDipSamplePathwayPlan.cs
@@ -73,8 +73,7 @@ public static class GetOutcomeQualityDipSamplePathwayPlan
                 .FirstAsync(cancellationToken);
 
             var activityQuery = from a in db.Activities                                
-                    .Include(a => a.TookPlaceAtLocation)
-                where a.Status == ActivityStatus.ApprovedStatus
+                    .Include(a => a.TookPlaceAtLocation)                
                 join t in (
                     from p in db.PathwayPlans
                     where p.ParticipantId == request.ParticipantId


### PR DESCRIPTION
### Objective screen fixed on Dip Sampling.

The dip sample screen has been fixed, status was crashing the screen (filter not needed)