### PR TITLE
Alter label adding to use a filterable table.

### DIFF
--- a/src/Application/Features/Labels/Queries/GetVisibleLabels.cs
+++ b/src/Application/Features/Labels/Queries/GetVisibleLabels.cs
@@ -54,7 +54,7 @@ public static class GetVisibleLabels
                                 """;
 
             var labels = await connection.QueryAsync<LabelDto>(sql, new { TenantId = request.CurrentUser.TenantId! });
-            return labels.OrderBy(x => x.Contract).ToArray();
+            return labels.OrderBy(x => x.Name).ToArray();
         }
     }
 }

--- a/src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor
+++ b/src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor
@@ -2,25 +2,63 @@
 @using Cfo.Cats.Application.Features.ParticipantLabels.AddParticipantLabel
 @using Cfo.Cats.Domain.Labels
 @using Cfo.Cats.Domain.Participants
+@using Cfo.Cats.Server.UI.Components.Labels
 
 @inherits OwningComponentBase<IMediator>
 
-<MudMenu 
-    Label="Add"
-    StartIcon="@Icons.Material.Filled.Add" 
-    Color="Color.Primary"
-    Variant="Variant.Filled"
-    AriaLabel="Open add label menu">
-    
-    @foreach (var label in VisibleLabels.Where(v => v.Scope == LabelScope.User))
-    {
-        <MudMenuItem 
-            Label="@label.Name" 
-            Icon="@label.AppIcon.AsMudIcon()" 
-            Disabled="@(AlreadySelected.Any(l => l == label.Id))"
-            OnClick="@(() => AddLabel(label))"/>
-    }
+<MudButton 
+    Variant="Variant.Filled" 
+    Color="Color.Secondary" 
+    StartIcon="@Icons.Material.Filled.Label"
+    OnClick="@(() => _showDialog = true)">
+    Add Label
+</MudButton>
 
-</MudMenu>
-
-
+<MudDialog Visible="_showDialog" Options="@(new DialogOptions() { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            Add a label
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTable 
+            T="LabelDto" 
+            Hover="true"
+            Items="VisibleLabels"
+            RowDisabledFunc="@(ctx => ctx.Scope == LabelScope.System || AlreadySelected.Contains(ctx.Id))"
+            @bind-SelectedItem="_selectedItem"
+            RowClassFunc="@SelectedRowClassFunc"
+            Filter="new Func<LabelDto,bool>(FilterFunc1)">
+        <ToolBarContent>
+            <MudText Typo="Typo.h6">Labels</MudText>
+            <MudSpacer />
+            <MudTextField @bind-Value="_searchText" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>
+                <MudTableSortLabel SortBy="new Func<LabelDto, object>(x => x.Name)">Name</MudTableSortLabel>
+            </MudTh>
+            <MudTh>
+                <MudTableSortLabel SortBy="new Func<LabelDto, object>(x => x.Description)">Description</MudTableSortLabel>
+            </MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Label">
+                 <CatsChip Description="@context.Description" Label="@context.Name" Variant="@context.Variant" Colour="@context.Colour" Icon="@context.AppIcon"/>
+            </MudTd>
+            <MudTd DataLabel="Description">@context.Description</MudTd>
+        </RowTemplate>
+        <PagerContent>
+            <MudTablePager PageSizeOptions="new int[] {5 ,10}"></MudTablePager>
+        </PagerContent>
+        </MudTable>
+    </DialogContent>
+    <DialogActions>
+        <MudButton StartIcon="@Icons.Material.Filled.Cancel" Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(() => { _showDialog = false; _selectedItem = null; } )">
+            Cancel
+        </MudButton>
+        <MudLoadingButton Loading="_saving" Disabled="@(_selectedItem is null)" Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" OnClick="@(() => AddLabel(_selectedItem))">
+            Save
+        </MudLoadingButton>
+    </DialogActions>
+</MudDialog>

--- a/src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor.cs
+++ b/src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor.cs
@@ -2,11 +2,21 @@ using Cfo.Cats.Application.Features.Labels.DTOs;
 using Cfo.Cats.Application.Features.ParticipantLabels.AddParticipantLabel;
 using Cfo.Cats.Domain.Labels;
 using Cfo.Cats.Domain.Participants;
+using Cfo.Cats.Server.UI.Pages.Candidates;
+using System;
 
 namespace Cfo.Cats.Server.UI.Components.ParticipantLabels;
 
 public partial class AddLabelMenu
 {
+
+    private bool _showDialog = false;
+    private bool _saving;
+
+    private LabelDto? _selectedItem = null;
+
+    private string? _searchText = null;
+
     /// <summary>
     /// The participant to whom we are adding the label to
     /// </summary>
@@ -31,17 +41,56 @@ public partial class AddLabelMenu
     [Parameter, EditorRequired]
     public EventCallback LabelAdded { get; set; }
 
-    private async Task AddLabel(LabelDto label)
+    private async Task AddLabel(LabelDto? label)
     {
-        var response = await Service.Send(new AddParticipantLabelCommand(ParticipantId, new LabelId(label.Id)));
-        if (!response.Succeeded)
+        try
         {
-            Snackbar.Add(response.ErrorMessage, Severity.Error);
+            _saving = true;
+            if(label is not null)
+            { 
+                var response = await Service.Send(new AddParticipantLabelCommand(ParticipantId, new LabelId(label.Id)));
+                if (!response.Succeeded)
+                {
+                    Snackbar.Add(response.ErrorMessage, Severity.Error);
+                }
+                else
+                {
+                    _selectedItem = null;
+                    _showDialog = false;
+                    await LabelAdded.InvokeAsync();
+                }
+            }
         }
-        else
+        finally
         {
-            await LabelAdded.InvokeAsync();
+            _saving = false;
         }
+        
+    }
+
+    private string SelectedRowClassFunc(LabelDto? label, int rowNumber) => 
+        _selectedItem is not null && _selectedItem.Equals(label) ? "selected-table-row-primary" : string.Empty;
+
+    private bool FilterFunc1(LabelDto label) => FilterFunc(label, _searchText);
+
+    private bool FilterFunc(LabelDto label, string? searchString)
+    {
+        if (string.IsNullOrWhiteSpace(searchString))
+        {
+            return true;
+        }
+
+        if(label.Name.Contains(searchString, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return true;
+        }
+
+        if(label.Description.Contains(searchString, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/src/Server.UI/wwwroot/css/app.css
+++ b/src/Server.UI/wwwroot/css/app.css
@@ -60,3 +60,15 @@
 .mud-rating-item.mud-disabled * {
     color: inherit !important;
 }
+
+.selected-table-row-primary {
+    background-color: var(--mud-palette-primary) !important;
+}
+
+.selected-table-row-primary > td {
+    color: white !important;
+}
+
+.selected-table-row-primary > td .mud-input {
+    color: white !important;
+}


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required 
- [x] Not required (explain below)

---

This pull request improves the user experience for adding labels to participants by replacing the previous menu-based approach with a searchable dialog, enhancing usability and accessibility. It also introduces visual feedback for selected rows and updates sorting logic for label display.

**UI/UX Improvements:**

* Replaces the `MudMenu` label selection with a `MudButton` that opens a dialog containing a searchable, sortable `MudTable` of labels, allowing users to easily browse, search, and select labels. The dialog disables system labels and already-selected labels, and provides clear Cancel/Save actions. (`src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor`)
* Adds a CSS class `.selected-table-row-primary` to highlight the selected label row in the table for better visual feedback. (`src/Server.UI/wwwroot/css/app.css`)

**Functionality and Logic Enhancements:**

* Implements search and filter logic for labels, row selection handling, and loading state management when adding a label. Also ensures dialog closes and selection resets after a successful addition. (`src/Server.UI/Components/ParticipantLabels/AddLabelMenu.razor.cs`) [[1]](diffhunk://#diff-0335e8d3c88df2b8acbf4a985817a4fd4f5ec2c7a60018f9427cb4c259eba922R5-R19) [[2]](diffhunk://#diff-0335e8d3c88df2b8acbf4a985817a4fd4f5ec2c7a60018f9427cb4c259eba922L34-R49) [[3]](diffhunk://#diff-0335e8d3c88df2b8acbf4a985817a4fd4f5ec2c7a60018f9427cb4c259eba922R58-R94)

**Data Handling:**

* Changes the sorting of visible labels from ordering by `Contract` to ordering by `Name`, making label selection more intuitive for users. (`src/Application/Features/Labels/Queries/GetVisibleLabels.cs`)
