### PR TITLE
Harden aspire to use SHA for docker dependencies

### DIFF
--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -9,7 +9,8 @@ internal static class AppExtensions
     {
         builder.AddProject<Projects.Server_UI>("cats")
         .WithCatsDatabaseReference(databases.CatsDb)
-        .WithReference(rabbit);
+        .WithReference(rabbit)
+        .WaitFor(rabbit);        
         return builder;
     }
 
@@ -18,5 +19,17 @@ internal static class AppExtensions
         builder.WithReference(database.DatabaseResource)
             .WaitForCompletion(database.SeedingProjectResource);
         return builder;
+    }
+    public static IResourceBuilder<RabbitMQServerResource> AddMessageBroker(this IDistributedApplicationBuilder builder)
+    {
+        var rabbit = builder.AddRabbitMQ("rabbit", port: 5672)
+            // 4.3.0-management-alpine
+            .WithImageSHA256("8724c6573b43d315bcec914f16a509d0b5faf5f3b281a832b484ece0bbcbe914")
+            .WithDataVolume("cats-aspire-rabbit")
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithHttpEndpoint(port: 15672, targetPort: 15672);            
+
+        return rabbit;
+
     }
 }

--- a/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
@@ -10,8 +10,9 @@ internal static class DatabaseExtensions
             .WithDataVolume("cats-data")
             .WithLifetime(ContainerLifetime.Persistent)
             .WithEndpointProxySupport(false)
-            .WithImageTag("2022-latest");
-
+            // 2022-CU24-ubuntu-22.04
+            .WithImageSHA256("49b45a911dc535e9345fbfd7101a1bd8a1e190a5f29b877ef75387a061e5fcf0");
+    
     internal static CatsDatabaseResources AddCatsDatabases(
         this IDistributedApplicationBuilder builder,
         IResourceBuilder<SqlServerServerResource> sqlServer

--- a/src/Aspire/Cats.AppHost/Program.cs
+++ b/src/Aspire/Cats.AppHost/Program.cs
@@ -8,11 +8,7 @@ var sql = builder.AddCatsSqlServer(sqlPassword);
 
 var databases = builder.AddCatsDatabases(sql);
 
-var rabbit = builder.AddRabbitMQ("rabbit",
-        port: 5672)
-    .WithDataVolume("cats-aspire-rabbit")
-    .WithLifetime(ContainerLifetime.Persistent)
-    .WithManagementPlugin(port: 15672);
+var rabbit = builder.AddMessageBroker();
 
 builder.AddCatsServices(
     rabbit, 


### PR DESCRIPTION
This pull request refactors how the RabbitMQ message broker is configured and referenced in the application, and updates the SQL Server image version for consistency and security. The main improvements include introducing a new extension method for adding RabbitMQ, ensuring dependent services wait for RabbitMQ to be ready, and specifying image digests for both RabbitMQ and SQL Server containers.

**Message broker configuration improvements:**

* Introduced a new `AddMessageBroker` extension method in `AppExtensions.cs` to encapsulate the RabbitMQ setup, including image SHA256, data volume, container lifetime, and management endpoint configuration. This replaces the previous inline RabbitMQ setup in `Program.cs` for better maintainability and reuse. [[1]](diffhunk://#diff-ed8725bf69e2e1e610c1638e9c8c0fd2f7886dabf875681d957ec61837f514b3R23-R34) [[2]](diffhunk://#diff-0ca06f27dbdc306e8b9f87d3dc6fab07f57f6751f7c31b532ee1049291251d3fL11-R11)
* Updated the call in `Program.cs` to use the new `AddMessageBroker` method, simplifying the main program logic.

**Dependency management:**

* Modified the `AddCatsServices` extension method to call `.WaitFor(rabbit)`, ensuring that the Cats services wait for RabbitMQ to be ready before starting, which improves reliability during startup.

**Container image specification:**

* Updated the SQL Server container configuration in `DatabaseExtensions.cs` to use a specific image SHA256 for `2022-CU24-ubuntu-22.04`, improving consistency and security over using a mutable image tag.
* Specified the RabbitMQ container image SHA256 (`4.3.0-management-alpine`) in the new `AddMessageBroker` method for the same reasons.

These changes improve reliability, security, and maintainability of the application's infrastructure setup.