### PR TITLE
Fix logging error from QL scanning

### DIFF
--- a/src/Server.UI/Components/Shared/CustomError.razor
+++ b/src/Server.UI/Components/Shared/CustomError.razor
@@ -76,8 +76,22 @@
         }
 
         StackTrace = Exception.StackTrace;
-        Logger.LogError(Exception, "{Message}. request url: {@url} {@UserName}", Message, Navigation.Uri, userName);
+        var requestPath = Uri.TryCreate(Navigation.Uri, UriKind.Absolute, out var currentUri)
+            ? currentUri.AbsolutePath
+            : Navigation.Uri;
+
+        Logger.LogError(
+            Exception,
+            "{Message}. request path: {RequestPath} {UserName}",
+            Message,
+            SanitizeForLog(requestPath),
+            SanitizeForLog(userName));
     }
 
     private void OnRefresh() => Navigation.NavigateTo(Navigation.Uri, true);
+
+    private static string SanitizeForLog(string? value)
+        => string.IsNullOrEmpty(value)
+            ? string.Empty
+            : value.Replace("\r", "\\r").Replace("\n", "\\n");
 }


### PR DESCRIPTION
This pull request updates the error logging in the `CustomError.razor` component to improve log clarity and security. The main changes include logging only the request path instead of the full URL and sanitizing log values to prevent log injection.

**Error Logging Improvements:**

* The error log now records only the request path (not the full URL) to reduce sensitive information exposure.
* Introduced a `SanitizeForLog` method to escape newline and carriage return characters in log entries, mitigating the risk of log injection.
* Updated the log message format to use `{RequestPath}` and `{UserName}` placeholders for improved clarity and consistency.