### PR TITLE
Fix Aspire load order by waiting for database seeding completion

### DIFF
--- a/src/Aspire/Cats.AppHost/Cats.AppHost.csproj
+++ b/src/Aspire/Cats.AppHost/Cats.AppHost.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Aspire.AppHost.Sdk/13.2.0">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <IsAspireHost>true</IsAspireHost>
-    <UserSecretsId>438e0658-688c-449c-b0b7-c8940c972575</UserSecretsId>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <IsAspireHost>true</IsAspireHost>
+        <UserSecretsId>438e0658-688c-449c-b0b7-c8940c972575</UserSecretsId>
+        <NoWarn>$(NoWarn);ASPIRE004</NoWarn>
+    </PropertyGroup>
 
-  <ItemGroup>
-      <PackageReference Include="Aspire.Hosting.Kubernetes" />
-      <PackageReference Include="Aspire.Hosting.RabbitMQ" />
-      <PackageReference Include="Aspire.Hosting.SqlServer" />
-      <PackageReference Include="CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Aspire.Hosting.Kubernetes"/>
+        <PackageReference Include="Aspire.Hosting.RabbitMQ"/>
+        <PackageReference Include="Aspire.Hosting.SqlServer"/>
+        <PackageReference Include="CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\DatabaseSeeding\DatabaseSeeding.csproj" />
-    <ProjectReference Include="..\..\Server.UI\Server.UI.csproj" />
-    <ProjectReference Include="..\..\Database\CatsDb\CatsDb.sqlproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\DatabaseSeeding\DatabaseSeeding.csproj"/>
+        <ProjectReference Include="..\..\Server.UI\Server.UI.csproj"/>
+        <ProjectReference Include="..\..\Database\CatsDb\CatsDb.sqlproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -16,7 +16,7 @@ internal static class AppExtensions
     private static IResourceBuilder<ProjectResource> WithCatsDatabaseReference(this IResourceBuilder<ProjectResource> builder, CatsDatabaseResource database)
     {
         builder.WithReference(database.DatabaseResource)
-            .WaitForCompletion(database.SqlProjectResource);
+            .WaitForCompletion(database.SeedingProjectResource);
         return builder;
     }
 }

--- a/src/Aspire/Cats.AppHost/Extensions/CatsDatabaseResource.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/CatsDatabaseResource.cs
@@ -1,0 +1,7 @@
+namespace Cats.AppHost.Extensions;
+
+internal record CatsDatabaseResource(
+    IResourceBuilder<SqlServerDatabaseResource> DatabaseResource,
+    IResourceBuilder<SqlProjectResource> SqlProjectResource,
+    IResourceBuilder<ProjectResource> SeedingProjectResource
+);

--- a/src/Aspire/Cats.AppHost/Extensions/CatsDatabaseResources.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/CatsDatabaseResources.cs
@@ -1,0 +1,5 @@
+namespace Cats.AppHost.Extensions;
+
+internal record CatsDatabaseResources(
+    CatsDatabaseResource CatsDb
+);

--- a/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
@@ -14,8 +14,7 @@ internal static class DatabaseExtensions
 
     internal static CatsDatabaseResources AddCatsDatabases(
         this IDistributedApplicationBuilder builder,
-        IResourceBuilder<SqlServerServerResource> sqlServer,
-        bool seedData = false
+        IResourceBuilder<SqlServerServerResource> sqlServer
     )
     {
         var catsDb = sqlServer.AddDatabase("CatsDb");
@@ -24,25 +23,10 @@ internal static class DatabaseExtensions
                                 .WithReference(catsDb)
                                 .WithSkipWhenDeployed();
 
-        if (seedData)
-        {
-            builder.AddProject<DatabaseSeeding>("DatabaseSeeding")
-                .WithReference(catsDb)
-                .WaitForCompletion(catsDbSqlProj);
+        var seeding = builder.AddProject<DatabaseSeeding>("DatabaseSeeding")
+            .WithReference(catsDb)
+            .WaitForCompletion(catsDbSqlProj);
 
-        }
-
-        return new CatsDatabaseResources(new CatsDatabaseResource(catsDb, catsDbSqlProj));
+        return new CatsDatabaseResources(new CatsDatabaseResource(catsDb, catsDbSqlProj, seeding));
     }
-
-    
 }
-
-internal record CatsDatabaseResources(
-        CatsDatabaseResource CatsDb
-    );
-
-    internal record CatsDatabaseResource(
-        IResourceBuilder<SqlServerDatabaseResource> DatabaseResource,
-        IResourceBuilder<SqlProjectResource> SqlProjectResource
-    );

--- a/src/Aspire/Cats.AppHost/Program.cs
+++ b/src/Aspire/Cats.AppHost/Program.cs
@@ -6,7 +6,7 @@ var sqlPassword = builder.AddParameter("sqlPassword", secret: true);
 
 var sql = builder.AddCatsSqlServer(sqlPassword);
 
-var databases = builder.AddCatsDatabases(sql, seedData: true);
+var databases = builder.AddCatsDatabases(sql);
 
 var rabbit = builder.AddRabbitMQ("rabbit",
         port: 5672)


### PR DESCRIPTION
This pull request refactors how database resources are defined and initialized in the `Cats.AppHost` project, focusing on improving the handling of database seeding and resource references. The changes simplify and clarify the code structure for managing database resources, particularly by always including the seeding project and updating related references.

**Database resource management improvements:**

* Refactored the `CatsDatabaseResource` and `CatsDatabaseResources` records to always include the `SeedingProjectResource`, ensuring the seeding project is consistently part of the database resource group. [[1]](diffhunk://#diff-9720a67e892390104f8f2c15fa02397ada98b499f0f34fc08781f4e92a1beef2R1-R7) [[2]](diffhunk://#diff-0d3ea7eca90cff0b5a5405caa8a92b83ac7109b4600d57ec92f2cef6b0264eceR1-R5)
* Updated the `AddCatsDatabases` method in `DatabaseExtensions.cs` to always add the seeding project and return it as part of the `CatsDatabaseResource`, removing the `seedData` parameter for simplicity. [[1]](diffhunk://#diff-9c40bbf8feb667dcd53a511f0c0ba010f93e45eebd4d6868c5d5ba768973ff75L17-R17) [[2]](diffhunk://#diff-9c40bbf8feb667dcd53a511f0c0ba010f93e45eebd4d6868c5d5ba768973ff75L27-L48)
* Changed the call to `AddCatsDatabases` in `Program.cs` to remove the now-unnecessary `seedData` argument.

**Resource dependency and warning handling:**

* Modified the `WithCatsDatabaseReference` extension method to depend on the `SeedingProjectResource` instead of the `SqlProjectResource`, ensuring correct dependency ordering.
* Suppressed the `ASPIRE004` warning in the `Cats.AppHost.csproj` file to reduce noise from known, non-critical issues.