### PR TITLE
Fix issue with zip paths. 

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,16 +29,10 @@ jobs:
       run: dotnet test ./cats.sln --configuration Release --no-build --no-restore
 
     - name: Publish UI
-      run: dotnet publish ./src/Server.UI/Server.UI.csproj --configuration Release --output ./artifacts/publish/Server.UI --no-restore --no-build
+      run: dotnet publish ./src/Server.UI/Server.UI.csproj --configuration Release --output ./artifacts/Server.UI --no-restore --no-build
 
     - name: Publish Migrations
-      run: dotnet publish ./src/DatabaseMigrator/DatabaseMigrator.csproj --configuration Release --output ./artifacts/publish/DatabaseMigrator --no-restore --no-build
-
-    - name: Create Build Artifacts Archive
-      run: |
-        cd artifacts
-        zip -r ../../Server.UI.zip Server.UI
-        zip -r ../../DatabaseMigrator.zip DatabaseMigrator
+      run: dotnet publish ./src/DatabaseMigrator/DatabaseMigrator.csproj --configuration Release --output ./artifacts/DatabaseMigrator --no-restore --no-build
 
     - name: Generate Version Tag
       id: version
@@ -52,14 +46,18 @@ jobs:
         echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
         echo "Generated tag: $TAG_NAME"
 
+    - name: Create Build Artifacts Archive
+      run: |
+        cd artifacts
+        zip -r ../../${{ steps.version.outputs.tag }}.zip Server.UI DatabaseMigrator
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.version.outputs.tag }}
         name: Release ${{ steps.version.outputs.tag }}
         files: |
-          Server.UI.zip
-          DatabaseMigrator.zip
+          ${{ steps.version.outputs.tag }}.zip
         draft: false
         prerelease: true
         generate_release_notes: true


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/create-release.yml` to simplify the build artifact archiving process and improve release versioning. The main changes are focused on how artifacts are published, zipped, and attached to releases.

**Build artifact archiving and release improvements:**

* The output paths for the `dotnet publish` steps for `Server.UI` and `DatabaseMigrator` have been changed to use `./artifacts/Server.UI` and `./artifacts/DatabaseMigrator`, respectively, making the artifact structure more consistent.
* The separate zipping steps for each artifact have been replaced by a single step that creates one archive named after the generated version tag, containing both `Server.UI` and `DatabaseMigrator`.
* The release step now attaches the single versioned archive (e.g., `v1.2.3.zip`) instead of separate `Server.UI.zip` and `DatabaseMigrator.zip` files, streamlining the release process and making it easier to track releases by version.