### PR TITLE
CFODEV-1667: Add policies for initiative management

### DIFF
--- a/src/Application/Features/Initiatives/Commands/AddInitiative/AddInitiativeCommand.cs
+++ b/src/Application/Features/Initiatives/Commands/AddInitiative/AddInitiativeCommand.cs
@@ -5,7 +5,7 @@ using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.Initiatives.Commands.AddInitiative;
 
-[RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+[RequestAuthorize(Policy = SecurityPolicies.ManageInitiatives)]
 public class AddInitiativeCommand : IRequest<Result>
 {
     [Display(Name = "Code", Description = "A unique 8-character code identifying this initiative (e.g. IF-01-01)")]

--- a/src/Application/Features/Initiatives/Commands/AmendInitiativeLifetime/AmendInitiativeLifetimeCommand.cs
+++ b/src/Application/Features/Initiatives/Commands/AmendInitiativeLifetime/AmendInitiativeLifetimeCommand.cs
@@ -4,7 +4,7 @@ using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.Initiatives.Commands.AmendInitiativeLifetime;
 
-[RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+[RequestAuthorize(Policy = SecurityPolicies.ManageInitiatives)]
 public class AmendInitiativeLifetimeCommand : IRequest<Result>
 {
     public required Guid Id { get; set; }

--- a/src/Application/Features/Initiatives/Commands/DeactivateInitiative/DeactivateInitiativeCommand.cs
+++ b/src/Application/Features/Initiatives/Commands/DeactivateInitiative/DeactivateInitiativeCommand.cs
@@ -3,7 +3,7 @@ using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.Initiatives.Commands.DeactivateInitiative;
 
-[RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+[RequestAuthorize(Policy = SecurityPolicies.ManageInitiatives)]
 public class DeactivateInitiativeCommand : IRequest<Result>
 {
     public required Guid Id { get; set; }

--- a/src/Application/Features/Initiatives/Commands/EditInitiative/EditInitiativeCommand.cs
+++ b/src/Application/Features/Initiatives/Commands/EditInitiative/EditInitiativeCommand.cs
@@ -5,7 +5,7 @@ using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.Initiatives.Commands.EditInitiative;
 
-[RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+[RequestAuthorize(Policy = SecurityPolicies.ManageInitiatives)]
 public class EditInitiativeCommand : IRequest<Result>
 {
     public required Guid Id { get; set; }

--- a/src/Application/Features/Initiatives/Queries/GetInitiatives.cs
+++ b/src/Application/Features/Initiatives/Queries/GetInitiatives.cs
@@ -7,7 +7,7 @@ namespace Cfo.Cats.Application.Features.Initiatives.Queries;
 
 public static class GetInitiatives
 {
-    [RequestAuthorize(Policy = SecurityPolicies.SeniorInternal)]
+    [RequestAuthorize(Policy = SecurityPolicies.Initiatives)]
     public class Query : IRequest<Result<InitiativeDto[]>>
     {
         public bool IncludeExpired { get; init; }

--- a/src/Application/SecurityConstants/SecurityPolicies.cs
+++ b/src/Application/SecurityConstants/SecurityPolicies.cs
@@ -67,5 +67,15 @@ public static class SecurityPolicies
 
     public const string ServiceDeskManagement = nameof(ServiceDeskManagement);
 
+    /// <summary>
+    /// Allows access to the Initiatives management page and list.
+    /// </summary>
+    public const string Initiatives = nameof(Initiatives);
+
+    /// <summary>
+    /// Allows adding, editing, amending, and deactivating initiatives. Aligns with CMPSM role.
+    /// </summary>
+    public const string ManageInitiatives = nameof(ManageInitiatives);
+
     public const string UserManagement = nameof(UserManagement);
 }

--- a/src/DatabaseSeeding/Scripts/0060_InitiativePermissions.sql
+++ b/src/DatabaseSeeding/Scripts/0060_InitiativePermissions.sql
@@ -1,0 +1,13 @@
+IF NOT EXISTS (SELECT Id FROM [Identity].[RoleClaim] WHERE ClaimType='Permission' AND ClaimValue='Initiatives')
+BEGIN
+    INSERT INTO [Identity].[RoleClaim] ([Description], [Group], RoleId, ClaimType, ClaimValue)
+    SELECT 'Initiatives', 'Permission', Id, 'Permission', 'Initiatives' FROM [Identity].[Role]
+    WHERE [Name] in ('System Support', 'SMT', 'Contract Support Officer', 'Contract Performance Manager', 'Contract Management Process Support Manager')
+END
+
+IF NOT EXISTS (SELECT Id FROM [Identity].[RoleClaim] WHERE ClaimType='Permission' AND ClaimValue='Manage Initiatives')
+BEGIN
+    INSERT INTO [Identity].[RoleClaim] ([Description], [Group], RoleId, ClaimType, ClaimValue)
+    SELECT 'Manage Initiatives', 'Permission', Id, 'Permission', 'Manage Initiatives' FROM [Identity].[Role]
+    WHERE [Name] in ('System Support', 'SMT', 'Contract Management Process Support Manager')
+END

--- a/src/Infrastructure/Constants/ClaimTypes/Permissions.cs
+++ b/src/Infrastructure/Constants/ClaimTypes/Permissions.cs
@@ -7,6 +7,10 @@ public static class Permissions
 
     public const string ServiceDeskManagement = "Service Desk Management";
 
+    public const string Initiatives = nameof(Initiatives);
+
+    public const string ManageInitiatives = "Manage Initiatives";
+
     public const string QA1 = nameof(QA1);
 
     public const string QA2 = nameof(QA2);

--- a/src/Infrastructure/PolicyExtensions.cs
+++ b/src/Infrastructure/PolicyExtensions.cs
@@ -153,6 +153,20 @@ internal static class PolicyExtensions
             policy.RequireClaim(ApplicationClaimTypes.Permission, Permissions.ServiceDeskManagement);  
 
         });
+
+        options.AddPolicy(SecurityPolicies.Initiatives, policy =>
+        {
+            policy.RequireAuthenticatedUser();
+            policy.RequireClaim(ApplicationClaimTypes.AccountLocked, "False");
+            policy.RequireClaim(ApplicationClaimTypes.Permission, Permissions.Initiatives);
+        });
+
+        options.AddPolicy(SecurityPolicies.ManageInitiatives, policy =>
+        {
+            policy.RequireAuthenticatedUser();
+            policy.RequireClaim(ApplicationClaimTypes.AccountLocked, "False");
+            policy.RequireClaim(ApplicationClaimTypes.Permission, Permissions.ManageInitiatives);
+        });
         
     }
 }

--- a/src/Server.UI/Components/Initiatives/InitiativesTable.razor
+++ b/src/Server.UI/Components/Initiatives/InitiativesTable.razor
@@ -18,14 +18,16 @@
             <MudText Typo="Typo.h6">Initiatives</MudText>
             <MudSpacer />
             <MudCheckBox @bind-Value="_showExpired" @bind-Value:after="RefreshAsync" Label="Show expired" Color="Color.Default" Size="Size.Small" Class="mr-2" />
-            <MudButton Variant="Variant.Filled"
-                       Size="Size.Small"
-                       Disabled="@Loading"
-                       OnClick="@(() => OnAdd())"
-                       StartIcon="@Icons.Material.Filled.Add"
-                       Color="Color.Primary">
-                Add Initiative
-            </MudButton>
+            <AuthorizeView Policy="@SecurityPolicies.ManageInitiatives">
+                <MudButton Variant="Variant.Filled"
+                           Size="Size.Small"
+                           Disabled="@Loading"
+                           OnClick="@(() => OnAdd())"
+                           StartIcon="@Icons.Material.Filled.Add"
+                           Color="Color.Primary">
+                    Add Initiative
+                </MudButton>
+            </AuthorizeView>
         </ToolBarContent>
         <HeaderContent>
             <MudTh></MudTh>
@@ -48,16 +50,19 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd>
-                <MudMenu Icon="@Icons.Material.Filled.Edit" Variant="Variant.Filled" Size="Size.Small"
-                         Dense="true"
-                         EndIcon="@Icons.Material.Filled.KeyboardArrowDown" IconColor="Color.Info" AnchorOrigin="Origin.CenterLeft">
-                    <MudMenuItem OnClick="@(() => OnEdit(context))">
-                        @ConstantString.Edit
-                    </MudMenuItem>
-                    <MudMenuItem OnClick="@(() => OnAmendLifetime(context))">
-                        Amend Lifetime
-                    </MudMenuItem>
-                </MudMenu>
+                @{ var item = context; }
+                <AuthorizeView Policy="@SecurityPolicies.ManageInitiatives" Context="authContext">
+                    <MudMenu Icon="@Icons.Material.Filled.Edit" Variant="Variant.Filled" Size="Size.Small"
+                             Dense="true"
+                             EndIcon="@Icons.Material.Filled.KeyboardArrowDown" IconColor="Color.Info" AnchorOrigin="Origin.CenterLeft">
+                        <MudMenuItem OnClick="@(() => OnEdit(item))">
+                            @ConstantString.Edit
+                        </MudMenuItem>
+                        <MudMenuItem OnClick="@(() => OnAmendLifetime(item))">
+                            Amend Lifetime
+                        </MudMenuItem>
+                    </MudMenu>
+                </AuthorizeView>
             </MudTd>
             <MudTd DataLabel="Code">@context.Code</MudTd>
             <MudTd DataLabel="Description">@context.Description</MudTd>

--- a/src/Server.UI/Components/Initiatives/_Imports.razor
+++ b/src/Server.UI/Components/Initiatives/_Imports.razor
@@ -4,3 +4,4 @@
 @using Cfo.Cats.Application.Features.Initiatives.Commands.EditInitiative
 @using Cfo.Cats.Application.Common.Interfaces.Contracts
 @using Cfo.Cats.Application.Features.Contracts.DTOs
+@using Cfo.Cats.Application.SecurityConstants

--- a/src/Server.UI/Pages/Initiatives/Index.razor
+++ b/src/Server.UI/Pages/Initiatives/Index.razor
@@ -1,7 +1,7 @@
 @page "/pages/initiatives"
 @inject IStringLocalizer<Index> L
 
-@attribute [Authorize(Policy = SecurityPolicies.SeniorInternal)]
+@attribute [Authorize(Policy = SecurityPolicies.Initiatives)]
 
 <PageTitle>@Title</PageTitle>
 

--- a/src/Server.UI/Services/Navigation/AsyncMenuService.cs
+++ b/src/Server.UI/Services/Navigation/AsyncMenuService.cs
@@ -117,20 +117,26 @@ public class AsyncMenuService(IAuthorizationService authorizationService) : IAsy
                                 Title = "Labels",
                                 Href = "/pages/labels",
                                 PageStatus = PageStatus.Wip
-                            },
-                            new MenuSectionSubItemModel()
-                            {
-                                Title = "Initiatives",
-                                Href = "/pages/initiatives",
-                                PageStatus = PageStatus.Wip
                             }
-
                        ] 
                     });
                 }
 
                 menuItems.Add(management);
             }
+
+            if(await PassesPolicy(principal, SecurityPolicies.Initiatives))
+            {
+                management.SectionItems.Add(new()
+                {
+                   IsParent = false,
+                   Title = "Initiatives",
+                   Icon = Icons.Material.Filled.Lightbulb,
+                   Href = "/pages/initiatives",
+                   PageStatus = PageStatus.Wip
+                });
+            }
+
         }
 
         return menuItems;


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)

---

This pull request introduces a new, more granular permissions model for managing initiatives. It separates the "view" and "manage" permissions, updates authorization policies throughout the backend and frontend, and ensures the correct roles are seeded with these permissions. The result is improved security and a clearer separation of access levels for initiative-related features.

**Authorization Policy Changes**

* Added two new security policies in `SecurityPolicies`: `Initiatives` (for viewing) and `ManageInitiatives` (for managing initiatives), with corresponding constants and documentation. [[1]](diffhunk://#diff-6b90bc53bd40cca6b4abc3286eb0dc341452f80da03d317d9315286e019642b1R70-R79) [[2]](diffhunk://#diff-1b218de42a7ac50abb794c04f1bd54d74953d5afcbb109f74a0e4089f538b86bR10-R13)
* Implemented these new policies in the authorization setup (`AddCatsPolicies`), requiring the appropriate claims.

**Backend Command and Query Updates**

* Updated initiative command classes (`AddInitiativeCommand`, `EditInitiativeCommand`, `DeactivateInitiativeCommand`, `AmendInitiativeLifetimeCommand`) to require the `ManageInitiatives` policy instead of the previous, broader `SeniorInternal` policy. [[1]](diffhunk://#diff-84c03721fde4c14f33addf47f87da67137452b78841c3b4f26a160a57b64306cL8-R8) [[2]](diffhunk://#diff-44d91eacc165ac1c3069209e0eb9556c3f19b72b74b5f3ea34b749ed1d4118a9L8-R8) [[3]](diffhunk://#diff-a9e52a83e358c20798cc1e6ddf9831367c9e5834e2a0160378481a1a8212e548L6-R6) [[4]](diffhunk://#diff-6a0e55cfadd348b404803a7ac5854e19789853177109a5860f335d07f57abae9L7-R7)
* Changed the initiatives query (`GetInitiatives.Query`) and the initiatives page to require the new `Initiatives` policy for viewing. [[1]](diffhunk://#diff-f0ca2f01d66cc68f049ed0c95ab3863725cfb21ebb89b67092e96ad1f082866bL10-R10) [[2]](diffhunk://#diff-a3cc9318c5fac0c3c85765235ea28737cfd788c72acbe662d7a48492dd85f1fbL4-R4)

**Frontend UI & Navigation Updates**

* Updated the initiatives table UI to show management actions (Add/Edit/Amend) only to users with the `ManageInitiatives` policy. [[1]](diffhunk://#diff-95dc9c74ca60feb51acf4db540f88c46c4aadfc9e329d2ed39e953976011ad69R21) [[2]](diffhunk://#diff-95dc9c74ca60feb51acf4db540f88c46c4aadfc9e329d2ed39e953976011ad69R30) [[3]](diffhunk://#diff-95dc9c74ca60feb51acf4db540f88c46c4aadfc9e329d2ed39e953976011ad69R53-R65)
* Adjusted the navigation menu to display the "Initiatives" link only if the user passes the `Initiatives` policy.

**Database Seeding**

* Added a new SQL script to seed the correct roles with the new `Initiatives` and `Manage Initiatives` permissions.