### PR TITLE
Allows Risk-licence end date up to 30 days in the past

### DIFF
--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -276,9 +276,9 @@ public class RiskDto
                 .NotEmpty()
                 .When(x => x.NoLicenseEndDate is false)
                 .WithMessage("You must provide the license end date")
-                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? DateTime.UtcNow.Date.AddDays(-30) : DateTime.UtcNow.Date)
+                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? x.DeactivatedInFeed.Value.AddDays(-30).ToDateTime(TimeOnly.MinValue) : DateTime.UtcNow.Date)
                 .WithMessage(x => x.DeactivatedInFeed.HasValue
-                    ? "Date must be no more than 30 days in the past."
+                    ? "License/Supervision End Date must be no more than 30 days before the participant's deactivation in feed date."
                     : ValidationConstants.DateMustBeInFuture);
 
             RuleFor(x => x.PSFRestrictions)

--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -86,10 +86,13 @@ public class RiskDto
     public DateTime? ReferredOn { get; set; }
     public string[] RegistrationDetails { get; init; } = [];
 
+    public DateOnly? DeactivatedInFeed { get; set; }
+
     private class Mapping : Profile
     {
         public Mapping() =>
             CreateMap<Risk, RiskDto>(MemberList.None)
+                .ForMember(dest => dest.DeactivatedInFeed, opt => opt.MapFrom(src => src.Participant!.DeactivatedInFeed))
                 .ForMember(dest => dest.RegistrationDetails, opt => opt.MapFrom((dest, src) =>
                 {
                     string? json;
@@ -273,8 +276,10 @@ public class RiskDto
                 .NotEmpty()
                 .When(x => x.NoLicenseEndDate is false)
                 .WithMessage("You must provide the license end date")
-                .GreaterThanOrEqualTo(DateTime.UtcNow.Date)
-                .WithMessage(ValidationConstants.DateMustBeInFuture);
+                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? DateTime.UtcNow.Date.AddDays(-30) : DateTime.UtcNow.Date)
+                .WithMessage(x => x.DeactivatedInFeed.HasValue
+                    ? "Date must be no more than 30 days in the past."
+                    : ValidationConstants.DateMustBeInFuture);
 
             RuleFor(x => x.PSFRestrictions)
                 .NotEmpty()

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor
@@ -28,7 +28,7 @@
                 <MudDatePicker @bind-Date="Model.LicenseEnd"
                             Label="@Model.GetMemberDescription(x => x.LicenseEnd)"
                             For="@(() => Model.LicenseEnd)"
-                            MinDate="DateTime.UtcNow.Date"
+                            MinDate="MinLicenseEndDate"
                             Class="mt-4"
                             Editable="true"/>
             }
@@ -52,7 +52,7 @@
             <MudDatePicker @bind-Date="Model.LicenseEnd"
                         Label="@Model.GetMemberDescription(x => x.LicenseEnd)"
                         For="@(() => Model.LicenseEnd)"
-                        MinDate="DateTime.UtcNow.Date"
+                        MinDate="MinLicenseEndDate"
                         Class="mt-4"
                         Editable="true"/>
         }

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
@@ -18,6 +18,6 @@ public partial class LicenseConditions
 
     private DateTime MinLicenseEndDate =>
         Model.DeactivatedInFeed.HasValue
-            ? DateTime.UtcNow.Date.AddDays(-30)
+            ? Model.DeactivatedInFeed.Value.AddDays(-30).ToDateTime(TimeOnly.MinValue)
             : DateTime.UtcNow.Date;
 }

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
@@ -15,4 +15,9 @@ public partial class LicenseConditions
         options.IncludeProperties(x => x.LicenseEnd);
         options.IncludeProperties(x => x.NoLicenseEndDate);
     };
+
+    private DateTime MinLicenseEndDate =>
+        Model.DeactivatedInFeed.HasValue
+            ? DateTime.UtcNow.Date.AddDays(-30)
+            : DateTime.UtcNow.Date;
 }


### PR DESCRIPTION
This pull request updates the handling and validation of the license end date in participant risk data, particularly to allow dates up to 30 days in the past if the participant has been deactivated in the feed. The changes ensure both backend validation and frontend date pickers reflect this new rule, and also introduce a new property to support this logic.

Validation and business logic updates:

* The `RiskDto` class now includes a new `DeactivatedInFeed` property, mapped from the participant entity, to track when a participant was deactivated.
* Validation for the `LicenseEnd` date now allows it to be up to 30 days in the past if `DeactivatedInFeed` is set; otherwise, it must be today or a future date. The validation message is updated accordingly.

Frontend updates:

* The minimum date for the `LicenseEnd` date picker in `LicenseConditions.razor` is now dynamically set using a new `MinLicenseEndDate` property, reflecting the updated validation logic. [[1]](diffhunk://#diff-1a0465f624515e47af12e63ef9509a9d7e281f0cadbbdef2f39b61ab4985cce3L31-R31) [[2]](diffhunk://#diff-1a0465f624515e47af12e63ef9509a9d7e281f0cadbbdef2f39b61ab4985cce3L55-R55)
* The `MinLicenseEndDate` property is implemented in the code-behind to mirror the backend logic, ensuring consistency between frontend and backend validation.Allow licence end date up to 30 days in the past where license has ended for the participant i.e. Participant.DeactivatedInFeed has value