### PR TITLE
Adds migration behaviour configuration

### DIFF
--- a/src/Aspire/Cats.AppHost/Program.cs
+++ b/src/Aspire/Cats.AppHost/Program.cs
@@ -31,8 +31,16 @@ var cats = builder.AddProject<Projects.Server_UI>("cats", configure: project =>
         project.ExcludeLaunchProfile = publishing;
     })
     .WithReference(catsDb)
-    .WithReference(rabbit)
-    .WaitFor(migrator);
+    .WithReference(rabbit);
+
+if(builder.Configuration["MigrationBehaviour"] is "WaitForCompletion")
+{
+    cats.WaitForCompletion(migrator);
+}
+else
+{
+    cats.WaitFor(migrator);
+}
 
 if (publishing)
 {

--- a/src/Aspire/Cats.AppHost/appsettings.Development.json
+++ b/src/Aspire/Cats.AppHost/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "MigrationBehaviour": "WaitForCompletion"
 }


### PR DESCRIPTION
Configures migration behaviour using the "MigrationBehaviour" setting.

Allows specifying whether to wait for migration completion before starting the App Host. Any value other than "WaitForCompletion" will switch to "WaitFor".

This will allow users to override the setting (using user secrets) should they wish to code in VS Code. 

This hack is required until the bug defined [here](https://github.com/dotnet/aspire/issues/12965) is fixed