### PR TITLE
Implement develop/main branch workflow strategy (#872)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version (e.g., v1.2.3 or leave empty for auto-generated)'
         required: false
         type: string
+  push:
+    branches:
+      - develop
+      - main
 
 jobs:
   build:
@@ -50,10 +54,24 @@ jobs:
         if [ -n "${{ inputs.version }}" ]; then
           TAG_NAME="${{ inputs.version }}"
         else
-          TAG_NAME="v$(date +'%Y.%m.%d')-build.${{ github.run_number }}"
+          BRANCH_NAME="${{ github.ref_name }}"
+          if [ "$BRANCH_NAME" = "develop" ]; then
+            TAG_NAME="v$(date +'%Y.%m.%d')-dev.${{ github.run_number }}"
+          else
+            TAG_NAME="v$(date +'%Y.%m.%d')-build.${{ github.run_number }}"
+          fi
         fi
         echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
         echo "Generated version: $TAG_NAME"
+
+    - name: Determine if latest release
+      id: is_latest
+      run: |
+        if [ "${{ github.ref_name }}" = "main" ]; then
+          echo "latest=true" >> $GITHUB_OUTPUT
+        else
+          echo "latest=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
@@ -64,6 +82,7 @@ jobs:
           Server.UI.zip
           DatabaseMigrator.zip
         draft: false
-        prerelease: true
+        prerelease: ${{ github.ref_name != 'main' }}
+        make_latest: ${{ steps.is_latest.outputs.latest }}
         generate_release_notes: true
         fail_on_unmatched_files: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,13 @@ name: .NET Core Unit Tests
 
 on:
   pull_request:
+    branches:
+      - develop
+      - main
 
 jobs:
   build:
+    name: .NET Core Unit Tests
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
* feat: implement develop/main branch workflow strategy

- Add branch filters to run-tests workflow for develop and main
- Add automatic release triggers on push to develop and main
- Implement smart versioning: -dev.X for develop, -build.X for main
- Set develop releases as prereleases (not latest)
- Set main releases as stable and latest
- Ensure PRs must pass tests before merging

* give the build a name for branch protections