### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "04:00"
-    target-branch: "develop"
+    target-branch: "main"
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 1


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings, changing the target branch for dependency updates.

* Changed the Dependabot `target-branch` from `develop` to `main` in `.github/dependabot.yml` to ensure dependency updates are opened against the main branch.