### PR TITLE
Use auto-compliant versions for answers

### DIFF
--- a/src/Domain/Entities/ManagementInformation/OutcomeQualityDipSample.cs
+++ b/src/Domain/Entities/ManagementInformation/OutcomeQualityDipSample.cs
@@ -138,8 +138,11 @@ public class OutcomeQualityDipSample : BaseAuditableEntity<Guid>
 
             if (participant.CsoIsCompliant.IsAnswer && (participant.CsoIsCompliant.IsAccepted == participant.CpmIsCompliant.IsAccepted))
             {
-                participant.FinalAnswer(participant.CpmIsCompliant, participant.CpmComments!, participant.CpmReviewedBy!,
-                    DateTime.UtcNow);
+                var finalAnswer = participant.CpmIsCompliant.IsAccepted ? 
+                    ComplianceAnswer.AutoCompliant : 
+                    ComplianceAnswer.AutoNotCompliant;
+
+                participant.FinalAnswer(finalAnswer, participant.CpmComments!, participant.CpmReviewedBy!, DateTime.UtcNow);
             }
         }
 


### PR DESCRIPTION
When the system sets the final answer (because there has been an agreement between CSO and CPM) the final answer should use the "automatic" variant of the compliance answer.

This will allow the finalising user to see which answers they have manually set, and which are automatic.

They are still able to override these answers, it's more for display purposes only.
