### PR TITLE
Allows enrolment if consent was previously approved

### DIFF
--- a/src/Application/Features/QualityAssurance/Commands/SubmitToProviderQa.cs
+++ b/src/Application/Features/QualityAssurance/Commands/SubmitToProviderQa.cs
@@ -208,7 +208,7 @@ public static class SubmitToProviderQa
             var participant = await _unitOfWork.DbContext
                 .Participants.SingleAsync(x => x.Id == participantId, cancellationToken);
 
-            return participant.CalculateConsentDate() >= DateTime.Today.AddMonths(-3);                
+            return participant.ConsentStatus == ConsentStatus.GrantedStatus || participant.CalculateConsentDate() >= DateTime.Today.AddMonths(-3);                
         }
     }
 }


### PR DESCRIPTION
Modifies consent check to allow enrolments from more than 3
months ago if the participant's consent status is "granted."
This addresses a scenario where previously approved consents
should not block enrolment.

Relates to CFODEV-1483
