### PR TITLE
feature/workflows v3

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,18 +38,17 @@ jobs:
       id: version
       run: |
         DATE_TAG="v$(date +'%Y.%m.%d')-build.${{ github.run_number }}"
-        if [ "${GITHUB_REF##*/}" = "develop" ]; then
-          TAG_NAME="${DATE_TAG}-dev"
+        if [ "${GITHUB_REF##*/}" = "main" ]; then
+          TAG_NAME="${DATE_TAG}"  
         else
-          TAG_NAME="${DATE_TAG}"
+          TAG_NAME="${DATE_TAG}-dev"  
         fi
         echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
         echo "Generated tag: $TAG_NAME"
 
     - name: Create Build Artifacts Archive
       run: |
-        cd artifacts
-        zip -r ../../${{ steps.version.outputs.tag }}.zip Server.UI DatabaseMigrator
+        zip -r ${{ steps.version.outputs.tag }}.zip artifacts/Server.UI artifacts/DatabaseMigrator
 
     - name: Create Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/create-release.yml` to improve how release tags are generated and how build artifacts are archived. The changes ensure that tags are correctly named based on the branch and simplify the artifact archiving process.

Release tag generation update:
* The release tag is now generated as the date-based tag for the `main` branch, and as a date-based tag with a `-dev` suffix for all other branches.

Artifact archiving simplification:
* The build artifact archive step now directly zips the `artifacts/Server.UI` and `artifacts/DatabaseMigrator` directories, removing the need to change directories before zipping.