### PR TITLE
Ignores AutoMapper and MediatR updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "AutoMapper"
+      - dependency-name: "AutoMapper.*"
+      - dependency-name: "MediatR"
+      - dependency-name: "MediatR.*"
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
Excludes AutoMapper and MediatR from automated dependency updates in Dependabot to manage these dependencies manually.