### PR TITLE
Fixes typo: 'Risk to Childen' → 'Risk to Children'...

### DIFF
--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -143,7 +143,7 @@ public class RiskDto
 
     public record class RiskDetail
     {
-        [Description("Risk to Childen")]
+        [Description("Risk to Children")]
         public RiskLevel? RiskToChildren { get; set; }
         [Description("Risk to Public")]
         public RiskLevel? RiskToPublic { get; set; }


### PR DESCRIPTION
Which appears on the Risk Overview section of Risk