### PR TITLE
CFODEV-1162:  Fix so no risk updates with 2 weeks not 70 days.

### DIFF
--- a/src/Application/Features/Participants/EventHandlers/RiskInformationCompleted.cs
+++ b/src/Application/Features/Participants/EventHandlers/RiskInformationCompleted.cs
@@ -13,7 +13,7 @@ public class RiskInformationCompleted(IUnitOfWork unitOfWork) : INotificationHan
         if (participant is not null)
         {
             //If risk still not completed class it as initial review and keep review date as 14 days
-            if (participant.EnrolmentStatus == EnrolmentStatus.EnrollingStatus && notification.Item.ReviewReason == RiskReviewReason.NoRiskInformationAvailable)
+            if (participant.RiskDueReason == RiskDueReason.InitialReview && notification.Item.ReviewReason == RiskReviewReason.NoRiskInformationAvailable)
             {
                 participant.SetRiskDue(DateTime.UtcNow.AddDays(14), RiskDueReason.InitialReview);
             }

--- a/src/Application/Features/Participants/EventHandlers/RiskInformationReviewed.cs
+++ b/src/Application/Features/Participants/EventHandlers/RiskInformationReviewed.cs
@@ -13,7 +13,7 @@ public class RiskInformationReviewed(IUnitOfWork unitOfWork) : INotificationHand
         if (participant is not null)
         {         
             //If risk still not completed class it as initial review and keep review date as 14 days
-            if (participant.EnrolmentStatus == EnrolmentStatus.EnrollingStatus && notification.Item.ReviewReason == RiskReviewReason.NoRiskInformationAvailable)
+            if (participant.RiskDueReason == RiskDueReason.InitialReview && notification.Item.ReviewReason == RiskReviewReason.NoRiskInformationAvailable)
             {
                 participant.SetRiskDue(DateTime.UtcNow.AddDays(14), RiskDueReason.InitialReview);
             }


### PR DESCRIPTION
This pull request updates the logic for determining when to set an initial risk review for a participant. Instead of checking the participant's enrolment status, the code now checks the participant's current risk due reason, making the condition more precise and aligned with risk review workflows.

Logic update for risk review handling:

* Changed the condition in both `RiskInformationCompleted` and `RiskInformationReviewed` event handlers to check `participant.RiskDueReason == RiskDueReason.InitialReview` instead of `participant.EnrolmentStatus == EnrolmentStatus.EnrollingStatus` when determining if a 14-day initial review period should be set. [[1]](diffhunk://#diff-77f6e9f525a0fd24f7ec79bc3e0a6faf87088bec125094bb5c850eff3ebdbc51L16-R16) [[2]](diffhunk://#diff-2828a4a20a5f7958170eb6f0061bb20cc169f26b4737e4b6c7cd55eefe6fa2d1L16-R16)