### PR TITLE
Adjust queries for activity dashboards.

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetApprovedActivitiesPerSupportWorker.cs
+++ b/src/Application/Features/Dashboard/Queries/GetApprovedActivitiesPerSupportWorker.cs
@@ -22,7 +22,7 @@ public static class GetApprovedActivitiesPerSupportWorker
                         join l in context.Locations on a.TookPlaceAtLocation.Id equals l.Id
                         where a.OwnerId == request.UserId
                               && a.CompletedOn >= request.StartDate
-                              && a.CompletedOn <= request.EndDate
+                              && a.CompletedOn < request.EndDate.AddDays(1).Date
                               && a.Status == ActivityStatus.ApprovedStatus.Value
                         group a by new
                         {

--- a/src/Application/Features/Dashboard/Queries/GetReassmentsPerSupportWorker.cs
+++ b/src/Application/Features/Dashboard/Queries/GetReassmentsPerSupportWorker.cs
@@ -24,7 +24,7 @@ public static class GetReassessmentsPerSupportWorker
                         join l in context.Locations on mi.LocationId equals l.Id
                         where mi.SupportWorker == request.UserId
                         && mi.AssessmentCompleted >= request.StartDate
-                        && mi.AssessmentCompleted <= request.EndDate
+                        && mi.AssessmentCompleted < request.EndDate.AddDays(1).Date
                         group mi by l into grp
                         orderby grp.Key.Name, grp.Key.LocationType
                         select new Details


### PR DESCRIPTION
# Adjust dashboard queries.



* This takes into account the query is looking at a datetime field not a
  date field. Therefore it needs to be less than tomorrow, not the date
  that is passed in
