### PR TITLE
Adds document version to consent information

### DIFF
--- a/src/Application/Common/Versioning/Documents.cs
+++ b/src/Application/Common/Versioning/Documents.cs
@@ -8,7 +8,8 @@ public static class Documents
 
         public static IReadOnlyList<string> Versions { get; set; } =
         [
-            "1.0"
+            "1.1",
+            "1.0",
         ];
     }
 

--- a/src/Application/Features/Documents/DTOs/DocumentDto.cs
+++ b/src/Application/Features/Documents/DTOs/DocumentDto.cs
@@ -11,6 +11,8 @@ public class DocumentDto
     [Description("File Name")] public string? Title { get; set; }
 
     [Description("Description")] public string? Description { get; set; }
+    
+    [Description("Version")] public string? Version { get; set; }
 
     [Description("Is Public")] public bool IsPublic { get; set; }
 

--- a/src/Application/Features/Participants/DTOs/ConsentDto.cs
+++ b/src/Application/Features/Participants/DTOs/ConsentDto.cs
@@ -11,6 +11,8 @@ public class ConsentDto
     public DateTime Created { get; set; }
     
     public string? FileName { get; set; }
+    
+    public string? Version { get; set; }
 
     private class Mapping : Profile
     {
@@ -20,7 +22,8 @@ public class ConsentDto
                 .ForMember(c => c.DocumentId, options => options.MapFrom(source => source.Document!.Id))
                 .ForMember(c => c.FileName, options => options.MapFrom(source => source.Document!.Title))
                 .ForMember(c => c.ConsentDate, options => options.MapFrom(source => source.Lifetime.StartDate))
-                .ForMember(c => c.Created, options => options.MapFrom(source => source.Created!));
+                .ForMember(c => c.Created, options => options.MapFrom(source => source.Created!))
+                .ForMember(c => c.Version, options => options.MapFrom(source => source.Document!.Version));
         }
     }
 }

--- a/src/Server.UI/Pages/Participants/Components/CaseDocuments.razor
+++ b/src/Server.UI/Pages/Participants/Components/CaseDocuments.razor
@@ -35,6 +35,7 @@
             </TemplateColumn>
             <PropertyColumn Property="x => x.Title" Title="@L[_currentDto.GetMemberDescription(x => x.Title)]" />
             <PropertyColumn Property="x => x.Description" Title="@L[_currentDto.GetMemberDescription(x => x.Description)]" />
+            <PropertyColumn Property="x => x.Version" Title="@L[_currentDto.GetMemberDescription(x => x.Version)]" />
             <PropertyColumn Property="x => x.CreatedBy" Title="@L[_currentDto.GetMemberDescription(x => x.CreatedBy)]">
                 <CellTemplate>
                     <div>

--- a/src/Server.UI/Pages/QA/Enrolments/Components/ConsentTabPanel.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/Components/ConsentTabPanel.razor
@@ -15,6 +15,7 @@
             <HeaderContent>
                 <MudTh>View</MudTh>
                 <MudTh>File Name</MudTh>
+                <MudTh>Version</MudTh>
                 <MudTh>Consent Date</MudTh>
                 <MudTh>Upload Date</MudTh>
                 <MudTh></MudTh>
@@ -24,6 +25,7 @@
                     <MudRadio Value="@context.DocumentId!.Value" Color="Color.Primary"/>
                 </MudTd>
                 <MudTd DataLabel="File Name">@context.FileName</MudTd>
+                <MudTd DataLabel="Version">@context.Version</MudTd>
                 <MudTd DataLabel="Consent">@context.ConsentDate.ToShortDateString()</MudTd>
                 <MudTd DataLabel="Uploaded By">@context.Created</MudTd>
                 <MudTd>


### PR DESCRIPTION
Adds the document version to the consent information displayed on the UI.
This allows users to easily identify the specific version of a document
they are adding.

The document versions are now displayed in the case documents and QA enrolments sections.

CFODEV-1535
