### PR TITLE
Removes explicit AppHost package reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Ardalis.SmartEnum" Version="8.2.0" />
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.0" />
     <PackageVersion Include="Aspire.Hosting.Kubernetes" Version="13.0.0-preview.1.25560.3" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.0.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.0.0" />

--- a/src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
+++ b/src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.0.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.0.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Aspire.Hosting.AppHost" />
       <PackageReference Include="Aspire.Hosting.Kubernetes" />
       <PackageReference Include="Aspire.Hosting.RabbitMQ" />
       <PackageReference Include="Aspire.Hosting.SqlServer" />


### PR DESCRIPTION
Updates the project to use the Aspire.AppHost.Sdk directly, removing the need for an explicit package reference.

This simplifies the project setup and ensures consistency in dependency management with the latest aspire templates from microsoft.

https://learn.microsoft.com/en-us/dotnet/aspire/get-started/upgrade-to-aspire-13?tabs=bash&pivots=vscode

Needs to go in after #862 