### PR TITLE
Fix "Engaged on" date exported as text instead of date

### DIFF
--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportLatestParticipantEngagementsIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportLatestParticipantEngagementsIntegrationEventConsumer.cs
@@ -54,7 +54,7 @@ public class DocumentExportLatestParticipantEngagementsIntegrationEventConsumer(
                     { "Description", item => item.Description },
                     { "Engaged at (Location)", item => item.EngagedAtLocationName },
                     { "Engaged at (Contract)", item => item.EngagedAtContractName },
-                    { "Engaged on", item => item.EngagedOn?.ToShortDateString() },
+                    { "Engaged on", item => item.EngagedOn },
                     { "Has Engaged Recently", item => item.HasEngagedRecently ? "Yes" : "No" },
                     { "Has Engaged", item => item.HasEngaged ? "Yes" : "No" },
                     { "Engaged With", item => item.EngagedWithDisplayName },


### PR DESCRIPTION
This pull request makes a small change to the export logic for participant engagements. Specifically, it updates the way the "Engaged on" field is handled, exporting the full `DateTime` value instead of just the short date string.

---
## PR Type
- [ ] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)
