### PR TITLE
QA dashboard landing page

### DIFF
--- a/src/Server.UI/Components/Shared/Layout/SearchDialog.razor
+++ b/src/Server.UI/Components/Shared/Layout/SearchDialog.razor
@@ -99,7 +99,8 @@
             allowed = [RoleNames.QAOfficer, RoleNames.QASupportManager, RoleNames.QAManager, RoleNames.SMT, RoleNames.SystemSupport];
             if (UserProfile.AssignedRoles.Any(r => allowed.Contains(r)))
             {
-                pages.Add("First Pass", "/pages/qa/enrolments/qa1");    
+                pages.Add("First Pass", "/pages/qa/enrolments/qa1");
+                pages.Add("QA", "/pages/dashboard/qadashboard");    
             }
 
             allowed = [RoleNames.QASupportManager, RoleNames.QAManager, RoleNames.SMT, RoleNames.SystemSupport];

--- a/src/Server.UI/Pages/Dashboard/DashboardQA.razor
+++ b/src/Server.UI/Pages/Dashboard/DashboardQA.razor
@@ -1,0 +1,51 @@
+@using Cfo.Cats.Application.SecurityConstants
+
+@page "/pages/dashboard/qadashboard"
+@attribute [Authorize(Policy = SecurityPolicies.Internal)]
+
+
+<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+    <MudText Typo="Typo.h3">
+        QA Dashboard
+    </MudText>
+    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+        This page is still under development and may produce inaccurate results.
+    </MudAlert>
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+
+        <MudDateRangePicker @ref="_picker" DateFormat="dd MMM yyyy" TitleDateFormat="MMMM dd" @bind-DateRange="@_dateRange" MaxDate="DateTime.Today" MinDate="@(new DateTime(2025, 1, 1))" Class="pa-2">
+            <PickerActions>
+                <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
+                <MudButton Color="Color.Primary" OnClick="@(() => _picker.CloseAsync())">OK</MudButton>
+            </PickerActions>
+        </MudDateRangePicker>
+        <MudSwitch @bind-Value="_visualMode"
+                   T="bool"
+                   ThumbIcon="@Icons.Material.Filled.StackedBarChart"
+                   Color="Color.Primary">
+            Visual Mode
+        </MudSwitch>
+    </MudStack>
+</MudStack>
+
+<MudStack>
+        <MudTabs PanelClass="pa-6" ApplyEffectsToContainer="true" Outlined="true">
+            <MudTabPanel Text="Enrolments: First Pass" Class="pa-3">
+                <MudAlert Severity="Severity.Info">
+                    Under development, coming soon...
+                </MudAlert>
+            </MudTabPanel>
+            <MudTabPanel Text="Returns To Providers" Class="pa-3">
+                <MudAlert Severity="Severity.Info">
+                    Under development, coming soon...
+                </MudAlert>
+            </MudTabPanel>
+            <MudTabPanel Text="Advisories to providers" Class="pa-3">
+                <MudAlert Severity="Severity.Info">
+                    Under development, coming soon...
+                </MudAlert>
+            </MudTabPanel>
+                        <MudTabPanel Text="...More reports" Class="pa-3">
+            </MudTabPanel>
+        </MudTabs>
+</MudStack>

--- a/src/Server.UI/Pages/Dashboard/DashboardQA.razor.cs
+++ b/src/Server.UI/Pages/Dashboard/DashboardQA.razor.cs
@@ -1,0 +1,20 @@
+using Cfo.Cats.Application.Common.Security;
+
+namespace Cfo.Cats.Server.UI.Pages.Dashboard;
+
+public partial class DashboardQA
+{
+    private MudDateRangePicker _picker = null!;
+
+    private bool _visualMode = true;
+    public string? SelectedUserId { get; set; }
+    public string? SelectedDisplayName { get; set; }
+    private DateRange _dateRange { get; set; } = new DateRange(new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1), DateTime.Today);
+    
+    [CascadingParameter]
+    public UserProfile CurrentUser { get; set; } = null!;
+    protected override void OnInitialized()
+    {
+
+    }
+}

--- a/src/Server.UI/Services/Navigation/MenuService.cs
+++ b/src/Server.UI/Services/Navigation/MenuService.cs
@@ -34,6 +34,14 @@ public class MenuService : IMenuService
                                 Title = "Support Worker",
                                 Href = "/pages/dashboard/supportworker/",
                                 PageStatus = PageStatus.Wip
+                            },
+
+                            new()
+                            {
+                                Title = "QA",
+                                Href = "/pages/dashboard/qadashboard/",
+                                PageStatus = PageStatus.Wip,
+                                Roles = [RoleNames.SystemSupport, RoleNames.SMT, RoleNames.QAOfficer, RoleNames.QASupportManager, RoleNames.QAManager],
                             }
                         ],
                     },
@@ -297,3 +305,4 @@ public class MenuService : IMenuService
             }
         ];
 }
+


### PR DESCRIPTION
Add QA dashboard landing page to view QA reports with records associated to me(logged in user) within a date range.

Adds QA dashboard landing page which is accessible from menu item: “QA” in Dashboard menu and only visible to CFO internal users i.e. users with SystemSupport, SMT, QAOfficer, QASupportManager, QAManager roles. All reports/components should be based on the selected dates and logged in user.