### PR TITLE
Disables unavailable menu items

### DIFF
--- a/src/Server.UI/Components/Shared/Layout/NavigationMenu.razor
+++ b/src/Server.UI/Components/Shared/Layout/NavigationMenu.razor
@@ -41,7 +41,7 @@
                             <MudNavGroup Icon="@sectionItem.Icon" Title="@L[sectionItem.Title]" Expanded="Expanded(sectionItem)">
                                 @foreach (var menuItem in sectionItem.MenuItems.Where(x => x.Roles == null || x.Roles.Any(x => Roles.Contains(x))))
                                 {
-                                    <MudNavLink Href="@(menuItem.Href)" Target="@(menuItem.Target)" Match="NavLinkMatch.All">
+                                    <MudNavLink Href="@(menuItem.Href)" Target="@(menuItem.Target)" Match="NavLinkMatch.All" Disabled="@(menuItem.PageStatus == PageStatus.ComingSoon)" >
                                         <div class="d-flex">
                                             @(L[menuItem.Title])
                                             @if (menuItem.PageStatus != PageStatus.Completed)
@@ -58,7 +58,7 @@
                         }
                         else
                         {
-                            <MudNavLink Href="@(sectionItem.Href)" Icon="@(sectionItem.Icon)" Target="@(sectionItem.Target)" Match="NavLinkMatch.All">
+                            <MudNavLink Href="@(sectionItem.Href)" Icon="@(sectionItem.Icon)" Target="@(sectionItem.Target)" Match="NavLinkMatch.All" Disabled="@(sectionItem.PageStatus == PageStatus.ComingSoon)">
                                 <div class="d-flex">
                                     @(L[sectionItem.Title])
                                     @if (sectionItem.PageStatus != PageStatus.Completed)

--- a/src/Server.UI/Pages/Labels/Index.razor
+++ b/src/Server.UI/Pages/Labels/Index.razor
@@ -3,7 +3,13 @@
 
 @attribute [Authorize(Policy = SecurityPolicies.UserHasAdditionalRoles)]
 
+
 <PageTitle>@Title</PageTitle>
+
+<MudAlert Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Work" Severity="Severity.Warning" >
+    This page is under development and is subject to change.
+</MudAlert>
+
 
 <LabelsTable  />
     

--- a/src/Server.UI/Services/Navigation/MenuService.cs
+++ b/src/Server.UI/Services/Navigation/MenuService.cs
@@ -32,7 +32,7 @@ public class MenuService : IMenuService
                             {
                                 Title = "Support Worker",
                                 Href = "/pages/dashboard/supportworker/",
-                                PageStatus = PageStatus.Completed
+                                PageStatus = PageStatus.Wip
                             },
                             
                             new()
@@ -42,12 +42,12 @@ public class MenuService : IMenuService
                                 PageStatus = PageStatus.Wip,
                                 Roles = RoleNames.AllExtraPermissions,
                             },
-                            
+
                             new()
                             {
                                 Title = "QA",
                                 Href = "/pages/dashboard/qa/",
-                                PageStatus = PageStatus.Wip,
+                                PageStatus = PageStatus.ComingSoon,
                                 Roles = [RoleNames.SystemSupport, RoleNames.SMT, RoleNames.QAOfficer, RoleNames.QASupportManager, RoleNames.QAManager],
                             },
                             
@@ -55,10 +55,9 @@ public class MenuService : IMenuService
                             {
                                 Title = "QA - Team",
                                 Href = "/pages/dashboard/qateam/",
-                                PageStatus = PageStatus.Wip,
+                                PageStatus = PageStatus.ComingSoon,
                                 Roles = [RoleNames.SystemSupport, RoleNames.SMT, RoleNames.QASupportManager, RoleNames.QAManager],
                             },
-
                         ],
                     },
 
@@ -323,7 +322,7 @@ public class MenuService : IMenuService
                             {
                                 Title = "Labels",
                                 Href = "/pages/labels",
-                                PageStatus = PageStatus.Wip,
+                                PageStatus = PageStatus.ComingSoon,
                             }
                         ]
                     }


### PR DESCRIPTION
Improves the user experience by visually disabling menu items that are marked as "Coming Soon".

Also, changes page status of Support Worker and Labels to "Coming Soon" for the QA and Team section.

Adds a warning to the Label page to indicate its under development.
