### PR TITLE
Allow WIP menus (and others) to be clicked.

### DIFF
--- a/src/Server.UI/Components/Shared/Layout/NavigationMenu.razor
+++ b/src/Server.UI/Components/Shared/Layout/NavigationMenu.razor
@@ -41,7 +41,7 @@
                             <MudNavGroup Icon="@sectionItem.Icon" Title="@L[sectionItem.Title]" Expanded="Expanded(sectionItem)">
                                 @foreach (var menuItem in sectionItem.MenuItems.Where(x => x.Roles == null || x.Roles.Any(x => Roles.Contains(x))))
                                 {
-                                    <MudNavLink Disabled="@(menuItem.PageStatus != PageStatus.Completed)" Href="@(menuItem.Href)" Target="@(menuItem.Target)" Match="NavLinkMatch.All">
+                                    <MudNavLink Href="@(menuItem.Href)" Target="@(menuItem.Target)" Match="NavLinkMatch.All">
                                         <div class="d-flex">
                                             @(L[menuItem.Title])
                                             @if (menuItem.PageStatus != PageStatus.Completed)
@@ -58,7 +58,7 @@
                         }
                         else
                         {
-                            <MudNavLink Disabled="@(sectionItem.PageStatus != PageStatus.Completed)" Href="@(sectionItem.Href)" Icon="@(sectionItem.Icon)" Target="@(sectionItem.Target)" Match="NavLinkMatch.All">
+                            <MudNavLink Href="@(sectionItem.Href)" Icon="@(sectionItem.Icon)" Target="@(sectionItem.Target)" Match="NavLinkMatch.All">
                                 <div class="d-flex">
                                     @(L[sectionItem.Title])
                                     @if (sectionItem.PageStatus != PageStatus.Completed)

--- a/src/Server.UI/Services/Navigation/MenuService.cs
+++ b/src/Server.UI/Services/Navigation/MenuService.cs
@@ -31,7 +31,7 @@ public class MenuService : IMenuService
 
                             new()
                             {
-                                Title = "Support Worker Dashboard",
+                                Title = "Support Worker",
                                 Href = "/pages/dashboard/supportworker/",
                                 PageStatus = PageStatus.Wip
                             }


### PR DESCRIPTION
# Enable menus that are WIP



This change allows menus to display that they are in development but
useable.

