### PR TITLE
CFODEV-1418:  Fix date range

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetArchivedCasesByContractAndReason.cs
+++ b/src/Application/Features/Dashboard/Queries/GetArchivedCasesByContractAndReason.cs
@@ -33,9 +33,10 @@ public static class GetArchivedCasesByContractAndReason
                 join u in context.Users on ac.CreatedBy equals u.Id into userJoin
                 from u in userJoin.DefaultIfEmpty()
 
-                where ac.From < request.EndDate.AddDays(1).Date
-                      && (ac.To == null || ac.To >= request.StartDate)
+                where ac.From >= request.StartDate.Date
+                      && ac.From < request.EndDate.AddDays(1).Date
                       && (c == null || c.Tenant!.Id.StartsWith(request.CurrentUser.TenantId!))
+
                 select new { ac, c,u };
 
             if (!string.IsNullOrWhiteSpace(request.TenantId))


### PR DESCRIPTION
This pull request updates the filtering logic in the `GetArchivedCasesByContractAndReason` query to improve the accuracy of date-based filtering for archived cases. The main change is tightening the date range conditions to ensure only cases starting within the specified range are included.

**Query filtering improvements:**

* Updated the `where` clause in `GetArchivedCasesByContractAndReason` to require `ac.From` to be greater than or equal to `request.StartDate.Date`, ensuring only cases starting within the desired range are selected.
* Removed the previous check on `ac.To` and replaced it with a stricter check on `ac.From`, which improves the precision of the date filter.