### PR TITLE
Clean up launch settings, removing the production and iis launch settings

### DIFF
--- a/src/Server.UI/Properties/launchSettings.json
+++ b/src/Server.UI/Properties/launchSettings.json
@@ -1,14 +1,15 @@
 ﻿{
   "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:61410",
-      "sslPort": 44336
-    }
-  },
   "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5033",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -16,15 +17,6 @@
       "applicationUrl": "https://localhost:7062;http://localhost:5033",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "production": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7062;http://localhost:5033",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Production"
       }
     }
   }


### PR DESCRIPTION
This pull request updates the launch settings for the UI server configuration to simplify and clarify the development environment profiles.

Launch profile changes:

* Removed the `iisSettings` section, which disables IIS Express-specific configuration and authentication settings.
* Removed the `production` section.