### PR TITLE
Get the latest bio on the summary page

### DIFF
--- a/src/Application/Features/Participants/Queries/GetParticipantSummary.cs
+++ b/src/Application/Features/Participants/Queries/GetParticipantSummary.cs
@@ -103,13 +103,15 @@ public static class GetParticipantSummary
                             BioSummary =
                                 (from bio in db.ParticipantBios
                                  where bio.ParticipantId == participantId
+                                 orderby bio.Created descending
                                  select new BioSummaryDto
                                  {
                                      BioCreator = bio.CreatedBy,
                                      BioDate = bio.Created,
                                      BioId = bio.Id,
                                      BioStatus = bio.Status
-                                 }).FirstOrDefault(),
+                                 })
+                                 .FirstOrDefault(),
                             LatestPri =
                                 (from pri in db.PRIs
                                  where pri.ParticipantId == participantId


### PR DESCRIPTION
# Get Latest Bio on the Summary page

Currently the page shows the first BIO. This means when a new one is created,  this isn't reflected on the summary page