### PR TITLE
Adjust assessment to be stored in tabular format rather than json

### DIFF
--- a/src/Application/Features/Assessments/Commands/BeginAssessment.cs
+++ b/src/Application/Features/Assessments/Commands/BeginAssessment.cs
@@ -13,7 +13,6 @@ using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Working;
 using Cfo.Cats.Application.Features.Locations.DTOs;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Entities.Assessments;
-using Newtonsoft.Json;
 
 namespace Cfo.Cats.Application.Features.Assessments.Commands;
 
@@ -64,12 +63,7 @@ public static class BeginAssessment
                 ]
             };
 
-            string json = JsonConvert.SerializeObject(assessment, new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Auto
-            });
-            
-            ParticipantAssessment pa = ParticipantAssessment.Create(assessment.Id, request.ParticipantId, assessmentJson: json, _currentUserService.TenantId!, request.Location!.Id);
+            ParticipantAssessment pa = ParticipantAssessment.Create(assessment.Id, request.ParticipantId, _currentUserService.TenantId!, request.Location!.Id);
             foreach (var pathway in assessment.Pathways)
             {
                 pa.SetPathwayScore(pathway.Title, -1);

--- a/src/Application/Features/Assessments/Commands/SaveAssessment.cs
+++ b/src/Application/Features/Assessments/Commands/SaveAssessment.cs
@@ -4,7 +4,6 @@ using Cfo.Cats.Application.Features.Assessments.Caching;
 using Cfo.Cats.Application.Features.Assessments.DTOs;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Entities.Assessments;
-using Newtonsoft.Json;
 
 namespace Cfo.Cats.Application.Features.Assessments.Commands;
 
@@ -32,11 +31,22 @@ public static class SaveAssessment
                                            request.Assessment.Id,
                                            request.Assessment.ParticipantId
                                        });
-            
-            pa.UpdateJson(JsonConvert.SerializeObject(request.Assessment, new JsonSerializerSettings
+
+            foreach (var pathway in request.Assessment.Pathways)
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            }));
+                foreach (var question in pathway.Questions())
+                {
+                    switch (question)
+                    {
+                        case SingleChoiceQuestion single when single.Answer is not null:
+                            pa.SetAnswer(single.Code, single.Answer);
+                            break;
+                        case MultipleChoiceQuestion multi when multi.Answers is not null:
+                            pa.SetAnswers(multi.Code, multi.Answers);
+                            break;
+                    }
+                }
+            }
 
             if (request.Submit)
             {

--- a/src/Application/Features/Assessments/DTOs/Assessment.cs
+++ b/src/Application/Features/Assessments/DTOs/Assessment.cs
@@ -5,4 +5,31 @@ public class Assessment
     public required Guid Id { get; set; }
     public required string ParticipantId { get; set; }
     public required PathwayBase[] Pathways { get; set; }
+
+    /// <summary>
+    /// Populates question answers from tabular storage.
+    /// For each question across all pathways, the matching answers are looked up
+    /// by <see cref="QuestionBase.Code"/> and applied to <see cref="SingleChoiceQuestion.Answer"/>
+    /// or <see cref="MultipleChoiceQuestion.Answers"/> as appropriate.
+    /// </summary>
+    public Assessment WithAnswers(ILookup<string, string> answers)
+    {
+        foreach (var pathway in Pathways)
+        {
+            foreach (var question in pathway.Questions())
+            {
+                var questionAnswers = answers[question.Code].ToList();
+                switch (question)
+                {
+                    case SingleChoiceQuestion single:
+                        single.Answer = questionAnswers.FirstOrDefault();
+                        break;
+                    case MultipleChoiceQuestion multi:
+                        multi.Answers = questionAnswers.Count > 0 ? questionAnswers : null;
+                        break;
+                }
+            }
+        }
+        return this;
+    }
 }

--- a/src/Application/Features/Assessments/DTOs/QuestionBase.cs
+++ b/src/Application/Features/Assessments/DTOs/QuestionBase.cs
@@ -43,6 +43,12 @@ public abstract partial class QuestionBase
     public string[] Options { get; }
 
     /// <summary>
+    ///     A stable identifier for this question (e.g. "B1", "D3").
+    ///     Used as the key when persisting answers in tabular storage.
+    /// </summary>
+    public abstract string Code { get; }
+
+    /// <summary>
     ///     Is the answer valid
     /// </summary>
     /// <returns>True if the answer has a valid return value</returns>

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D1.cs
@@ -10,6 +10,7 @@ public class D1() : SingleChoiceQuestion("What is your highest level of qualific
         DegreeOrHigher
     ])
 {
+    public override string Code => nameof(D1);
     public const string NoQualificationsOrEntryLevel = "No quals / entry level Example:Skills for life";
     public const string NvqLevelOneOrSimilar = "NVQ level 1 or similar Example:Grade D/3 or lower at GCSE";
     public const string FivePlusGcsesOrSimilar = "5+ GCSEs, NVQ level 2, etc. Example:Grade C/4 or higher at GCSE";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D2.cs
@@ -6,6 +6,7 @@ public class D2() : SingleChoiceQuestion("Did you finish school?",
         LeftBefore11
     ])
 { 
+    public override string Code => nameof(D2);
     public const string YesFinishedSchool = "Yes";
     public const string LeftBefore16 = "Left before age 16";
     public const string LeftBefore11 = "Left before age 11";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D3.cs
@@ -16,6 +16,7 @@ public class D3() : MultipleChoiceQuestion("Have you been diagnosed with or feel
         NoneOftheGivenOptions
     ])
 {
+    public override string Code => nameof(D3);
     public const string AutismOrASD = "Autism / ASD";
     public const string AdhdOrAdd= "ADHD / ADD";
     public const string Epilepsy = "Epilepsy";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D4.cs
@@ -15,6 +15,7 @@ public class D4() : MultipleChoiceQuestion("Do you have difficulty with any of t
         NoneOfThese,
     ])
 {
+    public override string Code => nameof(D4);
     public const string ReadingDifficulty = "Reading";
     public const string CoordinationDifficulty = "Coordination";
     public const string WritingDifficulty = "Writing";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Education/D5.cs
@@ -16,6 +16,7 @@ public class D5() : MultipleChoiceQuestion("In the last 12 months have you parti
         NoneOftheGivenOptions
     ])
 {
+    public override string Code => nameof(D5);
     public const string Painting = "Painting";
     public const string MakingFilms = "Making films";
     public const string Drawing = "Drawing";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E1.cs
@@ -7,6 +7,7 @@ public class E1() : SingleChoiceQuestion("How is your health in general?", [
     VeryGood,
 ])
 {
+    public override string Code => nameof(E1);
     public const string VeryBad = "Very bad";
     public const string Bad = "Bad";
     public const string Fair = "Fair";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E2.cs
@@ -8,6 +8,7 @@ public class E2(): SingleChoiceQuestion("Do you consider yourself disabled?", "F
         
     ])
 {
+    public override string Code => nameof(E2);
     public const string No = "No";
     public const string LittleImpairment = "Yes, A little impairment";
     public const string LotOfImpairment = "Yes, A lot of impairment";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E3.cs
@@ -7,6 +7,7 @@ public class E3() : SingleChoiceQuestion("Are you currently taking any regular m
         NotSure
     ])
 {
+    public override string Code => nameof(E3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NotSure = "Not Sure";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E4.cs
@@ -7,6 +7,7 @@ public class E4() : SingleChoiceQuestion("Are you registered with a GP and denti
         NotRegisteredWithGPOrDentist
     ])
 {
+    public override string Code => nameof(E4);
     public const string RegisteredWithGPAndDentist = "Registered with both";
     public const string RegisteredWithGPOnly = "Registered with a GP only";
     public const string RegisteredWithDentistOnly = "Registered with a dentist only";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E5.cs
@@ -8,6 +8,7 @@ public class E5() : SingleChoiceQuestion("How much sport, exercise or physical a
         Over2AndHalfHoursPerWeek
     ])
 {
+    public override string Code => nameof(E5);
     public const string LessThan30MinutesPerWeek = "Less than 30min per week";
     public const string ThirtyMinutesTo2AndHalfHoursPerWeek = "30min to 2½ hr per week";
     public const string Over2AndHalfHoursPerWeek = "Over 2½ hrs per week";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E6.cs
@@ -13,6 +13,7 @@ public class E6() : MultipleChoiceQuestion("Do you have a problem, receive, or r
         None
     ])
 {
+    public override string Code => nameof(E6);
     public const string Alcohol = "Alcohol";
     public const string Gambling = "Gambling";
     public const string IllegalDrugsOrSubstances = "Illegal drugs / substances";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E7.cs
@@ -13,6 +13,7 @@ public class E7() : MultipleChoiceQuestion("Have you previously had a problem or
         None
     ])
 {
+    public override string Code => nameof(E7);
     public const string Alcohol = "Alcohol";
     public const string Gambling = "Gambling";
     public const string IllegalDrugsOrSubstances = "Illegal drugs / substances";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E8.cs
@@ -7,6 +7,7 @@ public class E8() : SingleChoiceQuestion("Are you a smoker?",
         NeverSmoked
     ])
 {
+    public override string Code => nameof(E8);
     public const string Yes = "Yes";
     public const string IUsedTo = "I used to";
     public const string NeverSmoked = "Never smoked";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/HealthAndAdditiction/E9.cs
@@ -7,6 +7,7 @@ public class E9() : SingleChoiceQuestion("Are you a vaper?",
         NeverVaped
     ])
 {
+    public override string Code => nameof(E9);
     public const string Yes = "Yes";
     public const string IUsedTo = "I used to";
     public const string NeverVaped = "Never vaped";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B1.cs
@@ -11,6 +11,7 @@ public class B1() : SingleChoiceQuestion("Where do you normally live or spend mo
     ]
 )
 {
+    public override string Code => nameof(B1);
     public const string SleepRough = "Sleep rough";
     public const string ShelterHostelEmergencyHousingOrAP = "Shelter, hostel, emergency housing or AP";
     public const string TemporarilyStayingWithFamilyOrFriends = "Temporarily staying with family or friends";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B2.cs
@@ -12,6 +12,7 @@ public class B2() : MultipleChoiceQuestion("Are you facing any of the following 
     NoneOftheGivenOptions
 ])
 {
+    public override string Code => nameof(B2);
     public const string BehindOnRentOrMortgage = "Behind on rent/mortgage";
     public const string FacingEviction = "Facing eviction";
     public const string LicenceRestrictionsForcedMove = "Having to move due to licence restrictions";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B3.cs
@@ -13,6 +13,7 @@ public class B3()
             NoneOftheGivenOptions
         ])
 {
+    public override string Code => nameof(B3);
     public const string CookingOrMealPlanningOrHealthyEatingStruggle = "Cooking/meal planning/healthy eating";
     public const string CleaningOrLookingAfterYourHomeStruggle = "Cleaning or looking after your home";
     public const string KeepingYourHomeWarmStruggle = "Keeping your home warm";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B4.cs
@@ -11,6 +11,7 @@ public class B4() : SingleChoiceQuestion(
         VerySatisfied,
     ])
 {
+    public override string Code => nameof(B4);
     public const string VeryDissatisfied = "Very dissatisfied";
     public const string SlightlyDissatisfied = "Slightly dissatisfied";
     public const string NeitherSatisfiedOrDissatisfied = "Neither satisfied or dissatisfied";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B5.cs
@@ -9,6 +9,7 @@ public class B5() : SingleChoiceQuestion(
         VerySafeToWalkAloneAfterDarkInLocalArea,
     ])
 {
+    public override string Code => nameof(B5);
     public const string VeryUnsafeToWalkAloneAfterDarkInLocalArea = "Very unsafe";
     public const string ABitUnsafeToWalkAloneAfterDarkInLocalArea = "A bit unsafe";
     public const string FairlySafeToWalkAloneAfterDarkInLocalArea = "Fairly safe";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Housing/B6.cs
@@ -12,6 +12,7 @@ public class B6() : MultipleChoiceQuestion(
         LiveAlone
     ])
 {
+    public override string Code => nameof(B6);
     public const string LivingWithPartnerOrSpouse = "Partner/spouse";
     public const string LivingWithOtherFamilyMembers = "Other family members";
     public const string LivingWithOwnChildren = "Own Children";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C1.cs
@@ -10,6 +10,7 @@ public class C1() : SingleChoiceQuestion("How are you coping with money?",
         LivingComfortably
     ])
 {
+    public override string Code => nameof(C1);
     public const string FindingVeryDifficult = "Finding it very difficult";
     public const string FindingQuiteDifficult = "Finding it quite difficult";
     public const string JustAboutGettingBy= "Just about getting by";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C2.cs
@@ -4,6 +4,7 @@ public class C2()
     : SingleChoiceQuestion("Are you behind on credit card or store card payments or in paying your household bills?",
         [Yes, No])
 {
+    public override string Code => nameof(C2);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C3.cs
@@ -5,6 +5,7 @@ public class C3()
         "This includes things such as court fines but doesn’t include mortgages or secured loans.",
         [Yes, No])
 {
+    public override string Code => nameof(C3);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C4.cs
@@ -5,6 +5,7 @@ public class C4()
         "This includes owing money to loan sharks, prison debt, drug debt or owing family/friends.",
         [Yes, No])
 {
+    public override string Code => nameof(C4);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C5.cs
@@ -3,6 +3,7 @@ namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Money;
 public class C5()
     : SingleChoiceQuestion("Do you have a bank account?", [Yes, No])
 {
+    public override string Code => nameof(C5);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C6.cs
@@ -3,6 +3,7 @@ namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Money;
 public class C6() : SingleChoiceQuestion("Do you have a valid ID?", "(e.g. passport)",
     [Yes, No])
 {
+    public override string Code => nameof(C6);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C7.cs
@@ -6,6 +6,7 @@ public class C7() : SingleChoiceQuestion("Do you need help with budgeting or man
     No
 ])
 {
+    public override string Code => nameof(C7);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C8.cs
@@ -6,6 +6,7 @@ public class C8()
         No
  ])
 {
+    public override string Code => nameof(C8);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Money/C9.cs
@@ -11,6 +11,7 @@ public class C9() : SingleChoiceQuestion(
     ]
 )
 {
+    public override string Code => nameof(C9);
     public const string Never = "Never";
     public const string OverYearAgo = "Over a year ago";
     public const string WithinTheLastYear = "Within the last year";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F1.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F1() : SingleChoiceQuestion("How happy are you with your current personal relationships?",
     [
@@ -9,6 +9,7 @@ public class F1() : SingleChoiceQuestion("How happy are you with your current pe
         ExtremelyHappy,
     ])
 {
+    public override string Code => nameof(F1);
     public const string ExtremelyUnhappy = "Extremely unhappy";
     public const string FairlyUnhappy = "Fairly unhappy";
     public const string Happy = "Happy";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F2.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F2() : SingleChoiceQuestion("How often do you feel lonely?",
     [
@@ -9,6 +9,7 @@ public class F2() : SingleChoiceQuestion("How often do you feel lonely?",
         Never,
     ])
 {
+    public override string Code => nameof(F2);
     public const string OftenOrAlways = "Often or always";
     public const string Sometimes = "Some of the time";
     public const string Occasionally = "Occasionally";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F3.cs
@@ -1,12 +1,13 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F3() : SingleChoiceQuestion("Are you interested in having a mentor?", "For example, someone to give you support, advice, and guidance to help you.",
     [
-        Yes, 
-        No, 
+        Yes,
+        No,
         NotSure
     ])
 {
+    public override string Code => nameof(F3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NotSure = "Not sure";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F4.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F4() : SingleChoiceQuestion("Do you feel you could be a suitable mentor for someone else?",
     [
@@ -7,6 +7,7 @@ public class F4() : SingleChoiceQuestion("Do you feel you could be a suitable me
         NotSure
     ])
 {
+    public override string Code => nameof(F4);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NotSure = "Not sure";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F5.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F5() : SingleChoiceQuestion("How often do you see family or close friends in person?",
     [
@@ -7,6 +7,7 @@ public class F5() : SingleChoiceQuestion("How often do you see family or close f
         RarelyOrNever,
     ])
 {
+    public override string Code => nameof(F5);
     public const string AtleastOncePerWeek = "At least once per week";
     public const string LessThanOncePerWeek = "Less than once per week";
     public const string RarelyOrNever = "Rarely or never";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F6.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F6() : SingleChoiceQuestion("On a scale 1 to 5, in general how much do you trust most people?",
     [
@@ -9,6 +9,7 @@ public class F6() : SingleChoiceQuestion("On a scale 1 to 5, in general how much
         Completely,
     ])
 {
+    public override string Code => nameof(F6);
     public const string NotAtAll = "1 Not at all";
     public const string ALittle = "2 A little";
     public const string Somewhat = "3 Somewhat";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F7.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F7() : MultipleChoiceQuestion("Do you feel you can trust, confide in, and rely on any of the following? (tick all that apply)",
     [
@@ -10,6 +10,7 @@ public class F7() : MultipleChoiceQuestion("Do you feel you can trust, confide i
         NoneOfThese,
     ])
 {
+    public override string Code => nameof(F7);
     public const string PartnerOrSpouse = "A partner / spouse";
     public const string CloseFriend = "A close friend";
     public const string ParentOrGuardian = "A parent / guardian";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F8.cs
@@ -1,6 +1,6 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
-public class F8() : SingleChoiceQuestion("Are you a carer?", 
+public class F8() : SingleChoiceQuestion("Are you a carer?",
     "For example, do you provide unpaid care for family or a friend who needs help due to their illness, disability, mental health problem or an addiction? This can be officially or unofficially.",
     [
         No,
@@ -10,6 +10,7 @@ public class F8() : SingleChoiceQuestion("Are you a carer?",
         FiftyPlusHoursPerWeek
     ])
 {
+    public override string Code => nameof(F8);
     public const string No = "No";
     public const string UnderTenHoursPerWeek = "Yes - Under 10 hrs per week";
     public const string Between10And34HoursPerWeek = "Yes - 10 - 34 hrs per week";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Relationships/F9.cs
@@ -1,4 +1,4 @@
-﻿namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
 
 public class F9() : SingleChoiceQuestion("Which of the following best describes your parental situation?",
     "Try to select the option which best describes your situation.",
@@ -10,6 +10,7 @@ public class F9() : SingleChoiceQuestion("Which of the following best describes 
         LoneParent,
     ])
 {
+    public override string Code => nameof(F9);
     public const string NoChildren = "I do not have children";
     public const string ChildrenNoCareResponsibility = "I have children but I am not responsible for their care";
     public const string AdultChildrenOrLeftHome = "My children are adults / have left home";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G1.cs
@@ -9,6 +9,7 @@ public class G1() : SingleChoiceQuestion("I tend to bounce back quickly after ha
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G1);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G10.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G10.cs
@@ -17,6 +17,7 @@ public class G10() : MultipleChoiceQuestion("Which of the following is/are the m
         Nothing
     ])
 {
+    public override string Code => nameof(G10);
     public const string YourOffending = "Your offending";
     public const string LearningAndEducation = "Learning & education";
     public const string WellbeingAndMentalHealth = "Your wellbeing & mental health";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G2.cs
@@ -9,6 +9,7 @@ public class G2() : SingleChoiceQuestion("I often do things without thinking of 
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G2);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G3.cs
@@ -9,6 +9,7 @@ public class G3() : SingleChoiceQuestion("I am really working hard to change my 
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G3);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G4.cs
@@ -9,6 +9,7 @@ public class G4() : SingleChoiceQuestion("My life is full of problems which I ca
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G4);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G5.cs
@@ -9,6 +9,7 @@ public class G5() : SingleChoiceQuestion("I feel good about myself",
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G5);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G6.cs
@@ -9,6 +9,7 @@ public class G6() : SingleChoiceQuestion("I find it easy to adapt to changes in 
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G6);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G7.cs
@@ -9,6 +9,7 @@ public class G7() : SingleChoiceQuestion("I struggle to understand my own or oth
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G7);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G8.cs
@@ -9,6 +9,7 @@ public class G8() : SingleChoiceQuestion("My emotions can get the better of me",
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G8);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/ThoughtsAndBehaviours/G9.cs
@@ -9,6 +9,7 @@ public class G9() : SingleChoiceQuestion("I find it easy to talk to other people
         StronglyAgree
     ])
 {
+    public override string Code => nameof(G9);
     public const string StronglyDisagree = "Strongly disagree";
     public const string Disagree = "Disagree";
     public const string Neither = "Neither";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H1.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H1() : HealthCoreQuestion("I have felt tense, anxious or nervous");
+public class H1() : HealthCoreQuestion("I have felt tense, anxious or nervous")
+{
+    public override string Code => nameof(H1);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H10.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H10.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H10() : HealthCoreQuestion("I have felt I have someone to turn to for support when needed");
+public class H10() : HealthCoreQuestion("I have felt I have someone to turn to for support when needed")
+{
+    public override string Code => nameof(H10);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H11.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H11.cs
@@ -8,6 +8,7 @@ public class H11() : SingleChoiceQuestion("On a scale 1 to 5, overall how satisf
     Completely
 ])
 {
+    public override string Code => nameof(H11);
     public const string NotAtAll = "1 Not at all";
     public const string MostlyNot = "2 Mostly not";
     public const string Fairly  = "3 Fairly";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H12.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H12.cs
@@ -7,6 +7,7 @@ public class H12() : SingleChoiceQuestion("How often do you feel stressed?", [
     RarelyOrNever
 ])
 {
+    public override string Code => nameof(H12);
     public const string EveryDay = "Every day";
     public const string OneToTwoTimesPerWeek = "1-2 times a week";
     public const string FewTimesAMonth = "Few times a month";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H13.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H13.cs
@@ -17,6 +17,7 @@ public class H13() : MultipleChoiceQuestion("Do you live with any of the followi
         Other,
         NoneOfThese])
 {
+    public override string Code => nameof(H13);
     public const string AnxietyDisorders = "Anxiety disorders";
     public const string BipolarDisorder = "Bipolar Disorder";
     public const string BorderlinePersonalityDisorder = "Borderline Personality Disorder";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H2.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H2() : HealthCoreQuestion("I have felt able to cope when things go wrong");
+public class H2() : HealthCoreQuestion("I have felt able to cope when things go wrong")
+{
+    public override string Code => nameof(H2);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H3.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H3() : HealthCoreQuestion("Talking to people has felt too much for me");
+public class H3() : HealthCoreQuestion("Talking to people has felt too much for me")
+{
+    public override string Code => nameof(H3);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H4.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H4() : HealthCoreQuestion("I have felt panic or terror");
+public class H4() : HealthCoreQuestion("I have felt panic or terror")
+{
+    public override string Code => nameof(H4);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H5.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H5() : HealthCoreQuestion("I made plans to end my life");
+public class H5() : HealthCoreQuestion("I made plans to end my life")
+{
+    public override string Code => nameof(H5);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H6.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H6() : HealthCoreQuestion("I have had difficulty getting to sleep or staying asleep");
+public class H6() : HealthCoreQuestion("I have had difficulty getting to sleep or staying asleep")
+{
+    public override string Code => nameof(H6);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H7.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H7() : HealthCoreQuestion("I have felt despairing or helpless");
+public class H7() : HealthCoreQuestion("I have felt despairing or helpless")
+{
+    public override string Code => nameof(H7);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H8.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H8() : HealthCoreQuestion("I have felt unhappy");
+public class H8() : HealthCoreQuestion("I have felt unhappy")
+{
+    public override string Code => nameof(H8);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/WellbeingAndMentalHealth/H9.cs
@@ -1,3 +1,6 @@
 namespace Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
 
-public class H9() : HealthCoreQuestion("Unwanted images or memories have been distressing me");
+public class H9() : HealthCoreQuestion("Unwanted images or memories have been distressing me")
+{
+    public override string Code => nameof(H9);
+}

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A1.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A1.cs
@@ -10,6 +10,7 @@ public class A1() : SingleChoiceQuestion("What is your current employment status
     InPermanentJob
 ])
 {
+    public override string Code => nameof(A1);
     public const string DoNotWantAJob = "Do not want a job";
     public const string WantAJobButCannotWork = "Want a job but cannot work";
     public const string LookingForWork = "Looking for work";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A10.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A10.cs
@@ -7,6 +7,7 @@ public class A10() : SingleChoiceQuestion("Do you or your household have access 
     No,
 ])
 {
+    public override string Code => nameof(A10);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A2.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A2.cs
@@ -9,6 +9,7 @@ public class A2() : SingleChoiceQuestion(
     CurrentlyWorking
 ])
 {
+    public override string Code => nameof(A2);
     public const string NeverWorked = "I have never worked";
     public const string OverAYearAgo = "Over a year ago";
     public const string InTheLastYear = "In the last year";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A3.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A3.cs
@@ -7,6 +7,7 @@ public class A3() : SingleChoiceQuestion("Does or would your offence limit the t
     NotSure
 ])
 {
+    public override string Code => nameof(A3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NotSure = "Not Sure";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A4.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A4.cs
@@ -9,6 +9,7 @@ public class A4()
         NoPreferNot
     ])
 {
+    public override string Code => nameof(A4);
     public const string AtLeastOncePerMonth = "Yes - at least once per month";
     public const string LessThanOncePerMonth = "Yes - less than once per month";
     public const string NoCannot = "No - I am currently unable to";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A5.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A5.cs
@@ -6,6 +6,7 @@ public class A5() : SingleChoiceQuestion("Do you know how to find and apply for 
     No
 ])
 {
+    public override string Code => nameof(A5);
     public const string Yes = "Yes";
     public const string No = "No";
 };

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A6.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A6.cs
@@ -7,6 +7,7 @@ public class A6() : SingleChoiceQuestion("Are you able to fill in application fo
     No
 ])
 {
+    public override string Code => nameof(A6);
     public const string YesUnaided = "Yes, unaided";
     public const string YesWithHelp = "Yes, with help";
     public const string No = "No";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A7.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A7.cs
@@ -6,6 +6,7 @@ public class A7() : SingleChoiceQuestion("Are you comfortable using computers, t
     No
 ])
 {
+    public override string Code => nameof(A7);
     public const string Yes = "Yes";
     public const string No = "No";
 }

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A8.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A8.cs
@@ -10,6 +10,7 @@ public class A8() : SingleChoiceQuestion(
 ]
 )
 {
+    public override string Code => nameof(A8);
     public const string Yes = "Yes";
     public const string YesStruggleToAffordData = "Yes, but I struggle to afford data";
     public const string No = "No";

--- a/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A9.cs
+++ b/src/Application/Features/Assessments/DTOs/V1/Pathways/Working/A9.cs
@@ -8,6 +8,7 @@ public class A9() : SingleChoiceQuestion(
 ]
 )
 {
+    public override string Code => nameof(A9);
     public const string Yes = "Yes";
     public const string No = "No";
 };

--- a/src/Application/Features/Assessments/Queries/GetAssessment.cs
+++ b/src/Application/Features/Assessments/Queries/GetAssessment.cs
@@ -1,8 +1,15 @@
-﻿using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Security;
 using Cfo.Cats.Application.Common.Validators;
 using Cfo.Cats.Application.Features.Assessments.DTOs;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Education;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.HealthAndAdditiction;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Housing;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Money;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Relationships;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.ThoughtsAndBehaviours;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.WellbeingAndMentalHealth;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Working;
 using Cfo.Cats.Application.SecurityConstants;
-using Newtonsoft.Json;
 
 namespace Cfo.Cats.Application.Features.Assessments.Queries;
 
@@ -43,11 +50,22 @@ public static class GetAssessment
                 return Result<Assessment>.Failure(["Assessment not found"]);
             }
 
-            Assessment assessment = JsonConvert.DeserializeObject<Assessment>(pa.AssessmentJson,
-            new JsonSerializerSettings
+            var assessment = new Assessment
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            })!;
+                Id = pa.Id,
+                ParticipantId = pa.ParticipantId,
+                Pathways =
+                [
+                    new WorkingPathway(),
+                    new HousingPathway(),
+                    new MoneyPathway(),
+                    new EducationPathway(),
+                    new HealthAndAddictionPathway(),
+                    new RelationshipsPathway(),
+                    new ThoughtsAndBehavioursPathway(),
+                    new WellbeingAndMentalHealthPathway(),
+                ]
+            }.WithAnswers(pa.Answers.ToLookup(a => a.QuestionCode, a => a.Answer));
 
             return Result<Assessment>.Success(assessment);
         }

--- a/src/Database/CatsDb/Participant/Tables/Assessment.sql
+++ b/src/Database/CatsDb/Participant/Tables/Assessment.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [Participant].[Assessment] (
     [Id]             UNIQUEIDENTIFIER NOT NULL,
     [ParticipantId]  NVARCHAR (9)     NOT NULL,
-    [AssessmentJson] NVARCHAR (MAX)   NOT NULL,
+    [AssessmentJson] NVARCHAR (MAX)   NULL,
     [TenantId]       NVARCHAR (50)    NULL,
     [Created]        DATETIME2 (7)    NULL,
     [CreatedBy]      NVARCHAR (36)    NULL,

--- a/src/Database/CatsDb/Participant/Tables/AssessmentAnswer.sql
+++ b/src/Database/CatsDb/Participant/Tables/AssessmentAnswer.sql
@@ -1,0 +1,30 @@
+CREATE TABLE [Participant].[AssessmentAnswer] (
+    [Id] INT IDENTITY(1,1) NOT NULL,
+    [AssessmentId]       UNIQUEIDENTIFIER NOT NULL,
+    [QuestionCode]       NVARCHAR(3)   NOT NULL,
+    [Answer]             NVARCHAR(80)  NOT NULL,
+
+    CONSTRAINT [PK_AssessmentAnswer]
+        PRIMARY KEY CLUSTERED ([Id])
+);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [UQ_AssessmentAnswer_BusinessKey]
+ON [Participant].[AssessmentAnswer]
+(
+    [AssessmentId],
+    [QuestionCode],
+    [Answer]
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_AssessmentAnswer_AssessmentId]
+ON [Participant].[AssessmentAnswer] ([AssessmentId]);
+GO
+
+ALTER TABLE [Participant].[AssessmentAnswer]
+ADD CONSTRAINT [FK_AssessmentAnswer_Assessment_AssessmentId]
+FOREIGN KEY ([AssessmentId])
+REFERENCES [Participant].[Assessment] ([Id])
+ON DELETE CASCADE;
+GO

--- a/src/DatabaseSeeding/Scripts/0061_AssessmentAnswers.sql
+++ b/src/DatabaseSeeding/Scripts/0061_AssessmentAnswers.sql
@@ -1,0 +1,39 @@
+IF NOT EXISTS (SELECT TOP(1) 1 FROM [Participant].[AssessmentAnswer])
+BEGIN
+
+    -- Single-choice questions: each question object has { "Answer": "..." }
+    -- A third OPENJSON level opens each question object; filtering on ans.[key] = 'Answer'
+    -- naturally excludes the pathway-level $type row (non-JSON value produces no rows via CROSS APPLY)
+    -- and multi-choice questions (which have Answers, not Answer).
+    INSERT INTO [Participant].[AssessmentAnswer] ([AssessmentId], [QuestionCode], [Answer])
+    SELECT
+        a.[Id],
+        q.[key],
+        ans.[value]
+    FROM [Participant].[Assessment] a
+    CROSS APPLY OPENJSON(a.[AssessmentJson], '$.Pathways') pathways
+    CROSS APPLY OPENJSON(pathways.[value]) q
+    CROSS APPLY OPENJSON(q.[value]) ans
+    WHERE q.[key] != '$type'
+      AND ans.[key] = 'Answer'
+      AND ans.[value] is not null;
+
+    -- Multiple-choice questions: each question object has { "Answers": { "$type": "...", "$values": [...] } }
+    -- Newtonsoft wraps IEnumerable<string> as {"$type":"...","$values":[...]} with TypeNameHandling.Auto.
+    -- ans opens the question object; v opens the Answers wrapper and steps directly into $values.
+    -- "$values" must be quoted in the path because $ is reserved in SQL Server JSON paths.
+    INSERT INTO [Participant].[AssessmentAnswer] ([AssessmentId], [QuestionCode], [Answer])
+    SELECT
+        a.[Id],
+        q.[key],
+        v.[value]
+    FROM [Participant].[Assessment] a
+    CROSS APPLY OPENJSON(a.[AssessmentJson], '$.Pathways') pathways
+    CROSS APPLY OPENJSON(pathways.[value]) q
+    CROSS APPLY OPENJSON(q.[value]) ans
+    CROSS APPLY OPENJSON(ans.[value], '$."$values"') v
+    WHERE q.[key] != '$type'
+      AND ans.[key] = 'Answers'
+      and v.[value] is not null;
+
+END

--- a/src/DatabaseSeeding/Scripts/0062_NullAssessmentJson.sql
+++ b/src/DatabaseSeeding/Scripts/0062_NullAssessmentJson.sql
@@ -1,0 +1,8 @@
+
+
+IF EXISTS (SELECT TOP(1) [Id] FROM [Participant].[Assessment] WHERE [AssessmentJson] IS NOT NULL)
+BEGIN
+  -- This is in a separate file to ensure it doesn't run if the previous step fails due to timeout.
+  UPDATE [Participant].[Assessment]
+    SET [AssessmentJson] = NULL;
+END

--- a/src/DatabaseSeeding/SeedDataService.cs
+++ b/src/DatabaseSeeding/SeedDataService.cs
@@ -32,6 +32,7 @@ public class SeedDataBackgroundService(
             logger.LogInformation($"Seeding: {Path.GetFileName(file)}");
             var sql = await File.ReadAllTextAsync(file, cancellationToken);
             await using var cmd = new SqlCommand(sql, conn);
+            cmd.CommandTimeout = 60 * 3; // three minute timeout.
             await cmd.ExecuteNonQueryAsync(cancellationToken);
             logger.LogInformation($"Seeded: {Path.GetFileName(file)}");
         }

--- a/src/Domain/Entities/Assessments/ParticipantAssessment.cs
+++ b/src/Domain/Entities/Assessments/ParticipantAssessment.cs
@@ -16,31 +16,47 @@ public class ParticipantAssessment : OwnerPropertyEntity<Guid>, IMayHaveTenant, 
         #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
     private readonly List<PathwayScore> _scores = new();
+    private readonly List<AssessmentAnswer> _answers = new();
 
     public string ParticipantId {get; private set;}
-    public string AssessmentJson {get; private set;}
     public DateTime? Completed { get; private set; }
     public string? CompletedBy { get; private set; }
     public int LocationId { get; private set; }
 
     public IReadOnlyCollection<PathwayScore> Scores => _scores.AsReadOnly();
+    public IReadOnlyCollection<AssessmentAnswer> Answers => _answers.AsReadOnly();
 
-    private ParticipantAssessment(Guid id, string participantId, string assessmentJson, string tenantId, int locationId)
+    private ParticipantAssessment(Guid id, string participantId, string tenantId, int locationId)
     {
         Id = id;
         ParticipantId = participantId;
-        AssessmentJson = assessmentJson;
         TenantId = tenantId;
         LocationId = locationId;
         AddDomainEvent(new AssessmentCreatedDomainEvent(this));
     }
 
-    public ParticipantAssessment UpdateJson(string json)
+    public ParticipantAssessment SetAnswer(string questionCode, string answer)
     {
-        //TODO: Add events for update, and logic to stop locked assessments being updated
-        this.AssessmentJson = json;
+        _answers.RemoveAll(a => a.QuestionCode == questionCode);
+        _answers.Add(new AssessmentAnswer(questionCode, answer));
         return this;
     }
+
+    public ParticipantAssessment SetAnswers(string questionCode, IEnumerable<string> answers)
+    {
+        _answers.RemoveAll(a => a.QuestionCode == questionCode);
+        foreach (var answer in answers)
+        {
+            _answers.Add(new AssessmentAnswer(questionCode, answer));
+        }
+        return this;
+    }
+
+    public string? GetAnswer(string questionCode)
+        => _answers.FirstOrDefault(a => a.QuestionCode == questionCode)?.Answer;
+
+    public IEnumerable<string> GetAnswers(string questionCode)
+        => _answers.Where(a => a.QuestionCode == questionCode).Select(a => a.Answer);
 
     public ParticipantAssessment SetPathwayScore(string pathwayName, double score)
     {
@@ -64,8 +80,8 @@ public class ParticipantAssessment : OwnerPropertyEntity<Guid>, IMayHaveTenant, 
         return this;
     }
 
-    public static ParticipantAssessment Create(Guid id, string participantId, string assessmentJson, string tenantId, int locationId) 
-        => new(id, participantId, assessmentJson, tenantId, locationId);
+    public static ParticipantAssessment Create(Guid id, string participantId, string tenantId, int locationId) 
+        => new(id, participantId, tenantId, locationId);
 
     public string? TenantId {get; set;}
 

--- a/src/Domain/ValueObjects/AssessmentAnswer.cs
+++ b/src/Domain/ValueObjects/AssessmentAnswer.cs
@@ -1,0 +1,22 @@
+namespace Cfo.Cats.Domain.ValueObjects;
+
+public class AssessmentAnswer(string questionCode, string answer) : ValueObject
+{
+    /// <summary>
+    /// The stable code identifying the question (e.g. "B1", "D3", "H13").
+    /// </summary>
+    public string QuestionCode { get; private set; } = questionCode;
+
+    /// <summary>
+    /// One answer value. For single-choice questions there will be exactly one
+    /// row per question; for multiple-choice questions there will be one row per
+    /// selected answer.
+    /// </summary>
+    public string Answer { get; private set; } = answer;
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return QuestionCode;
+        yield return Answer;
+    }
+}

--- a/src/Infrastructure/Constants/Database/DatabaseConstants.cs
+++ b/src/Infrastructure/Constants/Database/DatabaseConstants.cs
@@ -51,6 +51,7 @@ internal static class DatabaseConstants
         public const string PriCode = nameof(PriCode);
 
         public const string AssessmentPathwayScore = nameof(AssessmentPathwayScore);
+        public const string AssessmentAnswer = nameof(AssessmentAnswer);
 
         public const string Timeline = nameof(Timeline);
 

--- a/src/Infrastructure/Persistence/Configurations/Participants/ParticipantAssessmentEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Participants/ParticipantAssessmentEntityTypeConfiguration.cs
@@ -1,5 +1,6 @@
 using Cfo.Cats.Domain.Entities.Administration;
 using Cfo.Cats.Domain.Entities.Assessments;
+using Cfo.Cats.Domain.ValueObjects;
 using Cfo.Cats.Infrastructure.Constants.Database;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -42,6 +43,18 @@ public class ParticipantAssessmentEntityTypeConfiguration : IEntityTypeConfigura
             );
             score.Property(x => x.Pathway).HasMaxLength(50).IsRequired();
             score.Property(x => x.Score).HasColumnType("float").IsRequired();
+        });
+
+        builder.OwnsMany(p => p.Answers, answer => {
+            answer.WithOwner().HasForeignKey("AssessmentId");
+            answer.HasKey("Id");
+            answer.HasIndex("AssessmentId", nameof(AssessmentAnswer.QuestionCode), nameof(AssessmentAnswer.Answer)).IsUnique();
+            answer.ToTable(
+                DatabaseConstants.Tables.AssessmentAnswer,
+                DatabaseConstants.Schemas.Participant
+            );
+            answer.Property(x => x.QuestionCode).HasMaxLength(3).IsRequired();
+            answer.Property(x => x.Answer).HasMaxLength(80).IsRequired();
         });
             
         builder.Property(x => x.CreatedBy).HasMaxLength(DatabaseConstants.FieldLengths.GuidId);

--- a/test/Application.UnitTests/Assessments/AssessmentWithAnswersTests.cs
+++ b/test/Application.UnitTests/Assessments/AssessmentWithAnswersTests.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using Cfo.Cats.Application.Features.Assessments.DTOs;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Education;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Housing;
+using Cfo.Cats.Application.Features.Assessments.DTOs.V1.Pathways.Working;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Cfo.Cats.Application.UnitTests.Assessments;
+
+public class AssessmentWithAnswersTests
+{
+    private Assessment _assessment = null!;
+
+    [SetUp]
+    public void Setup() => _assessment = new Assessment
+    {
+        Id = Guid.NewGuid(),
+        ParticipantId = "A12345678",
+        Pathways =
+        [
+            new WorkingPathway(),
+            new HousingPathway(),
+            new EducationPathway(),
+        ]
+    };
+
+    [Test]
+    public void WithAnswers_PopulatesSingleChoiceAnswer()
+    {
+        var lookup = new[]
+        {
+            ("B1", "Sleep rough"),
+            ("A1", "Looking for work"),
+        }.ToLookup(x => x.Item1, x => x.Item2);
+
+        _assessment.WithAnswers(lookup);
+
+        var housing = (HousingPathway)_assessment.Pathways[1];
+        housing.B1.Answer.ShouldBe("Sleep rough");
+
+        var working = (WorkingPathway)_assessment.Pathways[0];
+        working.A1.Answer.ShouldBe("Looking for work");
+    }
+
+    [Test]
+    public void WithAnswers_PopulatesMultipleChoiceAnswers()
+    {
+        var lookup = new[]
+        {
+            ("D3", "Dyslexia"),
+            ("D3", "ADHD / ADD"),
+        }.ToLookup(x => x.Item1, x => x.Item2);
+
+        _assessment.WithAnswers(lookup);
+
+        var education = (EducationPathway)_assessment.Pathways[2];
+        education.D3.Answers.ShouldNotBeNull();
+        education.D3.Answers!.ShouldContain("Dyslexia");
+        education.D3.Answers!.ShouldContain("ADHD / ADD");
+    }
+
+    [Test]
+    public void WithAnswers_LeavesUnansweredQuestionsNull()
+    {
+        var lookup = Enumerable.Empty<(string, string)>()
+            .ToLookup(x => x.Item1, x => x.Item2);
+
+        _assessment.WithAnswers(lookup);
+
+        var housing = (HousingPathway)_assessment.Pathways[1];
+        housing.B1.Answer.ShouldBeNull();
+    }
+
+    [Test]
+    public void WithAnswers_ReturnsTheSameAssessmentInstance()
+    {
+        var lookup = Enumerable.Empty<(string, string)>()
+            .ToLookup(x => x.Item1, x => x.Item2);
+
+        var result = _assessment.WithAnswers(lookup);
+
+        result.ShouldBeSameAs(_assessment);
+    }
+
+    [Test]
+    public void QuestionCode_MatchesClassName()
+    {
+        var working = (WorkingPathway)_assessment.Pathways[0];
+        working.A1.Code.ShouldBe("A1");
+        working.A10.Code.ShouldBe("A10");
+
+        var education = (EducationPathway)_assessment.Pathways[2];
+        education.D3.Code.ShouldBe("D3");
+    }
+}

--- a/test/Application.UnitTests/Assessments/ParticipantAssessmentAnswerTests.cs
+++ b/test/Application.UnitTests/Assessments/ParticipantAssessmentAnswerTests.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using Cfo.Cats.Domain.Entities.Assessments;
+using Cfo.Cats.Domain.ValueObjects;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Cfo.Cats.Application.UnitTests.Assessments;
+
+public class ParticipantAssessmentAnswerTests
+{
+    private ParticipantAssessment _assessment = null!;
+
+    [SetUp]
+    public void Setup() => _assessment = ParticipantAssessment.Create(
+            Guid.NewGuid(),
+            participantId: "A12345678",
+            tenantId: "1.",
+            locationId: 1
+        );
+
+    [Test]
+    public void SetAnswer_StoresAnswerByQuestionCode()
+    {
+        _assessment.SetAnswer("B1", "Sleep rough");
+
+        _assessment.GetAnswer("B1").ShouldBe("Sleep rough");
+    }
+
+    [Test]
+    public void SetAnswer_ReplacesExistingAnswer()
+    {
+        _assessment.SetAnswer("B1", "Sleep rough");
+        _assessment.SetAnswer("B1", "Housing is rented or owned by you, your partner, parent or guardian");
+
+        _assessment.GetAnswer("B1").ShouldBe("Housing is rented or owned by you, your partner, parent or guardian");
+        _assessment.Answers.Count(a => a.QuestionCode == "B1").ShouldBe(1);
+    }
+
+    [Test]
+    public void SetAnswers_StoresMultipleAnswersForOneQuestion()
+    {
+        _assessment.SetAnswers("D3", ["Dyslexia", "ADHD / ADD"]);
+
+        var answers = _assessment.GetAnswers("D3").ToList();
+        answers.Count.ShouldBe(2);
+        answers.ShouldContain("Dyslexia");
+        answers.ShouldContain("ADHD / ADD");
+    }
+
+    [Test]
+    public void SetAnswers_ReplacesExistingAnswersForCode()
+    {
+        _assessment.SetAnswers("D3", ["Dyslexia", "ADHD / ADD"]);
+        _assessment.SetAnswers("D3", ["Epilepsy"]);
+
+        var answers = _assessment.GetAnswers("D3").ToList();
+        answers.Count.ShouldBe(1);
+        answers.ShouldContain("Epilepsy");
+    }
+
+    [Test]
+    public void SetAnswer_DoesNotAffectOtherQuestions()
+    {
+        _assessment.SetAnswer("B1", "Sleep rough");
+        _assessment.SetAnswer("B2", "Yes");
+
+        _assessment.GetAnswer("B1").ShouldBe("Sleep rough");
+        _assessment.GetAnswer("B2").ShouldBe("Yes");
+    }
+
+    [Test]
+    public void GetAnswer_ReturnsNull_WhenQuestionNotAnswered()
+        => _assessment.GetAnswer("B1").ShouldBeNull();
+
+    [Test]
+    public void GetAnswers_ReturnsEmpty_WhenQuestionNotAnswered()
+        => _assessment.GetAnswers("D3").ShouldBeEmpty();
+
+    [Test]
+    public void Answers_ReadOnlyCollection_ReflectsAllStoredAnswers()
+    {
+        _assessment.SetAnswer("B1", "Sleep rough");
+        _assessment.SetAnswers("D3", ["Dyslexia", "ADHD / ADD"]);
+
+        _assessment.Answers.Count.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [x] CI is green
- [x] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)
---

This pull request refactors how assessment answers are stored and retrieved, moving away from serializing the entire assessment object as JSON and instead persisting answers in a more granular, tabular format keyed by a stable question code. It introduces a new `Code` property to each question class, adds logic to populate answers from storage, and updates command handlers to use the new approach.

Key changes include:

**Assessment Answer Storage and Retrieval:**
- Replaced JSON serialization of the whole assessment object with a tabular storage approach, where answers are stored and retrieved per question using a stable `Code` as the key. [[1]](diffhunk://#diff-d34a6c84d013ff17d73f793860f6ad96dac5d968565f406fcab83c72ad6658fdL67-R66) [[2]](diffhunk://#diff-bfee28a116153fe0e21163698b7154a5b8eda862d4983497ff3e1b6a1272983fL36-R49)
- Added the `WithAnswers` method to the `Assessment` class to populate question answers from tabular storage based on the question code.

**Question Code Infrastructure:**
- Introduced an abstract `Code` property in `QuestionBase`, providing a stable identifier for each question to be used as a key in answer storage.
- Implemented the `Code` property in all relevant question classes (e.g., `D1`, `D2`, `D3`, `D4`, `D5`, `E1`, `E2`, `E3`, `E4`, `E5`, `E6`, `E7`, `E8`, `E9`, `B1`, `B2`). [[1]](diffhunk://#diff-32bb55b679b161cb0bc15c3c5f0caf245d43fa89067c25993c31346c8255a631R13) [[2]](diffhunk://#diff-9c8cc684ea16188bbfb33e5614dcfbd3706916beea0a11bac2b2e1a96b809429R9) [[3]](diffhunk://#diff-b9c5a4a1d5b707941e649da17edafbfa450b98709c716db1366bd1040b92d309R19) [[4]](diffhunk://#diff-376dc65e729d79b64e3032530e2dbccbd2edbb1fec3cc1dc7b50e91b4e7a94afR18) [[5]](diffhunk://#diff-96a52826e5ee99d1a0ee74d1cfb8fe6feceb7386c35de91187d65061c7f13200R19) [[6]](diffhunk://#diff-482474234281e0aba7d17f45dd65c999b805f7c9b15831f2e7262a6045be6bd2R10) [[7]](diffhunk://#diff-5ff64218fda4739acd3adb66dfe27dc4ffa8a14757e3232e8b1fdbdf4de5bc21R11) [[8]](diffhunk://#diff-7d98fe650bb61d8d19df4548fd1338d3722db1c884d75de3c636234fc7440995R10) [[9]](diffhunk://#diff-5715e081bdead4b28a613a8100bb5a69bc2715e2f7b6b35de4e7a03d0f79a7feR10) [[10]](diffhunk://#diff-aa1fe9d22544e71efaef844feafbf68660edc06dc36b0ecae18dd38ba4ad73feR11) [[11]](diffhunk://#diff-a2577181086ff76f3d17560fd95f355a9658f635cfc044dd7b7f99fad3e09fdcR16) [[12]](diffhunk://#diff-18bf62c1db2d64f9aed6a76710faee1f566a1ed8ecb879ccd9a21d18a25fdf4aR16) [[13]](diffhunk://#diff-1859e3af881cd844fce1368e5c3e5da4ccab647405c35a2e6d2193a2dfa62fe9R10) [[14]](diffhunk://#diff-cd202e021f1e0c4e9ebcbff7d1170efa43ffbad5a8ccbf026fca41d935b0bf18R10) [[15]](diffhunk://#diff-7f9f3b1f90ee188987d79d85cd66e5a2fc1ff23bd73cb490b4f941b4dfe9d382R14) [[16]](diffhunk://#diff-07fd8f1588d77a2bab34710834cce8e867c6461b1628603386dfd7d1e0b2b1d1R15)

**Codebase Cleanup:**
- Removed unnecessary `Newtonsoft.Json` imports from files that no longer perform JSON serialization of assessments. [[1]](diffhunk://#diff-d34a6c84d013ff17d73f793860f6ad96dac5d968565f406fcab83c72ad6658fdL16) [[2]](diffhunk://#diff-bfee28a116153fe0e21163698b7154a5b8eda862d4983497ff3e1b6a1272983fL7)

These changes improve data integrity, make answer storage more robust and maintainable, and lay the groundwork for more flexible assessment processing in the future.
