### PR TITLE
Add warning for out-of-sync QA activity

### DIFF
--- a/src/Server.UI/Pages/QA/Activities/QA1.razor
+++ b/src/Server.UI/Pages/QA/Activities/QA1.razor
@@ -21,8 +21,6 @@
         justify-content: center;
         align-items: center;
     }
-
-
  </style>
 
 <ActivityQaExternalMessageWarning @ref="warningMessage" />
@@ -39,8 +37,7 @@
             Get Next
         </MudButton>
     }
-
-    @if (_activityQaDetailsDto is not null && _activityQaDetailsDto.Status== ActivityStatus.SubmittedToAuthorityStatus)
+    else if(_activityQaDetailsDto.Status == ActivityStatus.SubmittedToAuthorityStatus)
     {
         @if (_queueEntry!.IsAccepted)
         {
@@ -111,6 +108,12 @@
                 </MudTabs>
             </MudItem>
         </MudGrid>
+    }
+    else
+    {
+        <MudAlert Variant="Variant.Filled" Severity="Severity.Error">
+            Something has gone wrong, cannot process an activity that is @_activityQaDetailsDto.Status.Name
+        </MudAlert>
     }
 
 </MudContainer>

--- a/src/Server.UI/Pages/QA/Activities/QA2.razor
+++ b/src/Server.UI/Pages/QA/Activities/QA2.razor
@@ -35,8 +35,7 @@
             Get Next
         </MudButton>
     }
-
-    @if (_activityQaDetailsDto is not null && _activityQaDetailsDto.Status== ActivityStatus.SubmittedToAuthorityStatus)
+    else if(_activityQaDetailsDto.Status== ActivityStatus.SubmittedToAuthorityStatus)
     {
 
         @if (_queueEntry!.IsAccepted)
@@ -180,6 +179,12 @@
                 </MudTabs>
             </MudItem>
         </MudGrid>
+    }
+    else 
+    {
+        <MudAlert Variant="Variant.Filled" Severity="Severity.Error">
+            Something has gone wrong, cannot process an activity that is @_activityQaDetailsDto.Status.Name
+        </MudAlert>
     }
 </MudContainer>
 


### PR DESCRIPTION
This pull request improves error handling and refines conditional logic in the QA activity pages. The main changes ensure that users are properly notified when an activity is in an unexpected status and streamline the way status checks are performed.

Enhanced error handling:

* Added a `MudAlert` error message to both `QA1.razor` and `QA2.razor` to inform users when an activity cannot be processed due to its current status. [[1]](diffhunk://#diff-708ebf8eaa78864bed932dd28d8627c7b1584795efc6027067a4bb993d2ec52eR112-R117) [[2]](diffhunk://#diff-d7649903d526579ae372bc91d40c5ccc3bd487a37f6bfe29ea2a8ce90b6e8d47R183-R188)

Conditional logic improvements:

* Changed the conditional check for `SubmittedToAuthorityStatus` from an `if` to an `else if`, ensuring the error message is only shown when none of the expected conditions are met. [[1]](diffhunk://#diff-708ebf8eaa78864bed932dd28d8627c7b1584795efc6027067a4bb993d2ec52eL42-R40) [[2]](diffhunk://#diff-d7649903d526579ae372bc91d40c5ccc3bd487a37f6bfe29ea2a8ce90b6e8d47L38-R38)

Minor cleanup:

* Removed unnecessary blank lines from the `QA1.razor` file for improved readability.