### PR TITLE
CFODEV-1563:  Remove the blanks from PRI Code and refactored code 

### DIFF
--- a/src/Server.UI/Pages/PRIs/PRI.razor
+++ b/src/Server.UI/Pages/PRIs/PRI.razor
@@ -69,7 +69,7 @@
                                     InputMode="InputMode.numeric"
                                     Disabled="_model.Code.SelfAssign && _model.Code.IsSelfAssignmentAllowed"
                                     Class="mb-2" />
-
+                     
                                     @if(_model.Code.IsSelfAssignmentAllowed)
                                     {
                                         <MudCheckBox @bind-Value="_model.Code.SelfAssign"
@@ -208,7 +208,7 @@
 
         _model.Release.CustodyLocation = CurrentLocation;
     }
-
+    
     private async Task LocationChanged()
     {
         if(_model is { Release.ExpectedRegion: not null} )


### PR DESCRIPTION
This pull request refactors the AddPRI command and related UI to improve naming consistency, validation logic, and code clarity. The changes affect both the backend logic in `AddPRI.cs` and the frontend form in `PRI.razor`. The most important changes are grouped below.

### Backend Logic and Validation Improvements

* Renamed and standardized private field names in the `Validator` class to use underscore prefixes for clarity and consistency (e.g., `unitOfWork` → `_unitOfWork`). [[1]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL57-R59) [[2]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL69-R87) [[3]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL93-R189)
* Updated the `PriCodeDto` class: replaced the `Value` property with a public field `PriCode` and made `ParticipantId` an init-only property. Adjusted all usages and validation logic to reference `PriCode` instead of `Value`. [[1]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL16-R18) [[2]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL35-R38) [[3]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL93-R189)
* Improved validation logic in `PriCodeDto.Validator` to use `PriCode` consistently, and restructured rules to better handle self-assignment and code validation scenarios.
* Updated method and rule names for clarity and C# naming conventions (e.g., `NotAlreadyHavePRI` → `NotAlreadyHavePri`). [[1]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL69-R87) [[2]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL93-R189)
* Refactored LINQ queries and property accesses to use updated field/property names and the new validation logic throughout the handler and validator. [[1]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL35-R38) [[2]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL93-R189)

### Frontend/UI Consistency

* Refactored the `PRI.razor` page to use underscore-prefixed private fields (e.g., `model` → `_model`, `stepper` → `_stepper`) for consistency with backend changes.
* Updated all form bindings and component references to use the new field names and the `PriCode` property, ensuring alignment with backend DTO changes. [[1]](diffhunk://#diff-7976c5e13700ba2dc4e09c0db0cb1fe26818b9c8d3f3ede8187a3cefc5468da0L13-R41) [[2]](diffhunk://#diff-7976c5e13700ba2dc4e09c0db0cb1fe26818b9c8d3f3ede8187a3cefc5468da0L51-R54) [[3]](diffhunk://#diff-7976c5e13700ba2dc4e09c0db0cb1fe26818b9c8d3f3ede8187a3cefc5468da0L64-R104) [[4]](diffhunk://#diff-7976c5e13700ba2dc4e09c0db0cb1fe26818b9c8d3f3ede8187a3cefc5468da0L115-R124)

### AutoMapper Profile Refactoring

* Simplified AutoMapper profile constructors for `PriReleaseDto` and `PriMeetingDto` using expression-bodied members. [[1]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL213-L222) [[2]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL276-R284) [[3]](diffhunk://#diff-c7a1747d44c6440a637c0abfba36659d192bd2ae4b7841296a605d945ad5c6edL290)