### PR TITLE
Refactor risk validation for custody and community contexts

### DIFF
--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -164,9 +164,9 @@ public class RiskDto
         [Description("Risk to Other Prisoners")]
         public RiskLevel? RiskToOtherPrisoners { get; set; }
 
-        public class Validator : AbstractValidator<RiskDetail>
+        public class CustodyValidator : AbstractValidator<RiskDetail>
         {
-            public Validator()
+            public CustodyValidator()
             {
                 RuleFor(x => x.RiskToChildren)
                     .NotNull()
@@ -187,7 +187,33 @@ public class RiskDto
                 RuleFor(x => x.RiskToOtherPrisoners)
                     .NotNull()
                     .WithMessage("Risk To Other Prisoners option is mandatory");
+                    
+                RuleFor(x => x.RiskToSelfNew)
+                    .NotNull()
+                    .WithMessage("Risk To Self option is mandatory");
+            }
+        }
 
+        public class CommunityValidator : AbstractValidator<RiskDetail>
+        {
+            public CommunityValidator()
+            {
+                RuleFor(x => x.RiskToChildren)
+                    .NotNull()
+                    .WithMessage("Risk to Children option is mandatory");
+
+                RuleFor(x => x.RiskToPublic)
+                    .NotNull()
+                    .WithMessage("Risk to Public option is mandatory");
+
+                RuleFor(x => x.RiskToKnownAdult)
+                    .NotNull()
+                    .WithMessage("Risk to Known Adult option is mandatory");
+
+                RuleFor(x => x.RiskToStaff)
+                    .NotNull()
+                    .WithMessage("Risk To Staff option is mandatory");
+                    
                 RuleFor(x => x.RiskToSelfNew)
                     .NotNull()
                     .WithMessage("Risk To Self option is mandatory");
@@ -282,28 +308,16 @@ public class RiskDto
                 .When(x => x.IsRelevantToCommunity is false)
                 .WithMessage("You must pick one");
 
-            When(x => x.IsRelevantToCommunity, () =>
+            When(x => x.IsRelevantToCommunity || x.LocationType?.IsCommunity == true, () =>
             {
                 RuleFor(x => x.CommunityRiskDetail)
-                    .SetValidator(new RiskDetail.Validator());
+                    .SetValidator(new RiskDetail.CommunityValidator());
             });
 
-            When(x => x.IsRelevantToCustody, () =>
+            When(x => x.IsRelevantToCustody || x.LocationType?.IsCustody == true, () =>
             {
                 RuleFor(x => x.CustodyRiskDetail)
-                    .SetValidator(new RiskDetail.Validator());
-            });
-
-            When(x => x.LocationType?.IsCommunity == true, () =>
-            {
-                RuleFor(x => x.CommunityRiskDetail)
-                    .SetValidator(new RiskDetail.Validator());
-            });
-
-            When(x => x.LocationType?.IsCustody == true, () =>
-            {
-                RuleFor(x => x.CustodyRiskDetail)
-                    .SetValidator(new RiskDetail.Validator());
+                    .SetValidator(new RiskDetail.CustodyValidator());
             });
 
             RuleFor(x => x.IsSubjectToSHPO)


### PR DESCRIPTION
This pull request refactors the validation logic for risk details in the `RiskDto` data transfer object. The main improvement is splitting the original single validator for `RiskDetail` into two specialized validators: one for custody-related risks and one for community-related risks. This allows for more precise and context-specific validation depending on the scenario. The logic that applies these validators in the main `RiskDto` validator has also been updated to use the new classes and improved conditional checks.

**Validation Refactoring:**

* Split the original `RiskDetail.Validator` into two separate classes: `CustodyValidator` for custody-related risk properties, and `CommunityValidator` for community-related risk properties, each with their own set of required fields and messages. [[1]](diffhunk://#diff-924c5964cb068b7a3e4bcdae9e0f818d3655c585b30637b7b68bd0b8f33cf7a8L167-R169) [[2]](diffhunk://#diff-924c5964cb068b7a3e4bcdae9e0f818d3655c585b30637b7b68bd0b8f33cf7a8R196-R221)
* Updated the main `RiskDto.Validator` to use `CommunityValidator` and `CustodyValidator` instead of the original validator, and improved the conditional logic to apply validators based on both `IsRelevantToCommunity`/`IsRelevantToCustody` flags and `LocationType` properties.