### PR TITLE
Feature/index optomizations

### DIFF
--- a/src/Database/CatsDb/Participant/Tables/EnrolmentHistory.sql
+++ b/src/Database/CatsDb/Participant/Tables/EnrolmentHistory.sql
@@ -13,8 +13,26 @@ CREATE TABLE [Participant].[EnrolmentHistory] (
 );
 GO
 
-CREATE NONCLUSTERED INDEX [IX_EnrolmentHistory_ParticipantId]
-    ON [Participant].[EnrolmentHistory]([ParticipantId] ASC);
+/*
+Optimized index for 'latest and previous enrolment status per participant'
+*/
+CREATE NONCLUSTERED INDEX IX_EnrolmentHistory_ParticipantId_Created_DESC
+ON [Participant].[EnrolmentHistory]
+(
+    [ParticipantId],
+    [Created] DESC
+)
+INCLUDE
+(
+    [EnrolmentStatus]
+)
+WITH
+(
+    FILLFACTOR = 100,
+    SORT_IN_TEMPDB = ON,
+    ONLINE = ON
+);
+
 GO
 
 ALTER TABLE [Participant].[EnrolmentHistory]

--- a/src/Database/CatsDb/Participant/Tables/Participant.sql
+++ b/src/Database/CatsDb/Participant/Tables/Participant.sql
@@ -32,20 +32,8 @@ CREATE TABLE [Participant].[Participant] (
 );
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Participant_CurrentLocationId]
-    ON [Participant].[Participant]([CurrentLocationId] ASC);
-GO
-
-CREATE NONCLUSTERED INDEX [IX_Participant_EnrolmentLocationId]
-    ON [Participant].[Participant]([EnrolmentLocationId] ASC);
-GO
-
 CREATE NONCLUSTERED INDEX [IX_Participant_OwnerId]
     ON [Participant].[Participant]([OwnerId] ASC);
-GO
-
-CREATE NONCLUSTERED INDEX [IX_Participant_EditorId]
-    ON [Participant].[Participant]([EditorId] ASC);
 GO
 
 ALTER TABLE [Participant].[Participant]

--- a/src/Database/CatsDb/Participant/Tables/Participant.sql
+++ b/src/Database/CatsDb/Participant/Tables/Participant.sql
@@ -32,8 +32,47 @@ CREATE TABLE [Participant].[Participant] (
 );
 GO
 
-CREATE NONCLUSTERED INDEX [IX_Participant_OwnerId]
-    ON [Participant].[Participant]([OwnerId] ASC);
+-- this covers a lot of the owner id centric aggregate queries
+CREATE NONCLUSTERED INDEX [IX_Participant_OwnerId_Covering]
+ON [Participant].[Participant] ([OwnerId])
+INCLUDE (    
+    [EnrolmentStatus],    
+    [CurrentLocationId],    
+    [EnrolmentLocationId],    
+    [Created],    
+    [LastModified],    
+    [FirstName],    
+    [LastName])
+    WITH (FILLFACTOR = 95);
+
+GO
+
+-- covers enrolment status queries and dashboards
+CREATE NONCLUSTERED INDEX [IX_Participant_EnrolmentStatus_Covering]
+ON [Participant].[Participant] ([EnrolmentStatus])
+INCLUDE (
+    [OwnerId],
+    [CurrentLocationId],
+    [EnrolmentLocationId],
+    [RiskDue],
+    [DeactivatedInFeed],
+    [FirstName],
+    [LastName]
+)
+WITH (FILLFACTOR = 95);
+GO
+
+-- Composite OwnerId + EnrolmentStatus (highest-value seek pattern)
+CREATE NONCLUSTERED INDEX [IX_Participant_OwnerId_EnrolmentStatus]
+ON [Participant].[Participant] ([OwnerId], [EnrolmentStatus])
+INCLUDE (
+    [CurrentLocationId],
+    [EnrolmentLocationId],
+    [RiskDue],
+    [Created],
+    [LastModified]
+)
+WITH (FILLFACTOR = 95);
 GO
 
 ALTER TABLE [Participant].[Participant]


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [x] Not required (explain below)


---

This pull request makes targeted improvements to database indexing in the `Participant` schema to optimize query performance, especially for common access patterns involving enrolment status and ownership. The changes replace several older indexes with new, more efficient covering indexes that better support dashboard queries and aggregate lookups.

**Index optimizations for query performance:**

* Replaced the old `IX_EnrolmentHistory_ParticipantId` index with a new index `IX_EnrolmentHistory_ParticipantId_Created_DESC` on `[Participant].[EnrolmentHistory]` that includes `[Created] DESC` and covers `[EnrolmentStatus]`, with options set for optimal online index creation. This is designed to efficiently support queries for the latest and previous enrolment status per participant.
* Removed several single-column indexes from `[Participant].[Participant]` (such as `IX_Participant_CurrentLocationId`, `IX_Participant_EnrolmentLocationId`, `IX_Participant_OwnerId`, and `IX_Participant_EditorId`) and replaced them with new covering indexes tailored for the most common query patterns:
  - `IX_Participant_OwnerId_Covering`: Supports owner-centric aggregate queries by including relevant participant attributes.
  - `IX_Participant_EnrolmentStatus_Covering`: Optimizes enrolment status queries and dashboard performance by including key participant fields.
  - `IX_Participant_OwnerId_EnrolmentStatus`: Targets the highest-value seek pattern with a composite index on `OwnerId` and `EnrolmentStatus`, including additional fields for query coverage.