### PR TITLE
CFODEV-1646: Migration of existing initiatives

### DIFF
--- a/src/DatabaseSeeding/Scripts/0058_Initiatives.sql
+++ b/src/DatabaseSeeding/Scripts/0058_Initiatives.sql
@@ -1,19 +1,59 @@
+-- ============================================================
+-- Seed: Innovation Fund Initiatives
+--
+-- Contract mapping
+--   North East            -> con_24037
+--   Yorkshire & Humber    -> con_24038
+--   West Midlands         -> con_24041
+--   East Midlands         -> con_24042
+--   East of England       -> con_24043
+--   London                -> con_24044
+--   South East            -> con_24046
+--
+-- Each row is skipped if the Code already exists.
+-- ============================================================
+INSERT INTO [Configuration].[Initiative]
+    ([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd], [Created], [CreatedBy])
+SELECT
+    v.[Id], 
+    v.[Code], 
+    v.[Description], 
+    v.[ContractId],
+    v.[LifetimeStart], 
+    v.[LifetimeEnd],
+    GETUTCDATE(), 
+    N'2a9b3450-1feb-4be3-ab94-24e64cd34829' -- System Support
+FROM (VALUES
+    -- London
+    (N'c1a2b3c4-0001-0001-0001-000000000001', N'IF-25-15', N'RR Barista Training',                          N'con_24044', '2025-12-01 00:00:00', '2026-11-30 23:59:59'),
 
-IF NOT EXISTS (SELECT TOP(1) [Id] FROM [Configuration].[Initiative])
-BEGIN
-    INSERT INTO [Configuration].[Initiative] ([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd], [Created], [CreatedBy])
-    VALUES
-    -- Active: started several weeks ago, runs for months
-    (N'a1b2c3d4-0001-0001-0001-000000000001', N'IF-01-01', N'Initiative for North West',           N'con_24036', DATEADD(week, -6,  GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(month,  6, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
-    (N'a1b2c3d4-0002-0002-0002-000000000002', N'IF-02-01', N'Initiative for North East',           N'con_24037', DATEADD(week, -4,  GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(month,  4, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
-    (N'a1b2c3d4-0003-0003-0003-000000000003', N'IF-03-01', N'Initiative for Yorkshire',            N'con_24038', DATEADD(week, -2,  GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(month,  8, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
+    -- East of England
+    (N'c1a2b3c4-0002-0002-0002-000000000002', N'IF-25-24', N'Tattoo Course',                                N'con_24043', '2025-12-01 00:00:00', '2026-09-30 23:59:59'),
 
-    -- Expiring soon: started a few weeks ago, ends within a few days
-    (N'a1b2c3d4-0004-0004-0004-000000000004', N'IF-04-01', N'Initiative for West Midlands',        N'con_24041', DATEADD(week, -8,  GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(day,    3, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
-    (N'a1b2c3d4-0005-0005-0005-000000000005', N'IF-05-01', N'Initiative for East Midlands',        N'con_24042', DATEADD(week, -5,  GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(day,    5, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
+    -- West Midlands
+    (N'c1a2b3c4-0003-0003-0003-000000000003', N'IF-25-21', N'Inside Academy',                               N'con_24041', '2026-01-19 00:00:00', '2026-07-31 23:59:59'),
+    (N'c1a2b3c4-0004-0004-0004-000000000004', N'IF-25-22', N'Making Changes',                               N'con_24041', '2026-01-15 00:00:00', '2026-07-31 23:59:59'),
+    (N'c1a2b3c4-0012-0012-0012-000000000012', N'IF-26-05', N'New Tracks',                                   N'con_24041', '2026-02-24 00:00:00', '2026-05-29 23:59:59'),
 
-    -- Ended: lifetime is entirely in the past
-    (N'a1b2c3d4-0006-0006-0006-000000000006', N'IF-06-01', N'Initiative for London',               N'con_24044', DATEADD(week, -16, GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(week,  -2, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
-    (N'a1b2c3d4-0007-0007-0007-000000000007', N'IF-07-01', N'Initiative for South West',           N'con_24045', DATEADD(week, -20, GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(week,  -6, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),
-    (N'a1b2c3d4-0008-0008-0008-000000000008', N'IF-08-01', N'Initiative for South East',           N'con_24046', DATEADD(week, -12, GETUTCDATE()), DATEADD(second, -1, DATEADD(day, 1, CAST(CAST(DATEADD(day,   -3, GETUTCDATE()) AS DATE) AS DATETIME))), GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829');
-END
+    -- South East
+    (N'c1a2b3c4-0005-0005-0005-000000000005', N'IF-25-23', N'BearFace Theatre',                             N'con_24046', '2026-01-08 00:00:00', '2027-01-31 23:59:59'),
+    (N'c1a2b3c4-0008-0008-0008-000000000008', N'IF-25-29', N'Making It Out',                                N'con_24046', '2026-02-16 00:00:00', '2027-03-16 23:59:59'),
+
+    -- East Midlands
+    (N'c1a2b3c4-0006-0006-0006-000000000006', N'IF-25-01', N'Seeds of Change',                              N'con_24042', '2026-01-02 00:00:00', '2027-03-31 23:59:59'),
+
+    -- North East
+    (N'c1a2b3c4-0007-0007-0007-000000000007', N'IF-25-26', N'Doncaster Rugby',                              N'con_24037', '2026-01-07 00:00:00', '2027-04-30 23:59:59'),
+    (N'c1a2b3c4-0010-0010-0010-000000000010', N'IF-25-35', N'Understanding Me',                             N'con_24037', '2026-01-05 00:00:00', '2027-04-30 23:59:59'),
+    (N'c1a2b3c4-0011-0011-0011-000000000011', N'IF-26-04', N'My Sister''s Place',                           N'con_24037', '2026-02-01 00:00:00', '2027-03-31 23:59:59'),
+    (N'c1a2b3c4-0014-0014-0014-000000000014', N'IF-25-18', N'Garden Renovation',                            N'con_24037', '2025-09-18 00:00:00', '2026-02-28 23:59:59'),
+    (N'c1a2b3c4-0015-0015-0015-000000000015', N'IF-25-27', N'Maizel''s Method',                             N'con_24037', '2026-01-02 00:00:00', '2026-03-31 23:59:59'),
+
+    -- Yorkshire & Humber
+    (N'c1a2b3c4-0009-0009-0009-000000000009', N'IF-25-34', N'CSCS',                                         N'con_24038', '2026-03-02 00:00:00', '2027-03-31 23:59:59'),
+    (N'c1a2b3c4-0013-0013-0013-000000000013', N'IF-25-17', N'Doncaster RLFC Personal Development Programme', N'con_24038', '2025-09-23 00:00:00', '2026-06-20 23:59:59')
+
+) AS v([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd])
+WHERE NOT EXISTS (
+    SELECT 1 FROM [Configuration].[Initiative] WHERE [Code] = v.[Code]
+);

--- a/src/DatabaseSeeding/Scripts/0058_Initiatives.sql
+++ b/src/DatabaseSeeding/Scripts/0058_Initiatives.sql
@@ -9,51 +9,49 @@
 --   East of England       -> con_24043
 --   London                -> con_24044
 --   South East            -> con_24046
---
--- Each row is skipped if the Code already exists.
 -- ============================================================
-INSERT INTO [Configuration].[Initiative]
-    ([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd], [Created], [CreatedBy])
-SELECT
-    v.[Id], 
-    v.[Code], 
-    v.[Description], 
-    v.[ContractId],
-    v.[LifetimeStart], 
-    v.[LifetimeEnd],
-    GETUTCDATE(), 
-    N'2a9b3450-1feb-4be3-ab94-24e64cd34829' -- System Support
-FROM (VALUES
-    -- London
-    (N'c1a2b3c4-0001-0001-0001-000000000001', N'IF-25-15', N'RR Barista Training',                          N'con_24044', '2025-12-01 00:00:00', '2026-11-30 23:59:59'),
+IF NOT EXISTS(SELECT 1 FROM [Configuration].[Initiative])
+BEGIN
+    INSERT INTO [Configuration].[Initiative]
+        ([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd], [Created], [CreatedBy])
+    SELECT
+        v.[Id], 
+        v.[Code], 
+        v.[Description], 
+        v.[ContractId],
+        v.[LifetimeStart], 
+        v.[LifetimeEnd],
+        GETUTCDATE(), 
+        N'2a9b3450-1feb-4be3-ab94-24e64cd34829' -- System Support
+    FROM (VALUES
+        -- London
+        (N'c1a2b3c4-0001-0001-0001-000000000001', N'IF-25-15', N'RR Barista Training',                          N'con_24044', '2025-12-01 00:00:00', '2026-11-30 23:59:59'),
 
-    -- East of England
-    (N'c1a2b3c4-0002-0002-0002-000000000002', N'IF-25-24', N'Tattoo Course',                                N'con_24043', '2025-12-01 00:00:00', '2026-09-30 23:59:59'),
+        -- East of England
+        (N'c1a2b3c4-0002-0002-0002-000000000002', N'IF-25-24', N'Tattoo Course',                                N'con_24043', '2025-12-01 00:00:00', '2026-09-30 23:59:59'),
 
-    -- West Midlands
-    (N'c1a2b3c4-0003-0003-0003-000000000003', N'IF-25-21', N'Inside Academy',                               N'con_24041', '2026-01-19 00:00:00', '2026-07-31 23:59:59'),
-    (N'c1a2b3c4-0004-0004-0004-000000000004', N'IF-25-22', N'Making Changes',                               N'con_24041', '2026-01-15 00:00:00', '2026-07-31 23:59:59'),
-    (N'c1a2b3c4-0012-0012-0012-000000000012', N'IF-26-05', N'New Tracks',                                   N'con_24041', '2026-02-24 00:00:00', '2026-05-29 23:59:59'),
+        -- West Midlands
+        (N'c1a2b3c4-0003-0003-0003-000000000003', N'IF-25-21', N'Inside Academy',                               N'con_24041', '2026-01-19 00:00:00', '2026-07-31 23:59:59'),
+        (N'c1a2b3c4-0004-0004-0004-000000000004', N'IF-25-22', N'Making Changes',                               N'con_24041', '2026-01-15 00:00:00', '2026-07-31 23:59:59'),
+        (N'c1a2b3c4-0012-0012-0012-000000000012', N'IF-26-05', N'New Tracks',                                   N'con_24041', '2026-02-24 00:00:00', '2026-05-29 23:59:59'),
 
-    -- South East
-    (N'c1a2b3c4-0005-0005-0005-000000000005', N'IF-25-23', N'BearFace Theatre',                             N'con_24046', '2026-01-08 00:00:00', '2027-01-31 23:59:59'),
-    (N'c1a2b3c4-0008-0008-0008-000000000008', N'IF-25-29', N'Making It Out',                                N'con_24046', '2026-02-16 00:00:00', '2027-03-16 23:59:59'),
+        -- South East
+        (N'c1a2b3c4-0005-0005-0005-000000000005', N'IF-25-23', N'BearFace Theatre',                             N'con_24046', '2026-01-08 00:00:00', '2027-01-31 23:59:59'),
+        (N'c1a2b3c4-0008-0008-0008-000000000008', N'IF-25-29', N'Making It Out',                                N'con_24046', '2026-02-16 00:00:00', '2027-03-16 23:59:59'),
 
-    -- East Midlands
-    (N'c1a2b3c4-0006-0006-0006-000000000006', N'IF-25-01', N'Seeds of Change',                              N'con_24042', '2026-01-02 00:00:00', '2027-03-31 23:59:59'),
+        -- East Midlands
+        (N'c1a2b3c4-0006-0006-0006-000000000006', N'IF-25-01', N'Seeds of Change',                              N'con_24042', '2026-01-02 00:00:00', '2027-03-31 23:59:59'),
 
-    -- North East
-    (N'c1a2b3c4-0007-0007-0007-000000000007', N'IF-25-26', N'Doncaster Rugby',                              N'con_24037', '2026-01-07 00:00:00', '2027-04-30 23:59:59'),
-    (N'c1a2b3c4-0010-0010-0010-000000000010', N'IF-25-35', N'Understanding Me',                             N'con_24037', '2026-01-05 00:00:00', '2027-04-30 23:59:59'),
-    (N'c1a2b3c4-0011-0011-0011-000000000011', N'IF-26-04', N'My Sister''s Place',                           N'con_24037', '2026-02-01 00:00:00', '2027-03-31 23:59:59'),
-    (N'c1a2b3c4-0014-0014-0014-000000000014', N'IF-25-18', N'Garden Renovation',                            N'con_24037', '2025-09-18 00:00:00', '2026-02-28 23:59:59'),
-    (N'c1a2b3c4-0015-0015-0015-000000000015', N'IF-25-27', N'Maizel''s Method',                             N'con_24037', '2026-01-02 00:00:00', '2026-03-31 23:59:59'),
+        -- North East
+        (N'c1a2b3c4-0007-0007-0007-000000000007', N'IF-25-26', N'Doncaster Rugby',                              N'con_24037', '2026-01-07 00:00:00', '2027-04-30 23:59:59'),
+        (N'c1a2b3c4-0010-0010-0010-000000000010', N'IF-25-35', N'Understanding Me',                             N'con_24037', '2026-01-05 00:00:00', '2027-04-30 23:59:59'),
+        (N'c1a2b3c4-0011-0011-0011-000000000011', N'IF-26-04', N'My Sister''s Place',                           N'con_24037', '2026-02-01 00:00:00', '2027-03-31 23:59:59'),
+        (N'c1a2b3c4-0014-0014-0014-000000000014', N'IF-25-18', N'Garden Renovation',                            N'con_24037', '2025-09-18 00:00:00', '2026-02-28 23:59:59'),
+        (N'c1a2b3c4-0015-0015-0015-000000000015', N'IF-25-27', N'Maizel''s Method',                             N'con_24037', '2026-01-02 00:00:00', '2026-03-31 23:59:59'),
 
-    -- Yorkshire & Humber
-    (N'c1a2b3c4-0009-0009-0009-000000000009', N'IF-25-34', N'CSCS',                                         N'con_24038', '2026-03-02 00:00:00', '2027-03-31 23:59:59'),
-    (N'c1a2b3c4-0013-0013-0013-000000000013', N'IF-25-17', N'Doncaster RLFC Personal Development Programme', N'con_24038', '2025-09-23 00:00:00', '2026-06-20 23:59:59')
+        -- Yorkshire & Humber
+        (N'c1a2b3c4-0009-0009-0009-000000000009', N'IF-25-34', N'CSCS',                                         N'con_24038', '2026-03-02 00:00:00', '2027-03-31 23:59:59'),
+        (N'c1a2b3c4-0013-0013-0013-000000000013', N'IF-25-17', N'Doncaster RLFC Personal Development Programme', N'con_24038', '2025-09-23 00:00:00', '2026-06-20 23:59:59')
 
-) AS v([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd])
-WHERE NOT EXISTS (
-    SELECT 1 FROM [Configuration].[Initiative] WHERE [Code] = v.[Code]
-);
+    ) AS v([Id], [Code], [Description], [ContractId], [LifetimeStart], [LifetimeEnd])
+END

--- a/src/DatabaseSeeding/Scripts/0059_InitiativeObjectives.sql
+++ b/src/DatabaseSeeding/Scripts/0059_InitiativeObjectives.sql
@@ -1,20 +1,25 @@
 
-IF NOT EXISTS (SELECT TOP(1) [ObjectiveId] FROM [Participant].[InitiativeObjective])
-BEGIN
-    -- Link a selection of non-mandatory objectives to seeded initiatives.
-    -- ObjectiveId references [Participant].[Objective]; ParticipantId is denormalised from the owning PathwayPlan.
-    INSERT INTO [Participant].[InitiativeObjective] ([Id], [ObjectiveId], [InitiativeId], [ParticipantId], [Created], [CreatedBy])
-    VALUES
-    -- Active initiatives
-    (NEWID(), N'0195d736-5840-7a7b-be4a-17deff70eb3a', N'a1b2c3d4-0001-0001-0001-000000000001', N'1CFG5437L', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- EDUCATION / IF-01-01 North West
-    (NEWID(), N'0195d747-dbd9-7daa-9127-44196616b95c', N'a1b2c3d4-0002-0002-0002-000000000002', N'1CFG9326Y', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- preparing for work / IF-02-01 North East
-    (NEWID(), N'0195d77a-a8fa-7782-a761-205d33ec59c2', N'a1b2c3d4-0003-0003-0003-000000000003', N'1CFG4936J', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- testing testing / IF-03-01 Yorkshire
+-- ============================================================
+-- Seed: Initiative Objectives
+-- Links objectives to initiatives where the objective description
+-- starts with the initiative code,
+-- e.g. 'IF-25-15 RR Barista Training: 17/09/2025' -> IF-25-15.
+-- ============================================================
 
-    -- Expiring soon
-    (NEWID(), N'0195f145-803e-7c6c-baa3-42c034679203', N'a1b2c3d4-0004-0004-0004-000000000004', N'1CFG4261Y', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- housing support / IF-04-01 West Midlands
-    (NEWID(), N'01968c43-6fc9-72d3-8128-5a16cb8affb9', N'a1b2c3d4-0005-0005-0005-000000000005', N'1CFG6390M', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- working towards CSCS / IF-05-01 East Midlands
-
-    -- Ended initiatives
-    (NEWID(), N'01989949-8c6e-7a6c-9fb1-5e103061309a', N'a1b2c3d4-0006-0006-0006-000000000006', N'1CFG9798U', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829'),  -- HEALTH & ADDICTION / IF-06-01 London
-    (NEWID(), N'01995708-b707-7f59-a3fc-5077ac018cf2', N'a1b2c3d4-0007-0007-0007-000000000007', N'1CFG8236D', GETUTCDATE(), N'2a9b3450-1feb-4be3-ab94-24e64cd34829');  -- HEALTH & ADDICTION / IF-07-01 South West
-END
+INSERT INTO [Participant].[InitiativeObjective]
+    ([Id], [ObjectiveId], [InitiativeId], [ParticipantId], [Created], [CreatedBy])
+SELECT
+    NEWID(),
+    o.[Id],
+    i.[Id],
+    pp.[ParticipantId],
+    GETUTCDATE(),
+    N'2a9b3450-1feb-4be3-ab94-24e64cd34829'
+FROM        [Participant].[Objective]   o
+JOIN        [Participant].[PathwayPlan] pp ON pp.[Id]   = o.[PathwayPlanId]
+JOIN        [Configuration].[Initiative] i ON o.[Description] LIKE i.[Code] + '%'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM [Participant].[InitiativeObjective] io
+    WHERE io.[ObjectiveId] = o.[Id]
+);

--- a/src/DatabaseSeeding/Scripts/0059_InitiativeObjectives.sql
+++ b/src/DatabaseSeeding/Scripts/0059_InitiativeObjectives.sql
@@ -1,25 +1,26 @@
-
 -- ============================================================
 -- Seed: Initiative Objectives
 -- Links objectives to initiatives where the objective description
 -- starts with the initiative code,
 -- e.g. 'IF-25-15 RR Barista Training: 17/09/2025' -> IF-25-15.
 -- ============================================================
-
-INSERT INTO [Participant].[InitiativeObjective]
-    ([Id], [ObjectiveId], [InitiativeId], [ParticipantId], [Created], [CreatedBy])
-SELECT
-    NEWID(),
-    o.[Id],
-    i.[Id],
-    pp.[ParticipantId],
-    GETUTCDATE(),
-    N'2a9b3450-1feb-4be3-ab94-24e64cd34829'
-FROM        [Participant].[Objective]   o
-JOIN        [Participant].[PathwayPlan] pp ON pp.[Id]   = o.[PathwayPlanId]
-JOIN        [Configuration].[Initiative] i ON o.[Description] LIKE i.[Code] + '%'
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM [Participant].[InitiativeObjective] io
-    WHERE io.[ObjectiveId] = o.[Id]
-);
+IF NOT EXISTS(SELECT 1 FROM [Participant].[InitiativeObjective])
+BEGIN
+    INSERT INTO [Participant].[InitiativeObjective]
+        ([Id], [ObjectiveId], [InitiativeId], [ParticipantId], [Created], [CreatedBy])
+    SELECT
+        NEWID(),
+        o.[Id],
+        i.[Id],
+        pp.[ParticipantId],
+        GETUTCDATE(),
+        N'2a9b3450-1feb-4be3-ab94-24e64cd34829'
+    FROM        [Participant].[Objective]   o
+    JOIN        [Participant].[PathwayPlan] pp ON pp.[Id]   = o.[PathwayPlanId]
+    JOIN        [Configuration].[Initiative] i ON o.[Description] LIKE i.[Code] + '%'
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM [Participant].[InitiativeObjective] io
+        WHERE io.[ObjectiveId] = o.[Id]
+    );
+END;


### PR DESCRIPTION
This pull request updates the seeding scripts for initiatives and their objectives to align with a new set of Innovation Fund Initiatives and to automate the linking of objectives to initiatives based on code matching.

**Initiative seeding and data updates:**

* Replaced the previous static and conditional seeding logic in `0058_Initiatives.sql` with a new set of Innovation Fund Initiatives, with explicit contract mappings and fixed date ranges.

**Objective linking improvements:**

* Updated `0059_InitiativeObjectives.sql` to remove the old static inserts and conditional logic, replacing it with a dynamic insert that links objectives to initiatives by matching the start of the objective description to the initiative code. This automates the association process.