### PR TITLE
Cfodev 1601 licence end date validation fix

### DIFF
--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -276,9 +276,9 @@ public class RiskDto
                 .NotEmpty()
                 .When(x => x.NoLicenseEndDate is false)
                 .WithMessage("You must provide the license end date")
-                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? DateTime.UtcNow.Date.AddDays(-30) : DateTime.UtcNow.Date)
+                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? x.DeactivatedInFeed.Value.AddDays(-30).ToDateTime(TimeOnly.MinValue) : DateTime.UtcNow.Date)
                 .WithMessage(x => x.DeactivatedInFeed.HasValue
-                    ? "Date must be no more than 30 days in the past."
+                    ? "License/Supervision End Date must be no more than 30 days before the participant's deactivation in feed date."
                     : ValidationConstants.DateMustBeInFuture);
 
             RuleFor(x => x.PSFRestrictions)

--- a/src/Application/Features/Participants/DTOs/RiskDto.cs
+++ b/src/Application/Features/Participants/DTOs/RiskDto.cs
@@ -86,10 +86,13 @@ public class RiskDto
     public DateTime? ReferredOn { get; set; }
     public string[] RegistrationDetails { get; init; } = [];
 
+    public DateOnly? DeactivatedInFeed { get; set; }
+
     private class Mapping : Profile
     {
         public Mapping() =>
             CreateMap<Risk, RiskDto>(MemberList.None)
+                .ForMember(dest => dest.DeactivatedInFeed, opt => opt.MapFrom(src => src.Participant!.DeactivatedInFeed))
                 .ForMember(dest => dest.RegistrationDetails, opt => opt.MapFrom((dest, src) =>
                 {
                     string? json;
@@ -273,8 +276,10 @@ public class RiskDto
                 .NotEmpty()
                 .When(x => x.NoLicenseEndDate is false)
                 .WithMessage("You must provide the license end date")
-                .GreaterThanOrEqualTo(DateTime.UtcNow.Date)
-                .WithMessage(ValidationConstants.DateMustBeInFuture);
+                .GreaterThanOrEqualTo(x => x.DeactivatedInFeed.HasValue ? DateTime.UtcNow.Date.AddDays(-30) : DateTime.UtcNow.Date)
+                .WithMessage(x => x.DeactivatedInFeed.HasValue
+                    ? "Date must be no more than 30 days in the past."
+                    : ValidationConstants.DateMustBeInFuture);
 
             RuleFor(x => x.PSFRestrictions)
                 .NotEmpty()

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor
@@ -28,7 +28,7 @@
                 <MudDatePicker @bind-Date="Model.LicenseEnd"
                             Label="@Model.GetMemberDescription(x => x.LicenseEnd)"
                             For="@(() => Model.LicenseEnd)"
-                            MinDate="DateTime.UtcNow.Date"
+                            MinDate="MinLicenseEndDate"
                             Class="mt-4"
                             Editable="true"/>
             }
@@ -52,7 +52,7 @@
             <MudDatePicker @bind-Date="Model.LicenseEnd"
                         Label="@Model.GetMemberDescription(x => x.LicenseEnd)"
                         For="@(() => Model.LicenseEnd)"
-                        MinDate="DateTime.UtcNow.Date"
+                        MinDate="MinLicenseEndDate"
                         Class="mt-4"
                         Editable="true"/>
         }

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
@@ -18,6 +18,6 @@ public partial class LicenseConditions
 
     private DateTime MinLicenseEndDate =>
         Model.DeactivatedInFeed.HasValue
-            ? DateTime.UtcNow.Date.AddDays(-30)
+            ? Model.DeactivatedInFeed.Value.AddDays(-30).ToDateTime(TimeOnly.MinValue)
             : DateTime.UtcNow.Date;
 }

--- a/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
+++ b/src/Server.UI/Pages/Risk/RiskComponents/LicenseConditions.razor.cs
@@ -15,4 +15,9 @@ public partial class LicenseConditions
         options.IncludeProperties(x => x.LicenseEnd);
         options.IncludeProperties(x => x.NoLicenseEndDate);
     };
+
+    private DateTime MinLicenseEndDate =>
+        Model.DeactivatedInFeed.HasValue
+            ? DateTime.UtcNow.Date.AddDays(-30)
+            : DateTime.UtcNow.Date;
 }


### PR DESCRIPTION
This pull request updates the handling of the License End Date in the risk assessment feature to ensure it is validated and displayed according to new business rules related to the participant's deactivation date. The main changes introduce a new field, update validation logic, and adjust the UI to reflect these requirements.

**Validation and business logic updates:**

* Added a new property `DeactivatedInFeed` to `RiskDto` and mapped it from the participant entity, enabling logic based on the participant's deactivation date.
* Updated the validation rule for `LicenseEnd` to require that the date is no more than 30 days before the participant's deactivation in feed date if it exists, otherwise it must be in the future. The validation message is now context-aware.

**UI updates:**

* Changed the minimum selectable date for the license end date picker in `LicenseConditions.razor` to use the new `MinLicenseEndDate` property instead of always using today's date. [[1]](diffhunk://#diff-1a0465f624515e47af12e63ef9509a9d7e281f0cadbbdef2f39b61ab4985cce3L31-R31) [[2]](diffhunk://#diff-1a0465f624515e47af12e63ef9509a9d7e281f0cadbbdef2f39b61ab4985cce3L55-R55)
* Added a computed property `MinLicenseEndDate` in `LicenseConditions.razor.cs` to encapsulate the logic for determining the minimum allowed license end date based on the deactivation date.


## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [x] Peer review completed

---

### UAT
- [ ] Required → completed
- [x] Not required (explain below)


Minor change does not require full UAT
