### PR TITLE
Fix SQL Connection

### DIFF
--- a/src/Application/Common/Interfaces/ISqlConnectionFactory.cs
+++ b/src/Application/Common/Interfaces/ISqlConnectionFactory.cs
@@ -2,9 +2,7 @@ namespace Cfo.Cats.Application.Common.Interfaces;
 
 public interface ISqlConnectionFactory
 {
-    IDbConnection GetOpenConnection();
-
-    IDbConnection CreateNewConnection();
+    IDbConnection CreateOpenConnection();
 
     string GetConnectionString();
 }

--- a/src/Application/Features/Labels/LabelCounter.cs
+++ b/src/Application/Features/Labels/LabelCounter.cs
@@ -7,7 +7,7 @@ public class LabelCounter(ISqlConnectionFactory sqlConnectionFactory) : ILabelCo
 {
     public int CountParticipants(LabelId labelId)
     {
-        var connection = sqlConnectionFactory.GetOpenConnection();
+        using var connection = sqlConnectionFactory.CreateOpenConnection();
         
         const string sql = """
                            SELECT Count(*) 
@@ -24,7 +24,7 @@ public class LabelCounter(ISqlConnectionFactory sqlConnectionFactory) : ILabelCo
 
     public int CountVisibleLabels(string name, string? contractId)
     {
-        var connection = sqlConnectionFactory.GetOpenConnection();
+        using var connection = sqlConnectionFactory.CreateOpenConnection();
         
         const string sql = """
                          SELECT Count(*) 

--- a/src/Application/Features/Labels/Queries/GetLabelById.cs
+++ b/src/Application/Features/Labels/Queries/GetLabelById.cs
@@ -18,7 +18,7 @@ public static class GetLabelById
     {
         public async Task<Result<LabelDto>> Handle(Query request, CancellationToken cancellationToken)
         {
-            var connection = sqlConnectionFactory.GetOpenConnection();
+            using var connection = sqlConnectionFactory.CreateOpenConnection();
 
             const string sql = $"""
                                 SELECT 

--- a/src/Application/Features/Labels/Queries/GetVisibleLabels.cs
+++ b/src/Application/Features/Labels/Queries/GetVisibleLabels.cs
@@ -17,7 +17,7 @@ public static class GetVisibleLabels
     {
         public async Task<Result<LabelDto[]>> Handle(Query request, CancellationToken cancellationToken)
         {
-            var connection = sqlConnectionFactory.GetOpenConnection();
+            using var connection = sqlConnectionFactory.CreateOpenConnection();
 
             const string sql = $"""
                                     SELECT 

--- a/src/Application/Features/ParticipantLabels/GetParticipantLabels/GetParticipantLabelsQueryHandler.cs
+++ b/src/Application/Features/ParticipantLabels/GetParticipantLabels/GetParticipantLabelsQueryHandler.cs
@@ -8,7 +8,7 @@ public class GetParticipantLabelsQueryHandler(ISqlConnectionFactory sqlConnectio
 {
     public async Task<Result<GetParticipantLabelsDto>> Handle(GetParticipantLabelsQuery request, CancellationToken cancellationToken)
     {
-        var connection = sqlConnectionFactory.GetOpenConnection();
+        using var connection = sqlConnectionFactory.CreateOpenConnection();
 
         var sql = """
             select

--- a/src/Application/Features/ParticipantLabels/ParticipantLabelsCounter.cs
+++ b/src/Application/Features/ParticipantLabels/ParticipantLabelsCounter.cs
@@ -9,7 +9,7 @@ public class ParticipantLabelsCounter(ISqlConnectionFactory sqlConnectionFactory
 {
     public int CountOpenLabels(ParticipantId participantId, LabelId labelId)
     {
-        var connection = sqlConnectionFactory.GetOpenConnection();
+        using var connection = sqlConnectionFactory.CreateOpenConnection();
 
         const string sql = """
                             SELECT COUNT(*)

--- a/src/Infrastructure/Persistence/SqlConnectionFactory.cs
+++ b/src/Infrastructure/Persistence/SqlConnectionFactory.cs
@@ -3,24 +3,9 @@ using Microsoft.Data.SqlClient;
 
 namespace Cfo.Cats.Infrastructure.Persistence;
 
-public class SqlConnectionFactory(string connectionString) : ISqlConnectionFactory, IDisposable
+public class SqlConnectionFactory(string connectionString) : ISqlConnectionFactory
 {
-    private IDbConnection? _connection;
-
-    public IDbConnection GetOpenConnection()
-    {
-        if (this._connection is { State: ConnectionState.Open })
-        {
-            return _connection;
-        }
-
-        _connection = new SqlConnection(connectionString);
-        _connection.Open();
-
-        return _connection;
-    }
-    
-    public IDbConnection CreateNewConnection()
+    public IDbConnection CreateOpenConnection()
     {
         var connection = new SqlConnection(connectionString);
         connection.Open();
@@ -29,12 +14,4 @@ public class SqlConnectionFactory(string connectionString) : ISqlConnectionFacto
     }
 
     public string GetConnectionString() => connectionString;
-
-    public void Dispose()
-    {
-        if (this._connection != null && this._connection.State == ConnectionState.Open)
-        {
-            this._connection.Dispose();
-        }
-    }
 }

--- a/test/Application.UnitTests/Labels/LabelCounterTests.cs
+++ b/test/Application.UnitTests/Labels/LabelCounterTests.cs
@@ -29,7 +29,7 @@ public class LabelCounterTests
             .Returns(expectedCount);
 
         var sqlFactory = new Mock<ISqlConnectionFactory>();
-        sqlFactory.Setup(x => x.GetOpenConnection()).Returns(connection.Object);
+        sqlFactory.Setup(x => x.CreateOpenConnection()).Returns(connection.Object);
 
         var counter = new LabelCounter(sqlFactory.Object);
         var labelId = new LabelId(Guid.NewGuid());

--- a/test/Application.UnitTests/ParticipantLabels/ParticipantLabelsCounterTests.cs
+++ b/test/Application.UnitTests/ParticipantLabels/ParticipantLabelsCounterTests.cs
@@ -23,8 +23,7 @@ public class ParticipantLabelsCounterTests
 
     private class TestSqlConnectionFactory : ISqlConnectionFactory
     {
-        public IDbConnection GetOpenConnection() => null!;
-        public IDbConnection CreateNewConnection() => null!;
+        public IDbConnection CreateOpenConnection() => null!;
         public string GetConnectionString() => "";
     }
 }


### PR DESCRIPTION
This pull request refactors the way SQL connections are managed throughout the application. The main change is the replacement of the `GetOpenConnection` and `CreateNewConnection` methods with a single, consistently named `CreateOpenConnection` method in the `ISqlConnectionFactory` interface and its implementations. This update impacts both the application logic and the related unit tests, ensuring that database connections are created and disposed of properly.

**Refactoring connection management:**

* Replaced `GetOpenConnection` and `CreateNewConnection` with a single `CreateOpenConnection` method in the `ISqlConnectionFactory` interface (`src/Application/Common/Interfaces/ISqlConnectionFactory.cs`) and updated all usages throughout the codebase to use this new method. [[1]](diffhunk://#diff-8bf50111b40446a645f0600235c2f12bac9e259cc47b0ba245cec37d7cfa873bL5-R5) [[2]](diffhunk://#diff-356aecfc93fd6889f41fffb8045fab4612c518558190cd478a62f026fa31f83aL6-R8)
* Updated the implementation in `SqlConnectionFactory` to remove connection caching and disposal logic, ensuring each call to `CreateOpenConnection` returns a new, open connection (`src/Infrastructure/Persistence/SqlConnectionFactory.cs`). [[1]](diffhunk://#diff-356aecfc93fd6889f41fffb8045fab4612c518558190cd478a62f026fa31f83aL6-R8) [[2]](diffhunk://#diff-356aecfc93fd6889f41fffb8045fab4612c518558190cd478a62f026fa31f83aL32-L39)

**Codebase consistency and resource management:**

* Refactored all application services and handlers to use `using var connection = sqlConnectionFactory.CreateOpenConnection();` for proper disposal of connections (e.g., in `LabelCounter`, `GetLabelById.Handler`, `GetVisibleLabels.Handler`, `GetParticipantLabelsQueryHandler`, and `ParticipantLabelsCounter`). [[1]](diffhunk://#diff-2e80702fe8eadd920a0c55952ee3e39f9e4dcb8ed4ea7f1f5e224cd27cd02bcdL10-R10) [[2]](diffhunk://#diff-2e80702fe8eadd920a0c55952ee3e39f9e4dcb8ed4ea7f1f5e224cd27cd02bcdL27-R27) [[3]](diffhunk://#diff-b5dd735fc2715e0441ae91fd41486f13ca8aea899a3e840894e1f578a3f913e7L21-R21) [[4]](diffhunk://#diff-7e9c26cee8e0869971f75c30fd397b4b27f9eb82759e82e2122cbd52f50e2e7aL20-R20) [[5]](diffhunk://#diff-6b4dd28cd3a9f232c2dc003eb9781569914c9c610c80bad6fc5e5544c6ac2753L11-R11) [[6]](diffhunk://#diff-6f59be1fcb2651f97129bf9ca9708499b78f0a6bd2a60420d140494661cf328eL12-R12)

**Unit test updates:**

* Updated all unit tests and mocks to use the new `CreateOpenConnection` method instead of the removed methods, ensuring tests remain valid and up-to-date (`LabelCounterTests.cs`, `ParticipantLabelsCounterTests.cs`). [[1]](diffhunk://#diff-58a3ca684a1616c3ea53269110252cda6ab98d3b64b5676aa71050d917f0cbcfL32-R32) [[2]](diffhunk://#diff-81c71d75a632e049e93fd545116a85b10d846d17057b6e2450cb0fd22fd88e0bL26-R26)