### PR TITLE
Support Worker Dashboard menus.

### DIFF
--- a/src/Server.UI/Components/Identity/SelectUserDialog.razor
+++ b/src/Server.UI/Components/Identity/SelectUserDialog.razor
@@ -1,0 +1,15 @@
+﻿@using Cfo.Cats.Server.UI.Components.Users
+
+
+<MudDialog>
+	<DialogContent>
+		<div style="min-width: 600px;">
+			<UserSelectComponent ValueChanged="dto => { OnUserSelectedChanged(dto); }" TenantId="@CurrentUser.TenantId" />
+		</div>
+	</DialogContent>
+	<DialogActions>
+		<MudButton OnClick="Dialog.Cancel">@ConstantString.Cancel</MudButton>
+		<MudLoadingButton Loading="saving" Color="Color.Primary" OnClick="Submit" Disabled="@(SelectedUser.UserId == string.Empty)">@ConstantString.Ok</MudLoadingButton>
+	</DialogActions>
+</MudDialog>
+

--- a/src/Server.UI/Components/Identity/SelectUserDialog.razor.cs
+++ b/src/Server.UI/Components/Identity/SelectUserDialog.razor.cs
@@ -1,0 +1,34 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Features.Identity.DTOs;
+
+namespace Cfo.Cats.Server.UI.Components.Identity;
+
+public partial class SelectUserDialog
+{
+    private bool saving = false;
+
+    [CascadingParameter]
+    private IMudDialogInstance Dialog { get; set; } = null!;
+
+    [Parameter]
+    public UserProfile CurrentUser { get; set; } = null!;
+
+    private SelectedUser SelectedUser { get; set; } = new SelectedUser(string.Empty, string.Empty);
+
+    private void Submit()
+    {
+        saving = true;
+        Dialog.Close(DialogResult.Ok(SelectedUser));
+    }
+
+    private void OnUserSelectedChanged(ApplicationUserDto? dto)
+    {
+        SelectedUser = SelectedUser with
+        {
+            UserId = dto?.Id ?? string.Empty,
+            DisplayName = dto?.DisplayName ?? string.Empty
+        };
+    }
+}
+
+public record SelectedUser(string UserId, string DisplayName);

--- a/src/Server.UI/Components/Shared/Layout/SearchDialog.razor
+++ b/src/Server.UI/Components/Shared/Layout/SearchDialog.razor
@@ -74,7 +74,7 @@
     protected override void OnInitialized()
     {
         pages.Add("Home", "/");
-        pages.Add("Support Worker Performance", "/pages/dashboard/supportworker/performance");
+        pages.Add("Support Worker Dashboard", "/pages/dashboard/supportworker");
         pages.Add("Participants", "/pages/participants");
         pages.Add("New Enrolment", "/pages/candidates/search");
         pages.Add("My Documents", "/pages/analytics/my-documents");

--- a/src/Server.UI/Components/Users/UserSelectComponent.razor.cs
+++ b/src/Server.UI/Components/Users/UserSelectComponent.razor.cs
@@ -5,8 +5,8 @@ namespace Cfo.Cats.Server.UI.Components.Users;
 
 public partial class UserSelectComponent
 {
-    [CascadingParameter]
-    public UserProfile CurrentUser { get; set; } = null!;
+    [Parameter]
+    public string TenantId { get; set; } = null!;
     [Parameter] public ApplicationUserDto? Value { get; set; }
     [Parameter] public EventCallback<ApplicationUserDto?> ValueChanged { get; set; }
     [Parameter] public string Label { get; set; } = "Select User";
@@ -16,7 +16,7 @@ public partial class UserSelectComponent
     [Parameter] public Variant Variant { get; set; } = MudBlazor.Variant.Outlined;
     private ApplicationUserDto[] _users = [];
     protected override void OnInitialized() => _users = UserService.DataSource
-        .Where(d => d.TenantId!.StartsWith(CurrentUser.TenantId!))
+        .Where(d => d.TenantId!.StartsWith(TenantId))
         .OrderBy(u => u.DisplayName)
         .ToArray();
     private string GetDisplayName(ApplicationUserDto? user) => user?.DisplayName ?? string.Empty;

--- a/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor
+++ b/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor
@@ -4,36 +4,46 @@
 @using Cfo.Cats.Server.UI.Components.Users
 @using Cfo.Cats.Server.UI.Pages.Dashboard.Components
 
-@page "/pages/dashboard/supportworker/performance"
+@page "/pages/dashboard/supportworker"
 @attribute [Authorize(Policy = SecurityPolicies.AuthorizedUser)]
 
 
-<MudStack Row="true" Justify="Justify.SpaceBetween">
+<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
     <MudText Typo="Typo.h3">
-        Support Worker Performance Dashboard
+        Support Worker Dashboard
     </MudText>
-    <MudAlert Severity="Severity.Info" Variant="Variant.Filled">
+    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
         This page is still under development.
     </MudAlert>
-    <MudSwitch 
-        @bind-Value="_visualMode"
-        T="bool" 
-        ThumbIcon="@Icons.Material.Filled.StackedBarChart" 
-        Color="Color.Primary">
-        Visual Mode
-    </MudSwitch>
+	<MudStack Row="true" AlignItems="AlignItems.Center">
+
+		<MudDateRangePicker @ref="_picker" DateFormat="dd MMM yyyy" TitleDateFormat="MMMM dd" @bind-DateRange="@_dateRange" MaxDate="DateTime.Today" MinDate="@(new DateTime(2025, 1, 1))" Class="pa-2">
+			<PickerActions>
+				<MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+				<MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">OK</MudButton>
+			</PickerActions>
+		</MudDateRangePicker>
+
+		@if (CurrentUser.AssignedRoles is not [])
+		{
+			<MudLink OnClick="DisplayOptionsDialog" Disabled="@(CurrentUser.AssignedRoles is [])">
+				@SelectedDisplayName
+			</MudLink>
+		}
+
+		<MudSwitch @bind-Value="_visualMode"
+				   T="bool"
+				   ThumbIcon="@Icons.Material.Filled.StackedBarChart"
+				   Color="Color.Primary">
+			Visual Mode
+		</MudSwitch>
+	</MudStack>
 </MudStack>
 
 
 
 <MudStack>
-
-    @if (_showSelect)
-    {
-        <UserSelectComponent ValueChanged="dto => { OnUserSelectedChanged(dto);  }" />    
-    }
-
-    @if(SelectedUserId is null)
+	@if(SelectedUserId is null)
     {
         <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
             Please select a user.
@@ -42,35 +52,31 @@
 
     @if (SelectedUserId is not null)
     {
-
-        <MudTabs Outlined="true" ApplyEffectsToContainer="true">
-            <MudTabPanel Text="Performance Overview" Icon="@Icons.Material.Filled.DataExploration">
-				<MudDateRangePicker DateFormat="dddd, dd MMMM, yyyy" TitleDateFormat="MMMM dd" @bind-DateRange="@_dateRange" MaxDate="DateTime.Today" MinDate="@(new DateTime(2025, 1, 1))" Class="pa-2" />
-				
-                <MudTabs Outlined="true" ApplyEffectsToContainer="true" Centered="true" Color="Color.Primary">
-                    <MudTabPanel Text="Enrolments" Class="pa-3">
-                        <SupportWorkerEnrolmentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
-                    </MudTabPanel>
-                    <MudTabPanel Text="Inductions" Class="pa-3">
-                        <SupportWorkerInductionDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
-                    </MudTabPanel>
-                    <MudTabPanel Text="Activities">
-                    </MudTabPanel>
-                    <MudTabPanel Text="ETE">
-                        <SupportWorkerEducationDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
-                    </MudTabPanel>
-                    <MudTabPanel Text="Employment">
-                        <SupportWorkerEmploymentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
-                    </MudTabPanel>
-                    <MudTabPanel Text="PRI">
-                    </MudTabPanel>
-                </MudTabs>
-            </MudTabPanel>
-            <MudTabPanel Text="Cases Location Breakdown" Icon="@Icons.Material.Filled.People">
-                <CasesPerLocationPerSupportWorkerCardComponent UserId="@SelectedUserId" @key="@SelectedUserId" VisualMode="@_visualMode" />
-            </MudTabPanel>
-        </MudTabs>
-
+		<MudTabs PanelClass="pa-6" ApplyEffectsToContainer="true" Outlined="true">
+			<MudTabPanel Text="Location Breakdown">
+				<MudAlert Severity="Severity.Info">
+					This page is not affected by the date range selector. It is a breakdown of all cases assigned to @SelectedDisplayName
+					and their current status.
+				</MudAlert>
+				<CasesPerLocationPerSupportWorkerCardComponent UserId="@SelectedUserId" @key="@SelectedUserId" VisualMode="@_visualMode" />
+			</MudTabPanel>
+			<MudTabPanel Text="Enrolments" Class="pa-3">
+				<SupportWorkerEnrolmentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
+			</MudTabPanel>
+			<MudTabPanel Text="Inductions" Class="pa-3">
+				<SupportWorkerInductionDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
+			</MudTabPanel>
+			<MudTabPanel Text="Activities">
+			</MudTabPanel>
+			<MudTabPanel Text="Education & Training">
+				<SupportWorkerEducationDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
+			</MudTabPanel>
+			<MudTabPanel Text="Employment">
+				<SupportWorkerEmploymentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
+			</MudTabPanel>
+			<MudTabPanel Text="PRI">
+			</MudTabPanel>
+		</MudTabs>
     }
     
 </MudStack>

--- a/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/SupportWorkerPerformance.razor.cs
@@ -1,15 +1,20 @@
 using Cfo.Cats.Application.Common.Security;
-using Cfo.Cats.Application.Features.Identity.DTOs;
+using Cfo.Cats.Server.UI.Components.Identity;
+using CsvHelper.Configuration.Attributes;
 
 namespace Cfo.Cats.Server.UI.Pages.Dashboard;
 
 public partial class SupportWorkerPerformance
 {
+
+    private MudDateRangePicker _picker = null!; 
+
     private bool _showSelect;
     private bool _visualMode = true;
     public string? SelectedUserId { get; set; }
+    public string? SelectedDisplayName { get; set; }
 
-    private DateRange _dateRange { get; set; } = new DateRange(new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1), DateTime.Today);
+    private DateRange _dateRange { get; set; } = new DateRange(new DateTime(2025, 1, 1), DateTime.Today);
     
     [CascadingParameter]
     public UserProfile CurrentUser { get; set; } = null!;
@@ -18,11 +23,25 @@ public partial class SupportWorkerPerformance
         _showSelect = CurrentUser.AssignedRoles is { Length: > 0 };
 
         // if the current user has access to select, don't set the selected user.
-        SelectedUserId = _showSelect ? null : CurrentUser.UserId;
+        SelectedUserId = CurrentUser.UserId;
+        SelectedDisplayName = CurrentUser.DisplayName;
     }
 
-    private void OnUserSelectedChanged(ApplicationUserDto? dto)
-    {
-        SelectedUserId = dto?.Id;
+    private async Task DisplayOptionsDialog()
+	{
+        var parameters = new DialogParameters<SelectUserDialog>
+        {
+            { "CurrentUser", CurrentUser }           
+        };
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Large, FullWidth = false};
+        var dialog = await DialogService.ShowAsync<SelectUserDialog>("Dashboard Options", parameters, options);
+        var result = await dialog.Result;
+
+        if(result is { Canceled: false, Data: SelectedUser user})
+        {
+            SelectedUserId = user.UserId;
+            SelectedDisplayName = user.DisplayName;
+        }
     }
 }

--- a/src/Server.UI/Services/Navigation/MenuService.cs
+++ b/src/Server.UI/Services/Navigation/MenuService.cs
@@ -31,8 +31,8 @@ public class MenuService : IMenuService
 
                             new()
                             {
-                                Title = "Support Worker Performance",
-                                Href = "/pages/dashboard/supportworker/performance",
+                                Title = "Support Worker Dashboard",
+                                Href = "/pages/dashboard/supportworker/",
                                 PageStatus = PageStatus.Wip
                             }
                         ],


### PR DESCRIPTION
# Clean up of support worker dashboard





* cleaned up the menus for selecting a user and date range
* created a generic user lookup dialog
* adjusted the name of the page to be support worker dashboard rather
  than support worker performance
* Adjusted tab controls (much better use of screen real estate)
