### PR TITLE
CFODEV-1150:  Only use First and last name, not fullname.  

### DIFF
--- a/src/Server.UI/Pages/QA/Activities/Components/ActivityQaDetails.razor
+++ b/src/Server.UI/Pages/QA/Activities/Components/ActivityQaDetails.razor
@@ -1,7 +1,4 @@
-﻿@using Cfo.Cats.Application.Features.Activities.DTOs
-@using Cfo.Cats.Application.Features.Participants.Queries
-@using Cfo.Cats.Domain.Common.Enums
-@using Cfo.Cats.Server.UI.Pages.Activities.Components
+﻿@using Cfo.Cats.Domain.Common.Enums
 
 @inherits CatsComponentBase
 
@@ -24,7 +21,7 @@
    
     <MudStack Row="true" StretchItems="StretchItems.Start" Breakpoint="Breakpoint.Md">
         <MudText Typo="Typo.body1"><strong>Participant</strong></MudText>
-        <MudText Typo="Typo.body1">@Activity.Participant!.FullName</MudText>
+        <MudText Typo="Typo.body1">@Activity.Participant!.FirstName @Activity.Participant!.LastName</MudText>
     </MudStack>
     
     <MudDivider />
@@ -44,7 +41,7 @@
         <MudText Typo="Typo.body1">@Activity.Location!.Name</MudText>
     </MudStack>
 
-    @if (hasParticpantBeenAtThisLocationOnThisDate == false)
+    @if (_hasParticipantBeenAtThisLocationOnThisDate == false)
     {
         <MudStack Row="true" StretchItems="StretchItems.Start" Breakpoint="Breakpoint.Md">
             <MudAlert Severity="Severity.Warning">
@@ -192,26 +189,3 @@
         </MudStack>
     }
 </MudStack>
-    
-@code{
-    [Parameter, EditorRequired]
-    public ActivityQaDetailsDto Activity { get; set; } = default!;
-
-    bool hasParticpantBeenAtThisLocationOnThisDate;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await CheckParticipantBeenAtThisLocationOnDate();
-        await base.OnInitializedAsync();
-    }
-
-    private async Task CheckParticipantBeenAtThisLocationOnDate()
-    {
-        hasParticpantBeenAtThisLocationOnThisDate = await GetNewMediator().Send(new GetParticipantWasAtThisLocationCheck.Query()
-        {
-            ParticipantId = Activity.ParticipantId,
-            LocationId = Activity.Location!.Id,
-            DateAtLocation = Activity.CommencedOn
-        });
-    }
-}

--- a/src/Server.UI/Pages/QA/Activities/Components/ActivityQaDetails.razor.cs
+++ b/src/Server.UI/Pages/QA/Activities/Components/ActivityQaDetails.razor.cs
@@ -1,0 +1,26 @@
+using Cfo.Cats.Application.Features.Activities.DTOs;
+using Cfo.Cats.Application.Features.Participants.Queries;
+
+namespace Cfo.Cats.Server.UI.Pages.QA.Activities.Components;
+
+public partial class ActivityQaDetails
+{
+    [Parameter, EditorRequired] public ActivityQaDetailsDto Activity { get; set; } = null!;
+
+    private bool _hasParticipantBeenAtThisLocationOnThisDate;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CheckParticipantBeenAtThisLocationOnDate();
+        await base.OnInitializedAsync();
+    }
+
+    private async Task CheckParticipantBeenAtThisLocationOnDate() =>
+        _hasParticipantBeenAtThisLocationOnThisDate = await GetNewMediator().Send(
+            new GetParticipantWasAtThisLocationCheck.Query()
+            {
+                ParticipantId = Activity.ParticipantId,
+                LocationId = Activity.Location!.Id,
+                DateAtLocation = Activity.CommencedOn
+            });
+}


### PR DESCRIPTION
This pull request refactors the `ActivityQaDetails` component by moving its code-behind logic from the `.razor` file to a new `.razor.cs` partial class, improving code organization and maintainability. Additionally, it updates how participant names are displayed and corrects a variable naming inconsistency.

**Component refactoring and code organization:**

* Moved all code-behind logic (parameters, lifecycle methods, and helper methods) from `ActivityQaDetails.razor` to a new `ActivityQaDetails.razor.cs` partial class, resulting in a cleaner separation of markup and logic. [[1]](diffhunk://#diff-aabb8880ddd26c7f5fc90afb8c1777dd313599a972c8b36666d8afbd93952f8dL195-L217) [[2]](diffhunk://#diff-04556e25fbf66e02df3ff4b19434ae924e5aa1d5af82a994c5d499e7a889ce94R1-R26)

**UI improvements:**

* Updated participant name display to show `FirstName` and `LastName` separately instead of using `FullName`, providing more granular control over the output.

**Code consistency:**

* Renamed the variable `hasParticpantBeenAtThisLocationOnThisDate` to `_hasParticipantBeenAtThisLocationOnThisDate` throughout the component for clarity and consistency with C# naming conventions. [[1]](diffhunk://#diff-aabb8880ddd26c7f5fc90afb8c1777dd313599a972c8b36666d8afbd93952f8dL47-R44) [[2]](diffhunk://#diff-04556e25fbf66e02df3ff4b19434ae924e5aa1d5af82a994c5d499e7a889ce94R1-R26)

**Usings cleanup:**

* Removed unused `using` statements from the `.razor` file, as these are now handled in the `.razor.cs` file.