### PR TITLE
Add icon that allows you to view the users password

### DIFF
--- a/src/Server.UI/Pages/Identity/Authentication/Login.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Login.razor
@@ -79,12 +79,19 @@
                     <div class="mud-input-control-input-container">
                         <!--!--><!--!-->
                         <div class="mud-input mud-input-outlined mud-shrink">
-                            <InputText type="password" @bind-Value="Input.Password" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="off" aria-required="true" placeholder="password" />
+							<InputText type="password" @bind-Value="Input.Password" id="passwordInput" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="off" aria-required="true" placeholder="password" />
                             <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
                             <!--!-->
-                            <div class="mud-input-outlined-border"></div>
+							<div class="mud-input-outlined-border"></div>						
+							<MudIcon Icon="@Icons.Material.Filled.Visibility" 
+								Color="Color.Inherit"
+								Class="ms-2 cursor-pointer mr-2"
+								id="passwordToggleIcon"
+								onmouseover="document.getElementById('passwordInput').type = 'text';"
+								onmouseout="document.getElementById('passwordInput').type = 'password';" />
+							<!--!-->
                         </div>
-                        <!--!-->
+
                     </div>
                     <div class="mud-input-helper-text mud-input-error">
                         <div class="d-flex">


### PR DESCRIPTION
This pull request adds a user experience improvement to the login page by introducing a password visibility toggle. The main change is the addition of an icon next to the password input field that allows users to temporarily reveal their password when hovering over the icon.

**Login page enhancement:**

* Added an icon with a visibility icon next to the password input so the user can view the password they have typed