### PR TITLE
Allows older enrolments with prior consent

### DIFF
--- a/src/Application/Features/QualityAssurance/Commands/SubmitPqaResponse.cs
+++ b/src/Application/Features/QualityAssurance/Commands/SubmitPqaResponse.cs
@@ -164,12 +164,12 @@ public static class SubmitPqaResponse
 
         private bool EnrolmentOccurredWithin3Months(Command c)
         {
-           var entry = _unitOfWork.DbContext.EnrolmentPqaQueue
-                      .Include(c => c.Participant)
-                      .Include(d => d.Participant!.Consents)
-                      .FirstOrDefault(a => a.Id == c.QueueEntryId);
-
-            return entry != null && entry.Participant!.CalculateConsentDate() >= DateTime.Today.AddMonths(-3);
+            var entry = _unitOfWork.DbContext.EnrolmentPqaQueue
+                       .Include(c => c.Participant)
+                       .Include(d => d.Participant!.Consents)
+                       .First(a => a.Id == c.QueueEntryId);
+                                  
+            return entry.Participant!.ConsentStatus == ConsentStatus.GrantedStatus || entry.Participant!.CalculateConsentDate() >= DateTime.Today.AddMonths(-3);
         }
     }
   


### PR DESCRIPTION
Modifies enrolment validation to allow entries older than 3 months if the participant's consent status is already granted. This addresses a scenario where consent was previously given, but the system still flags the enrolment as invalid due to the time elapsed since enrolment.
