### PR TITLE
Add additional reasons for pathway plan review

### DIFF
--- a/src/Domain/Common/Enums/PathwayPlanReviewReason.cs
+++ b/src/Domain/Common/Enums/PathwayPlanReviewReason.cs
@@ -11,6 +11,8 @@ public sealed class PathwayPlanReviewReason : SmartEnum<PathwayPlanReviewReason>
     public static readonly PathwayPlanReviewReason ChangeToCircumstances = new("Change Of Personal Circumstances", 3);
     public static readonly PathwayPlanReviewReason EndOfWingPhaseDelivery = new("End Of Wing Phase Delivery",4);
     public static readonly PathwayPlanReviewReason NinetyDayReview = new("90 Day Review", 5);
+    public static readonly PathwayPlanReviewReason InitialReview = new ("Initial Review", 6);
+    public static readonly PathwayPlanReviewReason Reassignment = new("Reassignment", 7);
     
     private PathwayPlanReviewReason(string name, int value) 
         : base(name, value) 
@@ -26,6 +28,8 @@ public sealed class PathwayPlanReviewReason : SmartEnum<PathwayPlanReviewReason>
         AssessmentPerformed,
         ChangeToCircumstances,
         EndOfWingPhaseDelivery,
-        ParticipantChangedLocation
+        InitialReview,
+        ParticipantChangedLocation,
+        Reassignment
     };
 }


### PR DESCRIPTION
This pull request updates the `PathwayPlanReviewReason` enum to include additional review reason types. 

**Enhancements to review reason enum:**

* Added new enum values: `InitialReview` and `Reassignment` to the `PathwayPlanReviewReason` class, providing more options for specifying the reason for a pathway plan review.
* Updated the list of all possible values in the `List` property to include the new `InitialReview` and `Reassignment` options, ensuring they are recognized throughout the application.