### PR TITLE
Replace correlated subqueries used to resolve ContractName in all four

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetActivitiesAdvisoriesToProvider.cs
+++ b/src/Application/Features/Dashboard/Queries/GetActivitiesAdvisoriesToProvider.cs
@@ -37,15 +37,12 @@ public static class GetActivitiesAdvisoriesToProvider
                 from a in activityJoin.DefaultIfEmpty()
                 join submittedByUser in context.Users on pfa.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
                 from submittedByUser in submittedByUserJoin.DefaultIfEmpty()
-
+                join con in context.Contracts on pfa.ContractId equals con.Id into contractJoin
+                from con in contractJoin.DefaultIfEmpty()
+                
                 select new ActivitiesAdvisoriesTabularData
                 {
-                    ContractName =
-                        (from con in context.Contracts
-                        where pfa.TenantId.StartsWith(con.Tenant!.Id)
-                        orderby con.Tenant!.Id.Length descending
-                        select con.Description)
-                        .FirstOrDefault(),
+                    ContractName = con.Description,
                     ParticipantId = pfa.ParticipantId,
                     Queue = pfa.Queue,
                     ActivityType = a.Type,

--- a/src/Application/Features/Dashboard/Queries/GetActivitiesToProvider.cs
+++ b/src/Application/Features/Dashboard/Queries/GetActivitiesToProvider.cs
@@ -35,15 +35,12 @@ public static class GetActivitiesToProvider
                 from a in activityJoin.DefaultIfEmpty()
                 join submittedByUser in context.Users on pfa.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
                 from submittedByUser in submittedByUserJoin.DefaultIfEmpty()
+                join con in context.Contracts on pfa.ContractId equals con.Id into contractJoin
+                from con in contractJoin.DefaultIfEmpty()
 
                 select new ActivitiesTabularData
                 {
-                    ContractName =
-                        (from con in context.Contracts
-                        where pfa.TenantId.StartsWith(con.Tenant!.Id)
-                        orderby con.Tenant!.Id.Length descending
-                        select con.Description)
-                        .FirstOrDefault(),
+                    ContractName = con.Description,
                     ParticipantId = pfa.ParticipantId,
                     Queue = pfa.Queue,
                     ActivityType = a.Type,

--- a/src/Application/Features/Dashboard/Queries/GetEnrolmentAdvisoriesToProvider.cs
+++ b/src/Application/Features/Dashboard/Queries/GetEnrolmentAdvisoriesToProvider.cs
@@ -23,36 +23,33 @@ public static class GetEnrolmentAdvisoriesToProvider
             var context = unitOfWork.DbContext;
 
             
-            var query = from pfa in context.ProviderFeedbackEnrolments
-                where pfa.Message != null
-                    && (pfa.FeedbackType == ((int)FeedbackType.Advisory) || pfa.FeedbackType == ((int)FeedbackType.AcceptedByException))
-                    && pfa.ActionDate >= request.StartDate
-                    && pfa.ActionDate < request.EndDate.AddDays(1)
-                    && (!string.IsNullOrWhiteSpace(request.TenantId) ? pfa.TenantId.StartsWith(request.TenantId) : true)
-                join cfoUser in context.Users on pfa.CfoUserId equals cfoUser.Id into cfoUserJoin
+            var query = from pfe in context.ProviderFeedbackEnrolments
+                where pfe.Message != null
+                    && (pfe.FeedbackType == ((int)FeedbackType.Advisory) || pfe.FeedbackType == ((int)FeedbackType.AcceptedByException))
+                    && pfe.ActionDate >= request.StartDate
+                    && pfe.ActionDate < request.EndDate.AddDays(1)
+                    && (!string.IsNullOrWhiteSpace(request.TenantId) ? pfe.TenantId.StartsWith(request.TenantId) : true)
+                join cfoUser in context.Users on pfe.CfoUserId equals cfoUser.Id into cfoUserJoin
                 from cfoUser in cfoUserJoin.DefaultIfEmpty()
-                join sw in context.Users on pfa.SupportWorkerId equals sw.Id into swJoin
+                join sw in context.Users on pfe.SupportWorkerId equals sw.Id into swJoin
                 from sw in swJoin.DefaultIfEmpty()
-                join submittedByUser in context.Users on pfa.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
+                join submittedByUser in context.Users on pfe.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
                 from submittedByUser in submittedByUserJoin.DefaultIfEmpty()                
+                join con in context.Contracts on pfe.ContractId equals con.Id into contractJoin
+                from con in contractJoin.DefaultIfEmpty()
 
                 select new EnrolmentAdvisoriesTabularData
                 {
-                    ContractName =
-                        (from con in context.Contracts
-                        where pfa.TenantId.StartsWith(con.Tenant!.Id)
-                        orderby con.Tenant!.Id.Length descending
-                        select con.Description)
-                        .FirstOrDefault(),
-                    ParticipantId = pfa.ParticipantId,
-                    Queue = pfa.Queue,
+                    ContractName = con.Description,
+                    ParticipantId = pfe.ParticipantId,
+                    Queue = pfe.Queue,
                     SupportWorker = sw.DisplayName,
                     CfoUser = cfoUser.DisplayName,
-                    PqaSubmittedDate = pfa.PqaSubmittedDate,
+                    PqaSubmittedDate = pfe.PqaSubmittedDate,
                     PqaUser = submittedByUser.DisplayName,
-                    AdvisoryDate = pfa.ActionDate,
-                    FeedbackType = pfa.FeedbackType,
-                    Message = (pfa.Message ?? "").Replace("\r", " ").Replace("\n", " ")
+                    AdvisoryDate = pfe.ActionDate,
+                    FeedbackType = pfe.FeedbackType,
+                    Message = (pfe.Message ?? "").Replace("\r", " ").Replace("\n", " ")
                 };
 
             var result = await query.OrderBy(r => r.AdvisoryDate)

--- a/src/Application/Features/Dashboard/Queries/GetEnrolmentsToProvider.cs
+++ b/src/Application/Features/Dashboard/Queries/GetEnrolmentsToProvider.cs
@@ -21,34 +21,31 @@ public static class GetEnrolmentsToProvider
         {
             var context = unitOfWork.DbContext;
 
-            var query = from pfa in context.ProviderFeedbackEnrolments
-                where pfa.FeedbackType == ((int)FeedbackType.Returned)
-                    && pfa.ActionDate >= request.StartDate
-                    && pfa.ActionDate < request.EndDate.AddDays(1)
-                    && (!string.IsNullOrWhiteSpace(request.TenantId) ? pfa.TenantId.StartsWith(request.TenantId) : true)
-                join cfoUser in context.Users on pfa.CfoUserId equals cfoUser.Id into cfoUserJoin
+            var query = from pfe in context.ProviderFeedbackEnrolments
+                where pfe.FeedbackType == ((int)FeedbackType.Returned)
+                    && pfe.ActionDate >= request.StartDate
+                    && pfe.ActionDate < request.EndDate.AddDays(1)
+                    && (!string.IsNullOrWhiteSpace(request.TenantId) ? pfe.TenantId.StartsWith(request.TenantId) : true)
+                join cfoUser in context.Users on pfe.CfoUserId equals cfoUser.Id into cfoUserJoin
                 from cfoUser in cfoUserJoin.DefaultIfEmpty()
-                join sw in context.Users on pfa.SupportWorkerId equals sw.Id into swJoin
+                join sw in context.Users on pfe.SupportWorkerId equals sw.Id into swJoin
                 from sw in swJoin.DefaultIfEmpty()
-                join submittedByUser in context.Users on pfa.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
+                join submittedByUser in context.Users on pfe.ProviderQaUserId equals submittedByUser.Id into submittedByUserJoin
                 from submittedByUser in submittedByUserJoin.DefaultIfEmpty()                
+                join con in context.Contracts on pfe.ContractId equals con.Id into contractJoin
+                from con in contractJoin.DefaultIfEmpty()
 
                 select new EnrolmentsTabularData
                 {
-                    ContractName =
-                        (from con in context.Contracts
-                        where pfa.TenantId.StartsWith(con.Tenant!.Id)
-                        orderby con.Tenant!.Id.Length descending
-                        select con.Description)
-                        .FirstOrDefault(),
-                    ParticipantId = pfa.ParticipantId,
-                    Queue = pfa.Queue,
+                    ContractName = con.Description,
+                    ParticipantId = pfe.ParticipantId,
+                    Queue = pfe.Queue,
                     SupportWorker = sw.DisplayName,
                     CfoUser = cfoUser.DisplayName,
-                    PqaSubmittedDate = pfa.PqaSubmittedDate,
+                    PqaSubmittedDate = pfe.PqaSubmittedDate,
                     PqaUser = submittedByUser.DisplayName,
-                    ReturnedDate = pfa.ActionDate,
-                    Message = (pfa.Message ?? "").Replace("\r", " ").Replace("\n", " ")
+                    ReturnedDate = pfe.ActionDate,
+                    Message = (pfe.Message ?? "").Replace("\r", " ").Replace("\n", " ")
                 };
 
             var result = await query.OrderBy(r => r.ReturnedDate)


### PR DESCRIPTION
This pull request refactors several LINQ queries in the dashboard feature to simplify how contract names are retrieved and to improve query clarity and maintainability. Instead of using a subquery to look up the contract description, the code now directly joins the `Contracts` table and accesses the contract description property. Additionally, variable names have been standardized for consistency.

Query simplification and performance improvements:

* Replaced subqueries for retrieving `ContractName` with a direct left join on `Contracts` and assignment from `con.Description` in the following files:
  - `GetActivitiesAdvisoriesToProvider.cs`
  - `GetActivitiesToProvider.cs`
  - `GetEnrolmentAdvisoriesToProvider.cs`
  - `GetEnrolmentsToProvider.cs`

Code consistency and readability:

* Standardized variable names from `pfa` to `pfe` in enrolment-related queries to improve clarity and consistency across files:
  - `GetEnrolmentAdvisoriesToProvider.cs`
  - `GetEnrolmentsToProvider.cs` dashboard provider queries (GetActivitiesToProvider,
 GetActivitiesAdvisoriesToProvider, GetEnrolmentsToProvider,
 GetEnrolmentAdvisoriesToProvider) with a single left join on
 ContractId. The key change is replacing N+1-style correlated subqueries (one per row, filtering by tenant prefix and ordering by tenant ID length) with a straightforward LEFT JOIN on ContractId, which will be significantly more
efficient at the DB level.