### PR TITLE
Add test result publishing to GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,4 +27,12 @@ jobs:
       run: dotnet build ./cats.sln --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test ./ --configuration Release --no-build --no-restore
+      run: dotnet test ./ --configuration Release --no-build --no-restore --logger "trx;LogFileName=test-results.trx"
+    
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: '**/test-results.trx'
+        check_name: '.NET Test Results'
+        comment_title: '🧪 Test Results'


### PR DESCRIPTION
This pull request updates the test workflow in `.github/workflows/run-tests.yml` to improve visibility into test results. The most important change is the addition of a step to publish test results using a dedicated GitHub Action, making it easier to track and review test outcomes directly in the pull request.

**Continuous Integration Improvements:**

* The `dotnet test` command now generates a `.trx` test results file for easier reporting and analysis.
* Added a new workflow step that uses the `EnricoMi/publish-unit-test-result-action@v2` action to publish test results to the pull request, including custom naming and commenting for clarity.