### PR TITLE
Feature/lookups

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "aspire"
       ],
       "rollForward": false
+    },
+    "microsoft.sqlpackage": {
+      "version": "170.3.93",
+      "commands": [
+        "sqlpackage"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/cake.cs
+++ b/cake.cs
@@ -58,6 +58,13 @@ Task("Publish")
            NoRestore = true,
            OutputDirectory = "./artifacts/DatabaseMigrator",
         });
+
+        DotNetBuild("./src/Database/CatsDb/CatsDb.sqlproj", new DotNetBuildSettings()
+        {
+            Configuration = configuration,
+            OutputDirectory = "./artifacts/"
+        });
+
     });
 
 RunTarget(target); 

--- a/cats.slnx
+++ b/cats.slnx
@@ -38,6 +38,11 @@
     <Project Path="src/Aspire/Cats.AppHost/Cats.AppHost.csproj" />
     <Project Path="src/Aspire/Cats.ServiceDefaults/Cats.ServiceDefaults.csproj" />
   </Folder>
+  <Folder Name="/src/Database/">
+    <Project Path="src/Database/CatsDb/CatsDb.sqlproj">
+      <Platform Project="AnyCPU" />
+    </Project>
+  </Folder>
   <Folder Name="/test/">
     <Project Path="test/Application.UnitTests/Application.UnitTests.csproj" />
     <Project Path="test/ArchitectureTests/ArchitectureTests.csproj" />

--- a/src/Database/CatsDb/Lookups/Tables/ConsentStatus.sql
+++ b/src/Database/CatsDb/Lookups/Tables/ConsentStatus.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [Lookup].[ConsentStatus] (
+    [Value]         INT             NOT NULL,
+    [Name]          NVARCHAR (50)   NOT NULL
+);
+GO
+
+ALTER TABLE [Lookup].[ConsentStatus]
+    ADD CONSTRAINT [PK_ConsentStatus] PRIMARY KEY CLUSTERED ([Value] ASC)
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [ix_ConsentStatus_Name]
+    ON [Lookup].[ConsentStatus] ([Name] ASC)
+GO

--- a/src/Database/CatsDb/Lookups/Tables/EnrolmentStatus.sql
+++ b/src/Database/CatsDb/Lookups/Tables/EnrolmentStatus.sql
@@ -1,0 +1,14 @@
+CREATE TABLE [Lookup].[EnrolmentStatus] (
+    [Value]         INT             NOT NULL,
+    [Name]          NVARCHAR (50)   NOT NULL,
+    [LogicalOrder]  INT             NOT NULL
+);
+GO
+
+ALTER TABLE [Lookup].[EnrolmentStatus]
+    ADD CONSTRAINT [PK_EnrolmentStatus] PRIMARY KEY CLUSTERED ([Value] ASC)
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [ix_EnrolmentStatus_Name]
+    ON [Lookup].[EnrolmentStatus] ([Name] ASC)
+GO

--- a/src/Database/CatsDb/Lookups/Tables/RiskDueReason.sql
+++ b/src/Database/CatsDb/Lookups/Tables/RiskDueReason.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [Lookup].[RiskDueReason] (
+    [Value]         INT             NOT NULL,
+    [Name]          NVARCHAR (50)   NOT NULL
+);
+GO
+
+ALTER TABLE [Lookup].[RiskDueReason]
+    ADD CONSTRAINT [PK_RiskDueReason] PRIMARY KEY CLUSTERED ([Value] ASC)
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [ix_RiskDueReason_Name]
+    ON [Lookup].[RiskDueReason] ([Name] ASC)
+GO

--- a/src/Database/CatsDb/Participant/Tables/Participant.sql
+++ b/src/Database/CatsDb/Participant/Tables/Participant.sql
@@ -67,3 +67,19 @@ ALTER TABLE [Participant].[Participant]
     ADD CONSTRAINT [PK_Participant] PRIMARY KEY CLUSTERED ([Id] ASC);
 GO
 
+--These lookups cannot be applied until after Production is updated.
+
+--ALTER TABLE [Participant].[Participant]
+--    ADD CONSTRAINT [FK_Participant_EnrolmentStatus] FOREIGN KEY ( [EnrolmentStatus] ) REFERENCES [Lookup].[EnrolmentStatus] ( [Value] );
+
+--GO
+
+--ALTER TABLE [Participant].[Participant]
+--    ADD CONSTRAINT [FK_Participant_ConsentStatus] FOREIGN KEY  ( [ConsentStatus] ) REFERENCES [Lookup].[ConsentStatus] ( [Value] );
+
+--GO
+
+--ALTER TABLE [Participant].[Participant]
+--    ADD CONSTRAINT [FK_Participant_RiskDueReason] FOREIGN KEY  ( [RiskDueReason] ) REFERENCES [Lookup].[RiskDueReason] ( [Value] );
+
+--GO

--- a/src/Database/CatsDb/Security/Lookups.sql
+++ b/src/Database/CatsDb/Security/Lookups.sql
@@ -1,0 +1,4 @@
+CREATE SCHEMA [Lookup]
+    AUTHORIZATION [dbo];
+GO
+

--- a/src/DatabaseMigrator/Scripts/0000_Lookups.sql
+++ b/src/DatabaseMigrator/Scripts/0000_Lookups.sql
@@ -1,0 +1,39 @@
+
+IF NOT EXISTS (SELECT TOP(1) [Value] FROM [Lookup].[EnrolmentStatus])
+BEGIN
+
+    INSERT INTO [Lookup].[EnrolmentStatus] ( [Value], [Name], [LogicalOrder] )
+    VALUES 
+    (0, 'Identified', 0),
+    (1, 'Submitted To Provider', 2),
+    (2, 'Submitted To Authority', 3),
+    (3, 'Approved', 4),
+    (4, 'Archived', 5),
+    (5, 'Dormant', 6),
+    (6, 'Enrolling', 1);
+
+END
+
+IF NOT EXISTS (SELECT TOP(1) [Value] FROM [Lookup].[ConsentStatus])
+BEGIN
+
+    INSERT INTO [Lookup].[ConsentStatus] ( [Value], [Name] )
+    VALUES
+    (0, 'Pending'),
+    (1, 'Granted');
+
+END
+
+IF NOT EXISTS (SELECT TOP(1) [Value] FROM [Lookup].[RiskDueReason])
+BEGIN
+
+    INSERT INTO [Lookup].[RiskDueReason] ( [Value], [Name] )
+    VALUES
+    (0, 'No Reason Specified'),
+    (1, 'New Entry'),
+    (2, 'Initial Review'),
+    (3, 'Data Feed Updated'),
+    (4, 'Ten Week Review'),
+    (5, 'Removed From Archive');
+
+END


### PR DESCRIPTION
This pull request introduces new lookup tables to the database for participant statuses and reasons, sets up their supporting schema and indexes, and seeds them with initial data. It also prepares for future foreign key relationships in the `Participant` table, though these are currently commented out pending production updates.

**Database schema changes:**

* Added the `Lookup` schema to organize lookup tables.
* Created three new lookup tables: `EnrolmentStatus`, `ConsentStatus`, and `RiskDueReason`, each with appropriate columns, primary keys, and unique indexes on the `Name` column. [[1]](diffhunk://#diff-09d36ff0444ba6114c8451d92baa3b41e44180a6b75cacc1ca0f794198e6f1e3R1-R14) [[2]](diffhunk://#diff-0b92c55610a9bfd92ff53cb4dc4a180f7edb90df0b7050487172c671b7a6c95eR1-R13) [[3]](diffhunk://#diff-c2ea8d068714a4b99675460851e92f924e81d6097d03a60b2b03dba7213d0df4R1-R13)
* Registered the new database project `CatsDb.sqlproj` in the solution file (`cats.slnx`).

**Data seeding:**

* Added a migration script to seed the new lookup tables with initial values if they are empty.

**Preparation for future relationships:**

* Added (but commented out) foreign key constraints in the `Participant` table to reference the new lookup tables, with a note that they will be enabled after production is updated.