### PR TITLE
Simplifying + fixing issues with activity feedbacks

### DIFF
--- a/src/Application/Features/Activities/Commands/SubmitActivityEscalationResponse.cs
+++ b/src/Application/Features/Activities/Commands/SubmitActivityEscalationResponse.cs
@@ -83,33 +83,32 @@ public static class SubmitActivityEscalationResponse
                 {
                     EscalationResponse.Accept => FeedbackOutcome.Approved,
                     EscalationResponse.Return => FeedbackOutcome.Returned,
-                    EscalationResponse.Comment => FeedbackOutcome.EscalatedComment,
-                    _ => throw new ArgumentOutOfRangeException()
+                    _ => throw new ArgumentOutOfRangeException($"Cannot generate feedback for {response}")
                 };
                 
-                var previous = await (
-                        from q in unitOfWork.DbContext.ActivityQa2Queue
-                        where q.ActivityId == entry.ActivityId
-                              && q.IsCompleted
-                        orderby q.LastModified descending
-                        select new
-                        {
-                            Qa1User = q.CreatedBy,
-                            q.Created
-                        }
-                    )
-                    .FirstAsync(cancellationToken);
+                // get most recent QA1 for this activity
+                var qa1 = await unitOfWork.DbContext
+                            .ActivityQa1Queue
+                            .Where(x => x.ActivityId == entry.ActivityId)
+                            .Where(x => x.IsCompleted)
+                            .OrderByDescending(x => x.LastModified)
+                            .Select(x =>
+                                new {
+                                    Qa1User = x.LastModifiedBy,
+                                    Qa1Submitted = x.LastModified,
+                                    x.IsAccepted
+                                })
+                            .FirstAsync(cancellationToken);
                 
                 var activityFeedback = ActivityFeedback.Create(
                     entry.ActivityId,
                     entry.ParticipantId!,
-                    previous.Qa1User!,
+                    qa1.Qa1User!,
                     request.MessageToQa1,
+                    qa1.IsAccepted ? FeedbackOutcome.Approved : FeedbackOutcome.Returned,
                     outcome,
                     FeedbackStage.Escalation,
-                    previous.Created!.Value,
-                    request.CurrentUser!.UserId,
-                    entry.TenantId,
+                    qa1.Qa1Submitted!.Value,
                     entry.Activity!.Category.Name,
                     entry.Activity.Type.Name,
                     request.ActivityFeedbackReason

--- a/src/Application/Features/Activities/Commands/SubmitActivityQa2Response.cs
+++ b/src/Application/Features/Activities/Commands/SubmitActivityQa2Response.cs
@@ -85,20 +85,32 @@ public static class SubmitActivityQa2Response
                 {
                     Qa2Response.Accept => FeedbackOutcome.Approved,
                     Qa2Response.Return => FeedbackOutcome.Returned,
-                    Qa2Response.Escalate => FeedbackOutcome.Escalated,
-                    _ => throw new ArgumentOutOfRangeException()
+                    _ => throw new ArgumentOutOfRangeException($"Cannot generate feedback for {response}")
                 };
+
+                  // get most recent QA1 for this activity
+                var qa1 = await unitOfWork.DbContext
+                            .ActivityQa1Queue
+                            .Where(x => x.ActivityId == entry.ActivityId)
+                            .Where(x => x.IsCompleted)
+                            .OrderByDescending(x => x.LastModified)
+                            .Select(x =>
+                                new {
+                                    Qa1User = x.LastModifiedBy,
+                                    Qa1Submitted = x.LastModified,
+                                    x.IsAccepted
+                                })
+                            .FirstAsync(cancellationToken);
                 
                 var activityFeedback = ActivityFeedback.Create(
                     entry.ActivityId,
                     entry.ParticipantId!,
-                    entry.CreatedBy!,
+                    qa1.Qa1User!,
                     request.MessageToQa1,
+                    qa1.IsAccepted ? FeedbackOutcome.Approved : FeedbackOutcome.Returned,
                     outcome,
                     FeedbackStage.Qa2,
-                    entry.Created!.Value,
-                    request.CurrentUser!.UserId,
-                    entry.TenantId,
+                    qa1.Qa1Submitted!.Value,
                     entry.Activity!.Category.Name,
                     entry.Activity.Type.Name,
                     request.ActivityFeedbackReason!

--- a/src/Application/Features/Dashboard/Queries/GetActivitiesFeedback.cs
+++ b/src/Application/Features/Dashboard/Queries/GetActivitiesFeedback.cs
@@ -25,31 +25,24 @@ public static class GetActivitiesFeedback
         {
             var context = unitOfWork.DbContext;
 
-               var query =
+            var query =
                 from afb in context.ActivityFeedbacks.AsNoTracking()
 
                 join p in context.Participants on afb.ParticipantId equals p.Id
-                join ru in context.Users on afb.RecipientUserId equals ru.Id into ruJoin
+                join ru in context.Users on afb.OwnerId equals ru.Id into ruJoin
                 from ru in ruJoin.DefaultIfEmpty()
 
                 join cu in context.Users on afb.CreatedBy equals cu.Id into cuJoin
                 from cu in cuJoin.DefaultIfEmpty()
 
-                where afb.ActivityProcessedDate >= request.StartDate.Date
-                      && afb.ActivityProcessedDate < request.EndDate.AddDays(1).Date
-                      && afb.TenantId.StartsWith(request.CurrentUser.TenantId!)
-                      && (request.UserId == null || afb.RecipientUserId == request.UserId)
+                where afb.Created >= request.StartDate.Date
+                        && afb.Created < request.EndDate.AddDays(1).Date
+                        && (request.UserId == null || afb.OwnerId == request.UserId)
         
                 select new { afb, p, ru, cu };
 
-            if (!string.IsNullOrWhiteSpace(request.TenantId))
-            {
-                query = query.Where(x =>
-                    x.afb.TenantId.StartsWith(request.TenantId));
-            }
-
             var tabularData = await query
-                .OrderBy(x => x.afb.ActivityProcessedDate)
+                .OrderBy(x => x.afb.Qa1Date)
                 .Select(x => new ActivitiesFeedbackTabularData
                 {
                     Id = x.afb.Id,
@@ -63,7 +56,7 @@ public static class GetActivitiesFeedback
                     ActivityFeedbackReason = x.afb.ActivityFeedbackReason,
 
                     Queue = x.afb.Stage.Name ?? "Unknown",
-
+                    Qa1Outcome = x.afb.Qa1Outcome.Name,
                     Outcome = x.afb.Outcome.Name,
 
                     QaUser = x.cu != null
@@ -72,11 +65,8 @@ public static class GetActivitiesFeedback
 
                     Created = x.afb.Created, 
 
-                    ActivityProcessedDate = x.afb.ActivityProcessedDate,
-
-                    //LastModified = x.afb.LastModified ?? x.afb.Created,
-                    IsAccepted = x.afb.Outcome == FeedbackOutcome.Approved ? "Yes" : "No",
-                    
+                    ActivityProcessedDate = x.afb.Qa1Date,
+ 
                     IsRead = x.afb.IsRead,
                     Message = x.afb.Message
                 })
@@ -126,6 +116,7 @@ public static class GetActivitiesFeedback
 
         public required string Queue { get; init; }
         
+        public required string Qa1Outcome { get; init; }
         public required string Outcome { get; init; }
         public required string QaUser { get; init; }
        
@@ -133,7 +124,6 @@ public static class GetActivitiesFeedback
         public DateTime? Created { get; init; } 
         public DateTime ActivityProcessedDate { get; init; }
 
-        public required string IsAccepted { get; init; }
         public required string Message { get; init; }
         public required bool IsRead { get; set; }
     }

--- a/src/Database/CatsDb/Mi/Tables/ActivityFeedback.sql
+++ b/src/Database/CatsDb/Mi/Tables/ActivityFeedback.sql
@@ -1,15 +1,14 @@
-CREATE TABLE [Activities].[ActivityFeedback] (
+CREATE TABLE [Mi].[ActivityFeedback] (
     [Id]                            UNIQUEIDENTIFIER    NOT NULL,
     [ActivityId]                    UNIQUEIDENTIFIER    NOT NULL,
     [ParticipantId]                 NVARCHAR (9)        NOT NULL,
-    [RecipientUserId]               NVARCHAR (36)       NOT NULL,
     [Message]                       NVARCHAR (1000)     NOT NULL,
+    [Qa1Outcome]                    INT                 NOT NULL,
     [Outcome]                       INT                 NOT NULL,
     [Stage]                         INT                 NOT NULL,
-    [ActivityProcessedDate]         DATETIME2           NOT NULL,
+    [Qa1Date]                       DATETIME2           NOT NULL,
     [IsRead]                        BIT                 NOT NULL,
     [ReadAt]                        DATETIME2           NULL,
-    [TenantId]                      NVARCHAR (50)       NOT NULL,
     [Created]                       DATETIME2           NOT NULL,
     [CreatedBy]                     NVARCHAR (36)       NOT NULL,
     [LastModified]                  DATETIME2           NULL,
@@ -23,80 +22,66 @@ CREATE TABLE [Activities].[ActivityFeedback] (
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [FK_ActivityFeedback_Activity_ActivityId] FOREIGN KEY ( [ActivityId] ) REFERENCES [Activities].[Activity] ( [Id] );
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [FK_ActivityFeedback_Participant_ParticipantId] FOREIGN KEY ( [ParticipantId] ) REFERENCES [Participant].[Participant] ( [Id] );
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
-    ADD CONSTRAINT [FK_ActivityFeedback_Tenant_TenantId] FOREIGN KEY ( [TenantId] ) REFERENCES [Configuration].[Tenant] ( [Id] );
-
-GO
-
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [FK_ActivityFeedback_User_CreatedBy] FOREIGN KEY ( [CreatedBy] ) REFERENCES [Identity].[User] ( [Id] );
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [FK_ActivityFeedback_User_EditorId] FOREIGN KEY ( [EditorId] ) REFERENCES [Identity].[User] ( [Id] );
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [FK_ActivityFeedback_User_OwnerId] FOREIGN KEY ( [OwnerId] ) REFERENCES [Identity].[User] ( [Id] );
 
 GO
 
-ALTER TABLE [Activities].[ActivityFeedback] 
-    ADD CONSTRAINT [FK_ActivityFeedback_User_RecipientUserId] FOREIGN KEY ( [RecipientUserId] ) REFERENCES [Identity].[User] ( [Id] );
-
-GO
-
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_ActivityId]
-    ON [Activities].[ActivityFeedback] ([ActivityId] ASC);
+    ON [Mi].[ActivityFeedback] ([ActivityId] ASC);
 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_ActivityId_Created]
-    ON [Activities].[ActivityFeedback] ([ActivityId] ASC, [Created] ASC);
+    ON [Mi].[ActivityFeedback] ([ActivityId] ASC, [Created] ASC);
 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_CreatedBy]
-    ON [Activities].[ActivityFeedback] ([CreatedBy] ASC);
+    ON [Mi].[ActivityFeedback] ([CreatedBy] ASC);
 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_EditorId]
-    ON [Activities].[ActivityFeedback] ([EditorId] ASC);
+    ON [Mi].[ActivityFeedback] ([EditorId] ASC);
 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_OwnerId]
-    ON [Activities].[ActivityFeedback] ([OwnerId] ASC);
+    ON [Mi].[ActivityFeedback] ([OwnerId] ASC);
 
 GO
 
 CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_ParticipantId]
-    ON [Activities].[ActivityFeedback] ([ParticipantId] ASC);
+    ON [Mi].[ActivityFeedback] ([ParticipantId] ASC);
 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_RecipientUserId_IsRead]
-    ON [Activities].[ActivityFeedback] ([RecipientUserId] ASC, [IsRead] ASC);
+CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_OwnerId_IsRead]
+    ON [Mi].[ActivityFeedback] ([OwnerId] ASC, [IsRead] ASC);
 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_ActivityFeedback_TenantId]
-    ON [Activities].[ActivityFeedback] ([TenantId] ASC);
 
-GO
-
-ALTER TABLE [Activities].[ActivityFeedback] 
+ALTER TABLE [Mi].[ActivityFeedback] 
     ADD CONSTRAINT [PK_ActivityFeedback] PRIMARY KEY CLUSTERED ([Id] ASC);

--- a/src/Domain/Common/Enums/FeedbackOutcome.cs
+++ b/src/Domain/Common/Enums/FeedbackOutcome.cs
@@ -6,11 +6,9 @@ public sealed class FeedbackOutcome : SmartEnum<FeedbackOutcome>
 {
     public static readonly FeedbackOutcome Approved = new("Approved", 0);
     public static readonly FeedbackOutcome Returned = new("Returned", 1);
-    public static readonly FeedbackOutcome Escalated = new("Escalated", 2);
-    public static readonly FeedbackOutcome EscalatedComment = new(" Comment", 3);
-    
     private FeedbackOutcome(string name, int value)
         : base(name, value)
     {
     }
+
 }

--- a/src/Domain/Entities/Activities/ActivityFeedback.cs
+++ b/src/Domain/Entities/Activities/ActivityFeedback.cs
@@ -1,39 +1,27 @@
 using Cfo.Cats.Domain.Common.Entities;
 using Cfo.Cats.Domain.Common.Enums;
-using Cfo.Cats.Domain.Entities.Administration;
-using Cfo.Cats.Domain.Entities.Participants;
 using Cfo.Cats.Domain.Events;
-using Cfo.Cats.Domain.Identity;
 
 namespace Cfo.Cats.Domain.Entities.Activities;
 
 public class ActivityFeedback : OwnerPropertyEntity<Guid>
 {
-    public Guid ActivityId { get; init; }
-    public string ParticipantId { get; init; }
+    public Guid ActivityId { get; private set; }
+    public string ParticipantId { get; private set; }
+    public string Message { get; private set; } 
 
-    public string RecipientUserId { get; init; }
-    public ApplicationUser? RecipientUser { get; init; }
+    public FeedbackOutcome Qa1Outcome { get; private set;}
 
-    public string Message { get; init; } = null!;
+    public DateTime Qa1Date { get;set; }
 
     public FeedbackOutcome Outcome { get; private set; }
-    public FeedbackStage Stage { get; init; }
-
-    public DateTime ActivityProcessedDate { get; init; }
-
+    public FeedbackStage Stage { get; private set; }
     public bool IsRead { get; private set; }
     public DateTime? ReadAt { get; private set; }
-    public string TenantId { get; protected init; }
-    public ApplicationUser? CreatedByUser { get; private set; }
     public required string ActivityCategory { get; init; }
     public required string ActivityType { get; init; } 
     public required string ActivityFeedbackReason { get; init; } 
     
-    public virtual Activity? Activity { get; private set; }
-    public virtual Participant? Participant { get; protected init; }
-    public virtual Tenant? Tenant { get; init; }
-
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     private ActivityFeedback()
     {
@@ -43,13 +31,12 @@ public class ActivityFeedback : OwnerPropertyEntity<Guid>
     public static ActivityFeedback Create(
         Guid activityId,
         string participantId,
-        string recipientUserId,
+        string qa1UserId,
         string message,
+        FeedbackOutcome qa1Outcome,
         FeedbackOutcome outcome,
         FeedbackStage stage,
-        DateTime activityProcessedDate,
-        string createdBy,
-        string tenantId,
+        DateTime qa1Date,
         string activityCategory,
         string activityType,
         string activityFeedbackReason)
@@ -59,18 +46,16 @@ public class ActivityFeedback : OwnerPropertyEntity<Guid>
             Id = Guid.CreateVersion7(),
             ActivityId = activityId,
             ParticipantId = participantId,
-            RecipientUserId = recipientUserId,
+            OwnerId = qa1UserId,
             Message = message,
             Outcome = outcome,
             Stage = stage,
-            ActivityProcessedDate = activityProcessedDate,
-            CreatedBy = createdBy,
-            Created = DateTime.UtcNow,
+            Qa1Date = qa1Date,
             IsRead = false,
-            TenantId = tenantId,
             ActivityCategory = activityCategory,
             ActivityType = activityType,
-            ActivityFeedbackReason = activityFeedbackReason
+            ActivityFeedbackReason = activityFeedbackReason,
+            Qa1Outcome = qa1Outcome
         };
 
         feedback.AddDomainEvent(

--- a/src/Infrastructure/Persistence/Configurations/Activities/ActivityFeedbackEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Activities/ActivityFeedbackEntityTypeConfiguration.cs
@@ -13,7 +13,7 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
     {
         builder.ToTable(
             DatabaseConstants.Tables.ActivityFeedback,
-            DatabaseConstants.Schemas.Activities);
+            DatabaseConstants.Schemas.Mi);
 
         // --------------------
         // Key
@@ -35,7 +35,7 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
             .IsRequired()
             .HasMaxLength(DatabaseConstants.FieldLengths.ParticipantId);
 
-        builder.Property(x => x.RecipientUserId)
+        builder.Property(x => x.OwnerId)
             .IsRequired()
             .HasMaxLength(DatabaseConstants.FieldLengths.GuidId);
 
@@ -43,7 +43,7 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
             .IsRequired()
             .HasMaxLength(ValidationConstants.NotesLength);
 
-        builder.Property(x => x.ActivityProcessedDate)
+        builder.Property(x => x.Qa1Date)
             .IsRequired();
 
         builder.Property(x => x.IsRead)
@@ -68,6 +68,13 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
         // SmartEnum mappings 
         // --------------------
 
+        builder.Property(x => x.Qa1Outcome)
+            .IsRequired()
+            .HasConversion(
+                o => o.Value,
+                o => FeedbackOutcome.FromValue(0)
+            );
+
         builder.Property(x => x.Outcome)
             .IsRequired()
             .HasConversion(
@@ -80,39 +87,6 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
                 s => s.Value,
                 s => FeedbackStage.FromValue(s));
 
-        // --------------------
-        // Relationships
-        // --------------------
-
-        builder.HasOne(x => x.Activity)
-            .WithMany()
-            .HasForeignKey(x => x.ActivityId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder.HasOne(x => x.Participant)
-            .WithMany()
-            .HasForeignKey(x => x.ParticipantId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder.HasOne(x => x.RecipientUser)
-            .WithMany()
-            .HasForeignKey(x => x.RecipientUserId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder.HasOne(x => x.CreatedByUser)
-            .WithMany()
-            .HasForeignKey(x => x.CreatedBy)
-            .OnDelete(DeleteBehavior.Restrict);
-        
-        builder.HasOne(x => x.Tenant)
-            .WithMany()
-            .HasForeignKey(x => x.TenantId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder.Property(x => x.TenantId)
-            .IsRequired()
-            .HasMaxLength(DatabaseConstants.FieldLengths.TenantId);
-        
         // --------------------
         // Owner / Editor 
         // --------------------
@@ -144,13 +118,5 @@ internal sealed class ActivityFeedbackEntityTypeConfiguration
         builder.Property(x => x.LastModifiedBy)
             .HasMaxLength(DatabaseConstants.FieldLengths.GuidId);
 
-        // --------------------
-        // Indexes 
-        // --------------------
-
-        builder.HasIndex(x => x.ActivityId);
-        builder.HasIndex(x => new { x.RecipientUserId, x.IsRead });
-        builder.HasIndex(x => new { x.ActivityId, x.Created });
-        builder.HasIndex(x => x.TenantId);
     }
 }

--- a/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor
+++ b/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor
@@ -25,18 +25,15 @@
                                   Title="My Feedback by Reason"
                                   Options="Options"
                                   Height="650" Width="@("100%")">
-                
-                @foreach (var series in SeriesByReason)
-                {
-                    <ApexCharts.ApexPointSeries
-                        TItem="GetActivitiesFeedback.ActivitiesFeedbackChartData"
-                        Items="@series.Items"
-                        SeriesType="ApexCharts.SeriesType.Bar"
-                        Name="@series.Reason"
-                        XValue="e => e.Recipient"
-                        YValue="e => e.Count"
-                        ShowDataLabels="true"/>
-                }
+
+                <ApexCharts.ApexPointSeries
+                    TItem="GetActivitiesFeedback.ActivitiesFeedbackChartData"
+                    Items="@PieDataByReason"
+                    SeriesType="ApexCharts.SeriesType.Pie"
+                    Name="Reason"
+                    XValue="e => e.ActivityFeedbackReason"
+                    YValue="e => e.Count"
+                    ShowDataLabels="true"/>
 
             </ApexCharts.ApexChart>
     }

--- a/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor
+++ b/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor
@@ -55,7 +55,7 @@
                 <MudTh></MudTh>
                 <MudTh>Participant</MudTh>
                 <MudTh>Queue</MudTh>
-                <MudTh>Accepted</MudTh>
+                <MudTh>Qa1 Outcome</MudTh>
                 <MudTh>Outcome</MudTh>
                 <MudTh>Reason</MudTh>
                 <MudTh>Category</MudTh>
@@ -84,7 +84,7 @@
                     </MudStack>
                 </MudTd>
                 <MudTd>@context.Queue</MudTd>
-                <MudTd>@context.IsAccepted</MudTd>
+                <MudTd>@context.Qa1Outcome</MudTd>
                 <MudTd>@context.Outcome </MudTd>
                 <MudTd>@context.ActivityFeedbackReason</MudTd>
                 <MudTd>            

--- a/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackComponent.razor.cs
@@ -3,6 +3,7 @@ using Cfo.Cats.Application.Features.Dashboard.Queries;
 using Microsoft.AspNetCore.Components.Authorization;
 using ApexCharts;
 using Cfo.Cats.Application.Features.Activities.Commands;
+using ChartType = ApexCharts.ChartType;
 using Color = MudBlazor.Color;
 
 namespace Cfo.Cats.Server.UI.Components.Dashboard.QA;
@@ -42,41 +43,21 @@ public partial class ActivitiesFeedbackComponent
             ShowRead = ShowRead
         };
 
-    private List<ChartSeries> SeriesByReason
+    private List<GetActivitiesFeedback.ActivitiesFeedbackChartData> PieDataByReason
     {
         get
         {
             var data = Data?.ChartData ?? Array.Empty<GetActivitiesFeedback.ActivitiesFeedbackChartData>();
 
-            var recipients = data
-                .Select(x => x.Recipient ?? "Unknown")
-                .Distinct()
-                .OrderBy(x => x)
-                .ToList();
-
-            var reasons = data
-                .Select(x => x.ActivityFeedbackReason ?? "Unknown")
-                .Distinct()
-                .OrderBy(x => x)
-                .ToList();
-
-            return reasons.Select(reason => new ChartSeries
+            return data
+                .GroupBy(x => x.ActivityFeedbackReason ?? "Unknown")
+                .OrderBy(g => g.Key)
+                .Select(g => new GetActivitiesFeedback.ActivitiesFeedbackChartData
             {
-                Reason = reason,
-                Items = recipients.Select(recipient =>
-                {
-                    var match = data.FirstOrDefault(x =>
-                        (x.Recipient ?? "Unknown") == recipient &&
-                        (x.ActivityFeedbackReason ?? "Unknown") == reason);
-
-                    return new GetActivitiesFeedback.ActivitiesFeedbackChartData
-                    {
-                        Recipient = recipient,
-                        ActivityFeedbackReason = reason,
-                        Count = match?.Count ?? 0
-                    };
-                }).ToList()
-            }).ToList();
+                ActivityFeedbackReason = g.Key,
+                Count = g.Sum(x => x.Count)
+            })
+            .ToList();
         }
     }
     
@@ -96,43 +77,12 @@ public partial class ActivitiesFeedbackComponent
         }
     }
     
-    private class ChartSeries
-    {
-        public string Reason { get; init; } = null!;
-        public List<GetActivitiesFeedback.ActivitiesFeedbackChartData> Items { get; set; } = new();
-    }
-    
     private ApexChartOptions<GetActivitiesFeedback.ActivitiesFeedbackChartData> Options
         => new()
         {
             Chart = new Chart
             {
-                Stacked = true
-            },
-            PlotOptions = new PlotOptions
-            {
-                Bar = new PlotOptionsBar
-                {
-                    DataLabels = new PlotOptionsBarDataLabels
-                    {
-                        Total = new BarTotalDataLabels
-                        {
-                            Style = new BarDataLabelsStyle
-                            {
-                                FontWeight = "800",
-                                Color = IsDarkMode ? "#FFFFFF" : "#000000"
-                            }
-                        }
-                    }
-                }
-            },
-            Yaxis = new List<YAxis>
-            {
-                new()
-                {
-                    Min = 0,
-                    ForceNiceScale = true
-                }
+                Type = ChartType.Pie
             },
             Theme = new Theme
             {

--- a/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackSeniorComponent.razor
+++ b/src/Server.UI/Components/Dashboard/QA/ActivitiesFeedbackSeniorComponent.razor
@@ -56,7 +56,7 @@
                 <MudTh>Queue</MudTh>
                 <MudTh>Recipient</MudTh>
                 <MudTh>Feedback User</MudTh>
-                <MudTh>Accepted</MudTh>
+                <MudTh>Qa1 Outcome</MudTh>
                 <MudTh>Outcome</MudTh>
                 <MudTh>Reason</MudTh>
                 <MudTh>Category</MudTh>
@@ -87,7 +87,7 @@
                 <MudTd>@context.Queue</MudTd>
                 <MudTd>@context.RecipientUser</MudTd>
                 <MudTd>@context.QaUser</MudTd>
-                <MudTd>@context.IsAccepted</MudTd>
+                <MudTd>@context.Qa1Outcome</MudTd>
                 <MudTd>@context.Outcome </MudTd>
                 <MudTd>@context.ActivityFeedbackReason</MudTd>
                 <MudTd>            


### PR DESCRIPTION
This pull request introduces significant changes to the `ActivityFeedback` domain model, its database schema, and related application logic. The main focus is on refactoring the feedback tracking process to better capture QA1 outcomes, simplify ownership and recipient logic, and align the data model and queries with these changes. The database table is also moved to a new schema. Below are the most important changes:

**Domain Model and Application Logic Refactoring:**

* The `ActivityFeedback` entity now tracks the QA1 outcome and submission date directly (`Qa1Outcome`, `Qa1Date`), and uses `OwnerId` (formerly `RecipientUserId`) to represent the QA1 user. Several properties related to tenants and recipients have been removed. The `Create` method and related logic have been updated to use these new fields. [[1]](diffhunk://#diff-753ab4add31e32e5b7fb75eea64de248111d43a19327e0f34b764d58e8817c6cL3-L36) [[2]](diffhunk://#diff-753ab4add31e32e5b7fb75eea64de248111d43a19327e0f34b764d58e8817c6cL46-R39) [[3]](diffhunk://#diff-753ab4add31e32e5b7fb75eea64de248111d43a19327e0f34b764d58e8817c6cL62-R58)
* The `FeedbackOutcome` enum has been simplified, removing the `Escalated` and `EscalatedComment` values.
* In the submit handlers for activity escalation and QA2 responses, logic is updated to fetch the latest completed QA1 entry for feedback creation, and to set the QA1 outcome and date appropriately. [[1]](diffhunk://#diff-6f8da8bdd9f6a07ceff5e5d0a36e6a97369e1591ece1ee2c8a59637ccbb05ab4L86-R111) [[2]](diffhunk://#diff-b375381b38f1285b3762c47fb752702a04bfb20234731492a8f468028e189c37L88-R113)

**Database Schema Changes:**

* The `ActivityFeedback` table is moved from the `Activities` schema to the `Mi` schema, with several fields removed (`RecipientUserId`, `TenantId`, `ActivityProcessedDate`) and new fields added (`Qa1Outcome`, `Qa1Date`). Foreign key and index definitions are updated accordingly. [[1]](diffhunk://#diff-f7ed7df27a3fe56e2c771e52b251a3523c34884c920ad029757600ac551a4afaL1-L12) [[2]](diffhunk://#diff-f7ed7df27a3fe56e2c771e52b251a3523c34884c920ad029757600ac551a4afaL26-R86)
* The entity configuration is updated to match the new schema, field names, and relationships. Redundant relationships and indexes are removed. [[1]](diffhunk://#diff-760afd12bd8fe8a3646751acdb2122f97246e30c8f2c43888488988838863166L16-R16) [[2]](diffhunk://#diff-760afd12bd8fe8a3646751acdb2122f97246e30c8f2c43888488988838863166L38-R46) [[3]](diffhunk://#diff-760afd12bd8fe8a3646751acdb2122f97246e30c8f2c43888488988838863166R71-R77) [[4]](diffhunk://#diff-760afd12bd8fe8a3646751acdb2122f97246e30c8f2c43888488988838863166L83-L115) [[5]](diffhunk://#diff-760afd12bd8fe8a3646751acdb2122f97246e30c8f2c43888488988838863166L147-L154)

**Dashboard and Query Adjustments:**

* The activities feedback query now uses `OwnerId` instead of `RecipientUserId`, and filters/orders by `Created` and `Qa1Date` rather than the old fields. The tabular data DTO is updated to include `Qa1Outcome` and no longer contains the `IsAccepted` field. [[1]](diffhunk://#diff-ddfb3617e6358030248b61cb40359fc7e152a216e0f5255473e153a1179a1ad6L32-R45) [[2]](diffhunk://#diff-ddfb3617e6358030248b61cb40359fc7e152a216e0f5255473e153a1179a1ad6L66-R59) [[3]](diffhunk://#diff-ddfb3617e6358030248b61cb40359fc7e152a216e0f5255473e153a1179a1ad6L75-R68) [[4]](diffhunk://#diff-ddfb3617e6358030248b61cb40359fc7e152a216e0f5255473e153a1179a1ad6R119-L136)

These changes collectively improve the traceability and accuracy of feedback records, streamline the data model, and ensure the application logic is consistent with the new structure.