### PR TITLE
Adds education dashboard for support workers

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetEducationsPerSupportWorker.cs
+++ b/src/Application/Features/Dashboard/Queries/GetEducationsPerSupportWorker.cs
@@ -1,0 +1,71 @@
+﻿using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Queries;
+public static class GetEducationsPerSupportWorker
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Query : IRequest<Result<EducationsPerSupportWorkerDto>>
+    {
+        public required DateTime StartDate { get; set; }
+        public required DateTime EndDate { get; set; }
+        public required string UserId { get; set; }
+        public required UserProfile CurrentUser { get; set; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<EducationsPerSupportWorkerDto>>
+    {
+        public async Task<Result<EducationsPerSupportWorkerDto>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var context = unitOfWork.DbContext;
+
+            var query = from mi in context.EducationPayments
+                        join ap in context.Activities on mi.ActivityId equals ap.Id
+                        join l in context.Locations on mi.LocationId equals l.Id
+                        where ap.OwnerId == request.UserId
+                        && mi.ActivityApproved >= request.StartDate
+                        && mi.ActivityApproved <= request.EndDate
+                        group mi by l into grp
+                        select new LocationDetail
+                            (
+                                grp.Key.Name,
+                                grp.Key.LocationType,
+                                grp.Count(mi => mi.EligibleForPayment),
+                                grp.Count()
+                            );
+
+            var results = await query
+                .AsNoTracking()
+                .ToArrayAsync(cancellationToken);
+
+            return new EducationsPerSupportWorkerDto(results);
+        }
+    }
+
+    public record EducationsPerSupportWorkerDto
+    {
+        public EducationsPerSupportWorkerDto(LocationDetail[] details)
+        {
+            Details = details;
+
+            Custody = details.Where(d => d.LocationType.IsCustody).Sum(d => d.TotalCount);
+            CustodyPayable = details.Where(d => d.LocationType.IsCustody).Sum(d => d.Payable);
+
+            Community = details.Where(d => d.LocationType.IsCommunity).Sum(d => d.TotalCount);
+            CommunityPayable = details.Where(d => d.LocationType.IsCommunity).Sum(d => d.Payable);
+
+        }
+
+        public LocationDetail[] Details { get; }
+
+        public int Custody { get; }
+        public int CustodyPayable { get; }
+
+        public int Community { get; }
+        public int CommunityPayable { get; }
+
+    }
+
+    public record LocationDetail(string Name, LocationType LocationType, int Payable, int TotalCount);
+
+}

--- a/src/Server.UI/Components/Dashboard/SupportWorkerEducationDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/SupportWorkerEducationDashboardComponent.razor
@@ -1,0 +1,84 @@
+@using Cfo.Cats.Application.Features.Dashboard.Queries
+@inherits CatsComponent<GetEducationsPerSupportWorker.EducationsPerSupportWorkerDto>
+
+@if (Loading)
+{
+    <MudLoading Text="Loading" />
+}
+
+@if (ErrorMessage is not null)
+{
+    <MudAlert Variant="Variant.Outlined" Severity="Severity.Error">
+        @ErrorMessage
+    </MudAlert>
+}
+
+@if (Data is not null)
+{
+    <MudGrid Spacing="2">
+        <MudItem xs="12" Style="height: calc(100vh - 150px);">
+            <MudStack Row="true" Breakpoint="Breakpoint.SmAndDown" Style="height:100%; width:100%;">
+
+                <!-- This is the left column -->
+                <MudStack Style="width: 150px;">
+                    <MudChip T="string">Custody (@Data.Custody)</MudChip>
+                    <MudChip T="string">Community (@Data.Community)</MudChip>
+                </MudStack>
+
+                <!-- Right hand content -->
+                <MudStack Style="flex:1; height:80%; overflow:auto;">
+                    @if (VisualMode)
+                    {
+                        @if (VisualMode)
+                        {
+                            <ApexCharts.ApexChart TItem="GetEducationsPerSupportWorker.LocationDetail" Options="Options" Height="@("100%")" Width="@("100%")">
+
+                                <ApexCharts.ApexPointSeries TItem="GetEducationsPerSupportWorker.LocationDetail"
+                                                            Items="Data.Details"
+                                                            Name="@($"Payable ({(Data.CommunityPayable + Data.CustodyPayable)})")"
+                                                            SeriesType="ApexCharts.SeriesType.Bar"
+                                                            XValue="@(e => e.Name)"
+                                                            YValue="@(e => e.Payable)"
+                                                            OrderByDescending="e=>e.Y"
+                                                            ShowDataLabels="true">
+                                </ApexCharts.ApexPointSeries>
+
+                                <ApexCharts.ApexPointSeries TItem="GetEducationsPerSupportWorker.LocationDetail"
+                                                            Items="Data.Details"
+                                                            Name="@($"Non Payable ({(Data.Community + Data.Custody) - (Data.CommunityPayable + Data.CustodyPayable)})")"
+                                                            SeriesType="ApexCharts.SeriesType.Bar"
+                                                            XValue="@(e => e.Name)"
+                                                            YValue="@(e => e.TotalCount - e.Payable)"
+                                                            OrderByDescending="e=>e.Y"
+                                                            ShowDataLabels="true">
+                                </ApexCharts.ApexPointSeries>
+                            </ApexCharts.ApexChart>
+                        }
+                    }
+                    else
+                    {
+                        <MudTable Items="@Data.Details" MultiSelection="false" Striped="true" Hover="true">
+                            <HeaderContent>
+                                <MudTh>Location</MudTh>
+                                <MudTh>Type</MudTh>
+                                <MudTh>Payable</MudTh>
+                                <MudTh>Non-Payable</MudTh>
+                                <MudTh>Total Count</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Location">@context.Name</MudTd>
+                                <MudTd DataLabel="Type">@context.LocationType.Name</MudTd>
+                                <MudTd DataLabel="Payable">@context.Payable</MudTd>
+                                <MudTd DataLabel="Payable">@(context.TotalCount - context.Payable)</MudTd>
+                                <MudTd DataLabel="Total Count">@context.TotalCount</MudTd>
+                            </RowTemplate>
+                            <PagerContent>
+                                <MudTablePager PageSizeOptions="new int[] { 10, 20 }" />
+                            </PagerContent>
+                        </MudTable>
+                    }
+                </MudStack>
+            </MudStack>
+        </MudItem>
+    </MudGrid>
+}

--- a/src/Server.UI/Components/Dashboard/SupportWorkerEducationDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/SupportWorkerEducationDashboardComponent.razor.cs
@@ -1,0 +1,60 @@
+using Cfo.Cats.Application.Features.Dashboard.Queries;
+
+namespace Cfo.Cats.Server.UI.Components.Dashboard;
+public partial class SupportWorkerEducationDashboardComponent
+{
+
+    [EditorRequired, Parameter]
+    public DateRange? DateRange { get; set; }
+
+    [EditorRequired, Parameter]
+    public string UserId { get; set; } = null!;
+
+    [EditorRequired, Parameter]
+    public bool VisualMode { get; set; }
+
+    [CascadingParameter(Name = "IsDarkMode")]
+    public bool IsDarkMode { get; set; }
+
+    protected override IRequest<Result<GetEducationsPerSupportWorker.EducationsPerSupportWorkerDto>> CreateQuery()
+     => new GetEducationsPerSupportWorker.Query()
+     {
+         CurrentUser = CurrentUser,
+         UserId = UserId,
+         StartDate = DateRange?.Start ?? throw new InvalidOperationException("DateRange not set"),
+         EndDate = DateRange?.End ?? throw new InvalidOperationException("DateRange not set")
+     };
+
+    private ApexCharts.ApexChartOptions<GetEducationsPerSupportWorker.LocationDetail> Options => new()
+    {
+        Chart = new ApexCharts.Chart
+        {
+            Stacked = true
+        },
+        PlotOptions = new ApexCharts.PlotOptions
+        {
+            Bar = new ApexCharts.PlotOptionsBar
+            {
+                Horizontal = false,
+                DataLabels = new ApexCharts.PlotOptionsBarDataLabels
+                {
+                    Total = new ApexCharts.BarTotalDataLabels
+                    {
+                        Enabled = true,
+                        Style = new ApexCharts.BarDataLabelsStyle
+                        {
+                            FontWeight = "800",
+                            Color = IsDarkMode ? "#FFFFFF" : "#000000",
+                        }
+                    }
+                },
+            },
+        },
+        Theme = new ApexCharts.Theme
+        {
+            Mode = IsDarkMode ? ApexCharts.Mode.Dark : ApexCharts.Mode.Light
+        },
+        Colors = new List<string> { "#5cb85c", "#d9534f" }
+    };
+
+}

--- a/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor
+++ b/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor
@@ -57,6 +57,7 @@
                     <MudTabPanel Text="Activities">
                     </MudTabPanel>
                     <MudTabPanel Text="ETE">
+                        <SupportWorkerEducationDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
                     </MudTabPanel>
                     <MudTabPanel Text="Employment">
                         <SupportWorkerEmploymentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />


### PR DESCRIPTION
Introduces a new dashboard component that displays education data for support workers, broken down by location type (Custody and Community).

The dashboard includes a visual representation using ApexCharts, as well as a tabular view of the data, showing location details, payable counts, and total counts. This enables a more granular view of support worker performance and education activities.