### PR TITLE
Fix rag validation on submission

### DIFF
--- a/src/Application/Features/QualityAssurance/Commands/SubmitToProviderQa.cs
+++ b/src/Application/Features/QualityAssurance/Commands/SubmitToProviderQa.cs
@@ -153,7 +153,7 @@ public static class SubmitToProviderQa
             }
             
             // ok if we get here, we have at LEAST 1 red. So we just need an amber AND a justification
-            if (latest.Scores.Count(s => s.Score is < 25) >= 2 
+            if (latest.Scores.Count(s => s.Score is <= 25) >= 2 
                 && string.IsNullOrEmpty(command.JustificationReason) == false)
             {
                 return true;


### PR DESCRIPTION
The rag bar amber and the validation amber where using two different calculations.

This commit addresses that by making them in sync.

