### PR TITLE
CFODEV-1581:  Update PRI Panel to match other components on the Participant Summary Page

### DIFF
--- a/src/Server.UI/Pages/Participants/Components/Summary/PRISummary.razor
+++ b/src/Server.UI/Pages/Participants/Components/Summary/PRISummary.razor
@@ -7,103 +7,68 @@
             <MudText Typo="Typo.h6">Latest Pre-Release Inventory (PRI)</MudText>
         </CardHeaderContent>
     </MudCardHeader>
-    <MudCardContent Class="d-flex justify-space-between align-center">
-
+    <MudCardContent>
         @if (_latestPri is null)
         {
             <MudText Typo="Typo.body2">@_noPriInfo</MudText>
         }
         else
         {
-            <div>
-                <dl class="description-list">
-                    <div class="description-pair">
-                        <dt>
-                            <MudText Typo="Typo.subtitle2">Date Created</MudText>
-                        </dt>
-                        <dd>
-                            <MudText Typo="Typo.body2">@_latestPri.Created.ToString("dd/MM/yyyy")</MudText>
-                        </dd>
-                    </div>
+            <MudStack Row="true" StretchItems="StretchItems.Start" Class="mb-2">
+                <MudText><strong>Date Created</strong></MudText>
+                <MudText>@_latestPri.Created.ToString("dd/MM/yyyy")</MudText>
+            </MudStack>
 
+            <MudStack Row="true" StretchItems="StretchItems.Start" Class="mb-2">
+                <MudText><strong>Actual Release Date</strong></MudText>
 
-                    <div class="description-pair">
-                        <dt>
-                            <MudText Typo="Typo.subtitle2">Actual Release Date</MudText>
-                        </dt>
-                        <dd>
-                            @if (_latestPri.ActualReleaseDate != null)
-                            {
-                                <MudText Typo="Typo.body2">@_latestPri.ActualReleaseDate?.ToString("dd/MM/yyyy")</MudText>
-                            }
-                            else
-                            {
-                                <MudText Typo="Typo.body2">None</MudText>
-                            }
-                        </dd>
-                    </div>
+                @if (_latestPri.ActualReleaseDate != null)
+                {
+                    <MudText>@_latestPri.ActualReleaseDate?.ToString("dd/MM/yyyy")</MudText>
+                }
+                else
+                {
+                    <MudText>None</MudText>
+                }
+            </MudStack>
 
-                    @if (_latestPri.Status == PriStatus.Completed || _latestPri.Status == PriStatus.Abandoned)
-                    {
-                        <div class="description-pair">
-                            <dt>
-                                <MudText Typo="Typo.subtitle2">Date @_latestPri.Status.Name</MudText>
-                            </dt>
-                            <dd>
-                                <MudText Typo="Typo.body2">@_latestPri.CompletedOn?.ToString("dd/MM/yyyy")</MudText>
-                            </dd>
-                        </div>
+            @if (_latestPri.Status == PriStatus.Completed || _latestPri.Status == PriStatus.Abandoned)
+            {
+                <MudStack Row="true" StretchItems="StretchItems.Start" Class="mb-2">
+                    <MudText><strong>Date @_latestPri.Status.Name</strong></MudText>
+                    <MudText Typo="Typo.body2">@_latestPri.CompletedOn?.ToString("dd/MM/yyyy")</MudText>
+                </MudStack>
 
-                        <div class="description-pair">
-                            <dt>
-                                <MudText Typo="Typo.subtitle2">@_latestPri.Status.Name By</MudText>
-                            </dt>
-                            <dd>
-                                <MudText Typo="Typo.body2">@UserService.DataSource.First(u => u.Id == _latestPri.CompletedBy).DisplayName </MudText>
-                            </dd>
-                        </div>
+                if (_latestPri.Status == PriStatus.Abandoned)
+                {
+                    <MudStack Row="true" StretchItems="StretchItems.Start" Class="mb-2">
+                        <MudText><strong>@_latestPri.Status.Name Reason</strong></MudText>
+                        <MudText Typo="Typo.body2">@_latestPri.AbandonReason</MudText>
+                    </MudStack>
+                }
+            }
 
-                        if (_latestPri.Status == PriStatus.Abandoned)
-                        {
-                            <div class="description-pair">
-                                <dt>
-                                    <MudText Typo="Typo.subtitle2">@_latestPri.Status.Name Reason</MudText>
-                                </dt>
-                                <dd>
-                                    <MudText Typo="Typo.body2">@_latestPri.AbandonReason</MudText>
-                                </dd>
-                            </div>
-                        }
-                    }
-
-                    @if (_showTtgDue)
-                    {
-                        <div class="description-pair">
-                            <dt>
-                                <MudText Typo="Typo.subtitle2">TTG Due</MudText>
-                            </dt>
-                            <dd>
-                                <MudTooltip Text="@_priDueTooltipText">
-                                    <MudIcon Icon="@_priDueIcon" Size="@Size.Small" Color="@_priDueIconColor"/>
-                                    <MudText Typo="Typo.body2">
-                                        @_priDueInfo
-                                    </MudText>
-                                </MudTooltip>
-                            </dd>
-                        </div>
-                    }
-                </dl>
-            </div>
+            @if (_showTtgDue)
+            {
+                <MudStack Row="true" StretchItems="StretchItems.Start" Class="mb-2">
+                    <MudText><strong>TTG Due</strong></MudText>
+                    <MudTooltip Text="@_priDueTooltipText">
+                        <MudIcon Icon="@_priDueIcon" Size="@Size.Small" Color="@_priDueIconColor"/>
+                        <MudText>
+                            @_priDueInfo
+                        </MudText>
+                    </MudTooltip>
+                </MudStack>
+            }
         }
     </MudCardContent>
+    
     <MudCardActions>
-
         @if (CanAddPri())
         {
             <MudTooltip Text="Create PRI">
-                <MudIconButton Color="Color.Primary" Icon="@Icons.Material.Filled.Add" Variant="Variant.Filled" OnClick="BeginPri" />
+                <MudIconButton Color="Color.Primary" Icon="@Icons.Material.Filled.Add" Variant="Variant.Filled" OnClick="@BeginPri" />
             </MudTooltip>
         }
-
     </MudCardActions>
 </MudCard>

--- a/src/Server.UI/Pages/Participants/Components/Summary/PRISummary.razor.cs
+++ b/src/Server.UI/Pages/Participants/Components/Summary/PRISummary.razor.cs
@@ -1,5 +1,4 @@
-﻿using Cfo.Cats.Application.Common.Interfaces.Identity;
-using Cfo.Cats.Application.Features.Participants.DTOs;
+﻿using Cfo.Cats.Application.Features.Participants.DTOs;
 using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Infrastructure.Constants;
 using Humanizer;
@@ -10,9 +9,6 @@ public partial class PRISummary
 {
     [CascadingParameter]
     public ParticipantSummaryDto ParticipantSummaryDto { get; set; } = null!;
-
-    [Inject]
-    private IUserService UserService { get; set; } = null!;
 
     private PriSummaryDto? _latestPri;
 
@@ -83,5 +79,5 @@ public partial class PRISummary
         && ParticipantSummaryDto.LocationType.IsMapped
         && ParticipantSummaryDto.IsActive;
 
-    public void BeginPri() => Navigation.NavigateTo($"/pages/participants/{ParticipantSummaryDto.Id}/PRI");
+    private void BeginPri() => Navigation.NavigateTo($"/pages/participants/{ParticipantSummaryDto.Id}/PRI");
 }


### PR DESCRIPTION
This pull request refactors the `PRISummary` component to improve UI consistency and simplify the code. The most important changes include updating the layout to use `MudStack` for better alignment, removing the dependency on `UserService`, and adjusting method visibility and usage.

UI improvements:

* Replaced the custom description list layout with `MudStack` components in `PRISummary.razor` for improved alignment and consistency across PRI summary fields.

Codebase simplification:

* Removed the `UserService` dependency and related injection from `PRISummary.razor.cs`, reducing coupling and simplifying the component.
* Changed the `BeginPri` method from `public` to `private` and updated its usage in the Razor file for better encapsulation. [[1]](diffhunk://#diff-90a062f909a116d216998b504573082bd56557d4b69fb2407d88f065fbd20cd2L86-R82) [[2]](diffhunk://#diff-3b7b130cee4126a32151c45a35a45f11d5385d0a1832459b8bc41fafb5a38f4eL10-L107)

General cleanup:

* Removed unnecessary using statement for `IUserService` in `PRISummary.razor.cs`.