### PR TITLE
Configure user tracing by removing configureawait calls in the pipelines

### DIFF
--- a/src/Application/Pipeline/AuthorizationBehaviour.cs
+++ b/src/Application/Pipeline/AuthorizationBehaviour.cs
@@ -111,7 +111,7 @@ public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRe
             }
 
             // User is authorized / authorization not required
-            return await next(cancellationToken).ConfigureAwait(false);
+            return await next(cancellationToken);
         }
         finally
         {

--- a/src/Application/Pipeline/CacheInvalidationBehaviour.cs
+++ b/src/Application/Pipeline/CacheInvalidationBehaviour.cs
@@ -25,7 +25,7 @@ public class CacheInvalidationBehaviour<TRequest, TResponse>
     )
     {
         logger.LogTrace("{Name} cache expire with {@Request}", nameof(request), request);
-        var response = await next(cancellationToken).ConfigureAwait(false);
+        var response = await next(cancellationToken);
 
         foreach (var key in request.CacheKeys)
         {

--- a/src/Application/Pipeline/MemoryCacheBehaviour.cs
+++ b/src/Application/Pipeline/MemoryCacheBehaviour.cs
@@ -25,9 +25,8 @@ public class MemoryCacheBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequ
     {
         logger.LogTrace("{Name} is caching with {@Request}", nameof(request), request);
         var response = await cache
-            .GetOrAddAsync(request.CacheKey, async () => await next(cancellationToken), request.Options)
-            .ConfigureAwait(false);
-
+            .GetOrAddAsync(request.CacheKey, async () => await next(cancellationToken), request.Options);
+            
         return response;
     }
 }

--- a/src/Application/Pipeline/SessionValidatingBehaviour.cs
+++ b/src/Application/Pipeline/SessionValidatingBehaviour.cs
@@ -26,7 +26,7 @@ public class SessionValidatingBehaviour<TRequest, TResponse>(ISessionService ses
 
             // session is valid
             sessionService.UpdateActivity(userId);
-            return await next(cancellationToken).ConfigureAwait(false);
+            return await next(cancellationToken);
         }
         finally
         {

--- a/src/Application/Pipeline/UnhandledExceptionBehaviour.cs
+++ b/src/Application/Pipeline/UnhandledExceptionBehaviour.cs
@@ -27,7 +27,7 @@ public class UnhandledExceptionBehaviour<TRequest, TResponse>
     {
         try
         {
-            return await next(cancellationToken).ConfigureAwait(false);
+            return await next(cancellationToken);
         }
         catch (DomainException de)
         {

--- a/src/Infrastructure/Persistence/Interceptors/AuditibleEntityInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditibleEntityInterceptor.cs
@@ -38,8 +38,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
     )
     {
         var resultValueTask = await base.SavedChangesAsync(eventData, result, cancellationToken);
-        await TryUpdateTemporaryPropertiesForAuditTrail(eventData.Context!, cancellationToken)
-            .ConfigureAwait(false);
+        await TryUpdateTemporaryPropertiesForAuditTrail(eventData.Context!, cancellationToken);
         return resultValueTask;
     }
 
@@ -205,7 +204,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
             }
 
             await context.AddRangeAsync(temporaryAuditTrailList, cancellationToken);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await context.SaveChangesAsync(cancellationToken);
             temporaryAuditTrailList.Clear();
         }
     }

--- a/src/Infrastructure/Services/UploadService.cs
+++ b/src/Infrastructure/Services/UploadService.cs
@@ -87,10 +87,9 @@ public class UploadService : IUploadService
             {
                 BucketName = _bucketName,
                 Key = key
-            };            
+            };
 
-            using var response = await _client.GetObjectAsync(getRequest)
-                .ConfigureAwait(false);
+            using var response = await _client.GetObjectAsync(getRequest);
             var stream = new MemoryStream();
             await response.ResponseStream.CopyToAsync(stream);
             stream.Position = 0;

--- a/src/Server.UI/Pages/QA/Activities/QA2.razor
+++ b/src/Server.UI/Pages/QA/Activities/QA2.razor
@@ -177,7 +177,7 @@
 
     protected async Task SubmitToQa()
     {
-        await _form!.Validate().ConfigureAwait(false);
+        await _form!.Validate();
 
         if (_form.IsValid is false)
         {


### PR DESCRIPTION
This fixes an issue where user information is lost in the sentry logs and a random user id is generated.

Fixes #864
