### PR TITLE
Adding ethnicity to the participant record.

### DIFF
--- a/src/Application/Features/Participants/Commands/CreateParticipant.cs
+++ b/src/Application/Features/Participants/Commands/CreateParticipant.cs
@@ -57,7 +57,8 @@ public static class CreateParticipant
                 referralComments: request.ReferralComments,
                 locationId: candidate.MappedLocationId,
                 nationality: candidate.Nationality,
-                primaryRecordKeyAtCreation: candidate.PrimaryRecordKey);
+                primaryRecordKeyAtCreation: candidate.PrimaryRecordKey,
+                ethnicity: candidate.Ethnicity);
 
             if(candidate.Crn is not null)
             {

--- a/src/Application/Features/Participants/MessageBus/SyncParticipantCommandHandler.cs
+++ b/src/Application/Features/Participants/MessageBus/SyncParticipantCommandHandler.cs
@@ -82,6 +82,9 @@ public class SyncParticipantCommandHandler(
             logger.LogTrace("Update nationality");
             participant.UpdateNationality(candidate.Nationality);
 
+            logger.LogTrace("Update ethnicity");
+            participant.UpdateEthnicity(candidate.Ethnicity);
+
             participant.UpdateSync();
 
             // Dispatch events and commit transaction

--- a/src/Database/CatsDb/Mi/StoredProcedures/RiskComplianceReport.sql
+++ b/src/Database/CatsDb/Mi/StoredProcedures/RiskComplianceReport.sql
@@ -25,7 +25,7 @@ BEGIN
         [RiskLevelAtEnrolment] NVARCHAR(20) NULL,
         [RiskSetWithin4Weeks] BIT NULL,
         [ProbationPractitionerDetailsDocumented] BIT NULL,
-        [NoUnknownRiskSet] BIT NULL,
+        [NoUnknownRiskSet] BIT NULL
     )
 
     INSERT INTO #Cohort (ParticipantId)

--- a/src/Database/CatsDb/Participant/Tables/Participant.sql
+++ b/src/Database/CatsDb/Participant/Tables/Participant.sql
@@ -22,6 +22,7 @@ CREATE TABLE [Participant].[Participant] (
     [RegistrationDetailsJson]        NVARCHAR (MAX)  NULL,
     [RiskDue]                        DATE            NULL,
     [Nationality]                    NVARCHAR (50)   NULL,
+    [Ethnicity]                      NVARCHAR (100)  NULL,
     [DateOfFirstConsent]             DATE            NULL,
     [LastSyncDate]                   DATETIME2 (7)   NULL,
     [BioDue]                         DATETIME2 (7)   NULL,

--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -34,7 +34,8 @@ public class Participant : OwnerPropertyEntity<string>
         string? referralComments, 
         int locationId,
         string? nationality,
-        string? primaryRecordKeyAtCreation)
+        string? primaryRecordKeyAtCreation,
+        string? ethnicity)
     {
         Participant p = new()
         {
@@ -53,7 +54,8 @@ public class Participant : OwnerPropertyEntity<string>
             Nationality = nationality,
             RiskDueReason = RiskDueReason.NewEntry,
             PrimaryRecordKeyAtCreation = primaryRecordKeyAtCreation,
-            Created = DateTime.UtcNow
+            Created = DateTime.UtcNow,
+            Ethnicity = ethnicity
         };
 
         p.AddDomainEvent(new ParticipantCreatedDomainEvent(p, locationId));
@@ -72,6 +74,11 @@ public class Participant : OwnerPropertyEntity<string>
 
     public int? RiskDueInDays() => (RiskDue.HasValue ? (RiskDue!.Value.Date - DateTime.UtcNow.Date).Days:null);
     public string? Nationality { get; set; }
+
+    /// <summary>
+    /// The recorded ethnicity from the active record.
+    /// </summary>
+    public string? Ethnicity { get; set;}
 
     /// <summary>
     /// The date the participant was deactivated in the DMS feed, if applicable.
@@ -337,6 +344,16 @@ public class Participant : OwnerPropertyEntity<string>
             Nationality = nationality;
         }
 
+        return this;
+    }
+
+    public Participant UpdateEthnicity(string? ethnicity)
+    {
+        if(string.Equals(Ethnicity, ethnicity, StringComparison.OrdinalIgnoreCase) is false)
+        {
+            AddDomainEvent(new ParticipantEthnicityChangedDomainEvent(this, Ethnicity, ethnicity));
+            Ethnicity = ethnicity;
+        }
         return this;
     }
 

--- a/src/Domain/Events/ParticipantEvents.cs
+++ b/src/Domain/Events/ParticipantEvents.cs
@@ -62,6 +62,14 @@ public sealed class ParticipantNationalityChangedDomainEvent(Participant partici
     public string? To { get; } = to;
 }
 
+public sealed class ParticipantEthnicityChangedDomainEvent(Participant participant, string? from, string? to)
+    : DomainEvent
+{
+    public Participant Item { get; } = participant;
+    public string? From { get; } = from;
+    public string? To { get; } = to;
+}
+
 public sealed class ParticipantIdentifierChangedDomainEvent(Participant participant, ExternalIdentifier from, ExternalIdentifier to)
     : DomainEvent
 {

--- a/src/Infrastructure/Persistence/Configurations/Participants/ParticipantEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Participants/ParticipantEntityTypeConfiguration.cs
@@ -42,6 +42,9 @@ public class ParticipantEntityTypeConfiguration : IEntityTypeConfiguration<Parti
         builder.Property(p => p.Nationality)
             .HasMaxLength(50);
 
+        builder.Property(p => p.Ethnicity)
+            .HasMaxLength(100);
+
         builder.Property(p => p.ReferralSource)
             .IsRequired()
             .HasMaxLength(100);


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [x] Not required (explain below)


There is no change to the front end. This updates a new column in the database for upcoming compliance reporting.

---

This pull request adds support for tracking participant ethnicity throughout the application. The main changes include updating the domain model, database schema, and command handling logic to include and process the new `Ethnicity` field for participants.

**Domain Model and Business Logic Updates:**

* Added an `Ethnicity` property to the `Participant` entity, including a summary comment and a method `UpdateEthnicity` that raises a new `ParticipantEthnicityChangedDomainEvent` when the value changes. [[1]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09R78-R82) [[2]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09R350-R359) [[3]](diffhunk://#diff-ddc97b99b9bcf5633d192ad9703428c319ce038816812cc7d11768ebd431a123R65-R72)
* Updated the `CreateFrom` static factory method in `Participant` to accept and set the `ethnicity` parameter. [[1]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09L37-R38) [[2]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09L56-R58)

**Database and Persistence Layer:**

* Added an `Ethnicity` column to the `[Participant].[Participant]` table, with a maximum length of 100 characters, and updated the entity configuration accordingly. [[1]](diffhunk://#diff-2b5ce2290a11b15d1103fc644d5919729d5804c36a17860f6e2ef7e2a402b2beR25) [[2]](diffhunk://#diff-e97c87f3ce10a5ac38c7588a1bc14cce3142517fe7543d8051eeffcc3ce97955R45-R47)

**Application Logic:**

* Modified participant creation and synchronization logic to handle the new `Ethnicity` field, including passing it through commands and updating the participant entity. [[1]](diffhunk://#diff-bc3e40377aa862d6a79466b299499e924824b409524a209e055b1c7b5bc0e475L60-R61) [[2]](diffhunk://#diff-221395e0ad593ddad368b62c47fe2a9352ea1b62d31a33abe0745fff098a3697R85-R87)

**Other:**

* Minor formatting fix in the `RiskComplianceReport.sql` stored procedure.