### PR TITLE
Update CI Pipeline to support develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,12 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
       time: "04:00"
     cooldown:
       default-days: 7
 
-    target-branch: "main"
+    target-branch: "develop"
 
     commit-message:
       prefix: "deps"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,20 +1,26 @@
 name: Create new release
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 
 permissions:
   contents: write   # required for pushing tags & publishing releases
 
 jobs:
   build-and-release:
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout current branch
+      - name: Checkout merged commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Setup .NET
@@ -38,7 +44,7 @@ jobs:
       - name: Create Git Tag and Push
         run: |
           set -euo pipefail
-          git tag "${{ steps.version.outputs.tag }}" "${{ github.sha }}"
+          git tag "${{ steps.version.outputs.tag }}" "${{ github.event.pull_request.merge_commit_sha }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create Release

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: .NET Core Unit Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the CI/CD workflow and dependency management configuration to improve automation and align with the project's branching strategy. The most important changes are:

**Release workflow improvements:**

* The `create-release.yml` workflow now triggers automatically when a pull request is closed and merged into the `main` branch, instead of requiring manual dispatch. This ensures releases are only created for merged PRs.
* The workflow checks out the actual merge commit and tags/releases that commit, ensuring that releases are based on the correct code state. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L4-R23) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L41-R47)

**Dependency update configuration:**

* Dependabot is now configured to check for NuGet updates daily instead of weekly, and to target the `develop` branch instead of `main`. This keeps dependencies up-to-date more frequently in the active development branch.

**Test workflow updates:**

* The unit test workflow (`run-tests.yml`) will now run on both `main` and `develop` branches, ensuring tests are executed for changes in either branch.