### PR TITLE
Enables QA to set sticky location with justification

### DIFF
--- a/src/Application/Features/Candidates/Commands/SetCandidateStickyLocation.cs
+++ b/src/Application/Features/Candidates/Commands/SetCandidateStickyLocation.cs
@@ -1,16 +1,47 @@
 ﻿using Cfo.Cats.Application.Common.Security;
 using Cfo.Cats.Application.Common.Validators;
 using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.ValueObjects;
 
 namespace Cfo.Cats.Application.Features.Candidates.Commands;
 
 public static class SetCandidateStickyLocation
 {
-    [RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+    [RequestAuthorize(Policy = SecurityPolicies.Qa1)]
     public class Command : IRequest<Result>
     {
         public string? ParticipantId { get; set; }
         public string? Region { get; set; }
+        
+        [Description("Justification")]
+        public string? Justification { get;set; }
+        
+        [Description("Call Reference")]
+        public string? CallReference { get; set; }
+    }
+
+    public class Handler(ICandidateService candidateService, IUnitOfWork unitOfWork) : IRequestHandler<Command, Result>
+    {
+        public async Task<Result> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var participant = unitOfWork.DbContext.Participants.FirstOrDefault(x => x.Id == request.ParticipantId!);
+            
+            if(participant is not null)
+            {
+                var callResult = await candidateService.SetStickyLocation(request.ParticipantId!, request.Region!);
+                if(callResult is { Succeeded: true, Data: true })
+                {
+                    participant.AddNote(new Note()
+                    {
+                        Message = request.Justification!,
+                        CallReference = request.CallReference!
+                    });
+                    return Result.Success();
+                }
+                return callResult;
+            }
+            return Result.Failure();
+        }
     }
 
     public class Validator : AbstractValidator<Command>
@@ -34,6 +65,16 @@ public static class SetCandidateStickyLocation
                 .MinimumLength(4)
                 .Matches(ValidationConstants.AlphaNumeric)
                 .WithMessage(string.Format(ValidationConstants.AlphaNumericMessage, "Region"));
+
+            RuleFor(x => x.Justification)
+                .NotEmpty()
+                .Matches(ValidationConstants.Notes)
+                .WithMessage(string.Format(ValidationConstants.NotesMessage, "Justification"));
+            
+            RuleFor(x => x.CallReference)
+                .NotEmpty()
+                .Matches(ValidationConstants.Numbers)
+                .WithMessage(string.Format(ValidationConstants.NumbersMessage, "Call Reference"));
 
             RuleSet(ValidationConstants.RuleSet.MediatR, () =>
             {

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
@@ -50,6 +50,14 @@
                                 </MudText>
                                 <MudText Typo="Typo.body2">@note.CreatedByEmail</MudText>
                             </CardHeaderContent>
+                            <CardHeaderActions>
+                                @if (note.CallReference is not null)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary">
+                                        Call Reference @note.CallReference
+                                    </MudChip>
+                                }
+                            </CardHeaderActions>
                         </MudCardHeader>
                         <MudCardContent>
                             <MudText Typo="Typo.body1">
@@ -57,7 +65,7 @@
                                     @note.Message
                                 </div>
                             </MudText>
-
+                           
                         </MudCardContent>
                         <MudCardActions>
                             <MudTooltip Text="@note.Created.ToLocalTime().ToString("ddd, dd MMM yyyy 'at' HH:mm")">

--- a/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
+++ b/src/Server.UI/Pages/Participants/Components/ParticipantActionMenu.razor
@@ -72,7 +72,7 @@
     protected override async Task OnInitializedAsync()
     {
         var state = await AuthState;
-        _canForceUpdate = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.SeniorInternal)).Succeeded;
+        _canForceUpdate = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.Qa1)).Succeeded;
     }
 
     protected async Task Archive()

--- a/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor
+++ b/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor
@@ -1,7 +1,6 @@
 ﻿@using Cfo.Cats.Application.Features.Candidates.Commands
 
-
-@inject ICandidateService CandidateService
+@inherits OwningComponentBase<IMediator>
 
 @if (Model is not null)
 {
@@ -23,6 +22,21 @@
                                 <MudSelectItem T="string" Value="@("CAT9")">South East</MudSelectItem>
                             </MudSelect>
                         </MudItem>
+                        <MudItem xs="12">
+                            <MudTextField @bind-Value="Model.CallReference"
+                                          Label="@Model.GetMemberDescription(x => x.CallReference)"
+                                          For="@(() => Model.CallReference)"
+                                          Required="true">
+                                
+                            </MudTextField>
+                        </MudItem>
+                        <MudItem xs="12">
+                             <MudTextField @bind-Value="Model.Justification"
+                                Label="@Model.GetMemberDescription(x => x.Justification)"
+                                For="@(() => Model.Justification)"
+                                Lines="5" 
+                                Required="true"/>
+                        </MudItem>
                     </MudGrid>
                 </MudForm>
             </MudPaper>
@@ -34,64 +48,3 @@
     </MudDialog>
 }
 
-@code {
-
-    private SetCandidateStickyLocation.Command? Model { get; set; }
-
-    private MudForm? _form;
-    private bool _saving;
-
-
-    [CascadingParameter]
-    private IMudDialogInstance MudDialog { get; set; } = default!;
-
-
-    [EditorRequired] [Parameter] public string ParticipantId { get; set; } = default!;
-
-    protected override void OnInitialized()
-    {
-        Model = new SetCandidateStickyLocation.Command()
-        {
-            ParticipantId = ParticipantId
-        };
-    }
-
-    private async Task Submit()
-    {
-        try
-        {
-            _saving = true;
-
-            await _form!.Validate();
-
-            if (_form!.IsValid == false)
-            {                
-                Snackbar.Add("Failed to set sticky location", Severity.Error);
-                return;
-            }
-
-            var result = await CandidateService.SetStickyLocation(Model!.ParticipantId!, Model!.Region!); //await GetNewMediator().Send(Model!);
-            if (result)
-            {
-                MudDialog.Close(DialogResult.Ok(true));
-                Snackbar.Add(ConstantString.SaveSuccess, Severity.Info);
-            }
-            else
-            {
-                Snackbar.Add("Failed to set sticky location", Severity.Error);
-            }
-        }
-        finally
-        {
-            _saving = false;
-        }
-    }
-
-    private void Cancel()
-    { 
-        MudDialog.Cancel();
-    }
-
-    
-
-}

--- a/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor.cs
+++ b/src/Server.UI/Pages/Participants/Components/SetStickyLocationDialog.razor.cs
@@ -1,0 +1,62 @@
+using Cfo.Cats.Application.Features.Candidates.Commands;
+using Cfo.Cats.Infrastructure.Constants;
+
+namespace Cfo.Cats.Server.UI.Pages.Participants.Components;
+
+public partial class SetStickyLocationDialog
+{
+
+    private SetCandidateStickyLocation.Command? Model { get; set; }
+
+    private MudForm? _form;
+    private bool _saving;
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [EditorRequired][Parameter] public string ParticipantId { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        Model = new SetCandidateStickyLocation.Command()
+        {
+            ParticipantId = ParticipantId
+        };
+    }
+
+    private async Task Submit()
+    {
+        try
+        {
+            _saving = true;
+
+            await _form!.Validate();
+
+            if (_form!.IsValid == false)
+            {
+                Snackbar.Add("Failed to set sticky location", Severity.Error);
+                return;
+            }
+
+            var result = await Service.Send(Model!); 
+            if (result.Succeeded)
+            {
+                MudDialog.Close(DialogResult.Ok(true));
+                Snackbar.Add(ConstantString.SaveSuccess, Severity.Info);
+            }
+            else
+            {
+                Snackbar.Add("Failed to set sticky location", Severity.Error);
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+}


### PR DESCRIPTION
Allows QA officers to set sticky locations for candidates,  requiring justification and call reference for audit purposes. Adds a dialog for setting the sticky location with input fields for justification and call reference, and displays the call reference in case notes.

Updates authorization policies to allow QA access.

Related to CFODEV-1532