### PR TITLE
CFODEV-1442: Add icon that allows you to view the users password

### DIFF
--- a/src/Server.UI/Pages/Identity/Authentication/Login.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Login.razor
@@ -79,12 +79,19 @@
                     <div class="mud-input-control-input-container">
                         <!--!--><!--!-->
                         <div class="mud-input mud-input-outlined mud-shrink">
-                            <InputText type="password" @bind-Value="Input.Password" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="off" aria-required="true" placeholder="password" />
+							<InputText type="password" @bind-Value="Input.Password" id="passwordInput" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="off" aria-required="true" placeholder="password" />
                             <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
                             <!--!-->
-                            <div class="mud-input-outlined-border"></div>
+							<div class="mud-input-outlined-border"></div>						
+							<MudIcon Icon="@Icons.Material.Filled.Visibility" 
+								Color="Color.Inherit"
+								Class="ms-2 cursor-pointer mr-2"
+								id="passwordToggleIcon"
+								onmouseover="document.getElementById('passwordInput').type = 'text';"
+								onmouseout="document.getElementById('passwordInput').type = 'password';" />
+							<!--!-->
                         </div>
-                        <!--!-->
+
                     </div>
                     <div class="mud-input-helper-text mud-input-error">
                         <div class="d-flex">


### PR DESCRIPTION
# Password Visibility



This pull request allows a user to see the password they have entered if they hold their mouse over the eye icon.



This should help users check they have entered their password correctly.

<img width="1743" height="877" alt="image" src="https://github.com/user-attachments/assets/4eda6ea7-260b-4682-a513-d51bf5453e6d" />

