### PR TITLE
Comments Copy over functionality on Verification

### DIFF
--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
@@ -25,14 +25,31 @@
             <MudStack Spacing="2">
                 @if (!ReadOnly && !string.IsNullOrWhiteSpace(CsoComments))
                 {
-                    <MudButton Color="Color.Secondary" 
-                               Variant="Variant.Filled" 
-                               Size="Size.Small"
-                               StartIcon="@Icons.Material.Filled.ContentCopy"
-                               Style="width: fit-content;"
-                               OnClick="CopyFromReview">
-                        Copy from Review
-                    </MudButton>
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudButton Color="Color.Secondary" 
+                                   Variant="Variant.Filled" 
+                                   Size="Size.Small"
+                                   StartIcon="@Icons.Material.Filled.ContentCopy"
+                                   Style="width: fit-content;"
+                                   OnClick="CopyFromReview">
+                            Copy from Review
+                        </MudButton>
+                        <MudTooltip Text="Click to view Review comments">
+                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                          Size="Size.Small" 
+                                          Color="Color.Info"
+                                          OnClick="() => _showCsoComments = !_showCsoComments" />
+                        </MudTooltip>
+                    </MudStack>
+                    @if (_showCsoComments)
+                    {
+                        <MudPaper Class="pa-3" Elevation="1" Style="background-color: var(--mud-palette-background-grey);">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Review Comments (CSO):</MudText>
+                                <MudText Typo="Typo.body2">@CsoComments</MudText>
+                            </MudStack>
+                        </MudPaper>
+                    }
                 }
                 <MudTextField @bind-Value="@Command.Comments"
                               For="@(() => Command.Comments)"

--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor
@@ -21,14 +21,27 @@
                 @Command.GetMemberDescription(x => x.Comments)
             </MudText>
         </MudItem>
-        <MudItem xs="12" md="9" Class="d-flex align-center">
-            <MudTextField @bind-Value="@Command.Comments"
-                          For="@(() => Command.Comments)"
-                          Lines="5"
-                          MaxLength=@ValidationConstants.NotesLength
-                          Counter=@ValidationConstants.NotesLength
-                          Immediate="true">
-            </MudTextField>
+        <MudItem xs="12" md="9">
+            <MudStack Spacing="2">
+                @if (!ReadOnly && !string.IsNullOrWhiteSpace(CsoComments))
+                {
+                    <MudButton Color="Color.Secondary" 
+                               Variant="Variant.Filled" 
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.ContentCopy"
+                               Style="width: fit-content;"
+                               OnClick="CopyFromReview">
+                        Copy from Review
+                    </MudButton>
+                }
+                <MudTextField @bind-Value="@Command.Comments"
+                              For="@(() => Command.Comments)"
+                              Lines="5"
+                              MaxLength=@ValidationConstants.NotesLength
+                              Counter=@ValidationConstants.NotesLength
+                              Immediate="true">
+                </MudTextField>
+            </MudStack>
         </MudItem>
 
         <MudItem xs="12" md="8">

--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
@@ -10,6 +10,7 @@ public partial class SubmitCpmResponseComponent
 {
     private MudForm form = new();
     private bool ReadOnly { get; set; } = true;
+    private bool _showCsoComments = false;
 
     [Parameter][EditorRequired] public required EventCallback<SubmitCpmResponse.Command> OnFormSubmit { get; set; }
     [Parameter][EditorRequired] public required SubmitCpmResponse.Command Command { get; set; }
@@ -17,8 +18,22 @@ public partial class SubmitCpmResponseComponent
     [Parameter, EditorRequired] public required DipSampleStatus Status { get; set; }
     [Parameter] public string? CsoComments { get; set; }
 
-    private void CopyFromReview()
+    private async Task CopyFromReview()
     {
+        if (!string.IsNullOrWhiteSpace(Command.Comments))
+        {
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Confirm Copy",
+                "This will replace your current comments. Do you want to continue?",
+                yesText: "Yes, Replace",
+                cancelText: "Cancel");
+            
+            if (result != true)
+            {
+                return;
+            }
+        }
+
         if (!string.IsNullOrWhiteSpace(CsoComments))
         {
             Command.Comments = CsoComments;

--- a/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitCpmResponseComponent.razor.cs
@@ -15,6 +15,15 @@ public partial class SubmitCpmResponseComponent
     [Parameter][EditorRequired] public required SubmitCpmResponse.Command Command { get; set; }
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
     [Parameter, EditorRequired] public required DipSampleStatus Status { get; set; }
+    [Parameter] public string? CsoComments { get; set; }
+
+    private void CopyFromReview()
+    {
+        if (!string.IsNullOrWhiteSpace(CsoComments))
+        {
+            Command.Comments = CsoComments;
+        }
+    }
 
     private async Task OnSubmit()
     {

--- a/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
@@ -19,14 +19,31 @@
             <MudStack Spacing="2">
                 @if (!ReadOnly && !string.IsNullOrWhiteSpace(CpmComments))
                 {
-                    <MudButton Color="Color.Secondary" 
-                               Variant="Variant.Filled" 
-                               Size="Size.Small"
-                               StartIcon="@Icons.Material.Filled.ContentCopy"
-                               Style="width: fit-content;"
-                               OnClick="CopyFromVerification">
-                        Copy from Verification
-                    </MudButton>
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudButton Color="Color.Secondary" 
+                                   Variant="Variant.Filled" 
+                                   Size="Size.Small"
+                                   StartIcon="@Icons.Material.Filled.ContentCopy"
+                                   Style="width: fit-content;"
+                                   OnClick="CopyFromVerification">
+                            Copy from Verification
+                        </MudButton>
+                        <MudTooltip Text="Click to view Verification comments">
+                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                          Size="Size.Small" 
+                                          Color="Color.Info"
+                                          OnClick="() => _showCpmComments = !_showCpmComments" />
+                        </MudTooltip>
+                    </MudStack>
+                    @if (_showCpmComments)
+                    {
+                        <MudPaper Class="pa-3" Elevation="1" Style="background-color: var(--mud-palette-background-grey);">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Verification Comments (CPM):</MudText>
+                                <MudText Typo="Typo.body2">@CpmComments</MudText>
+                            </MudStack>
+                        </MudPaper>
+                    }
                 }
                 <MudTextField @bind-Value="@Command.Comments"
                               For="@(() => Command.Comments)"

--- a/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
@@ -22,7 +22,9 @@
                     <MudButton Color="Color.Secondary" 
                                Variant="Variant.Filled" 
                                Size="Size.Small"
-                               StartIcon="@Icons.Material.Filled.ContentCopy"                               Style="width: fit-content;"                               OnClick="CopyFromVerification">
+                               StartIcon="@Icons.Material.Filled.ContentCopy"
+                               Style="width: fit-content;"
+                               OnClick="CopyFromVerification">
                         Copy from Verification
                     </MudButton>
                 }

--- a/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor
@@ -15,14 +15,25 @@
                 @Command.GetMemberDescription(x => x.Comments)
             </MudText>
         </MudItem>
-        <MudItem xs="12" md="9" Class="d-flex align-center">
-            <MudTextField @bind-Value="@Command.Comments"
-                          For="@(() => Command.Comments)"
-                          Lines="5"
-                          MaxLength=@ValidationConstants.NotesLength
-                          Counter=@ValidationConstants.NotesLength
-                          Immediate="true">
-            </MudTextField>
+        <MudItem xs="12" md="9">
+            <MudStack Spacing="2">
+                @if (!ReadOnly && !string.IsNullOrWhiteSpace(CpmComments))
+                {
+                    <MudButton Color="Color.Secondary" 
+                               Variant="Variant.Filled" 
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.ContentCopy"                               Style="width: fit-content;"                               OnClick="CopyFromVerification">
+                        Copy from Verification
+                    </MudButton>
+                }
+                <MudTextField @bind-Value="@Command.Comments"
+                              For="@(() => Command.Comments)"
+                              Lines="5"
+                              MaxLength=@ValidationConstants.NotesLength
+                              Counter=@ValidationConstants.NotesLength
+                              Immediate="true">
+                </MudTextField>
+            </MudStack>
         </MudItem>
 
         <MudItem xs="12" md="8">

--- a/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor.cs
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor.cs
@@ -18,6 +18,15 @@ public partial class SubmitFinalResponseComponent
 
     [Parameter][EditorRequired] public required EventCallback<SubmitFinalResponse.Command> OnFormSubmit { get; set; }
     [Parameter][EditorRequired] public required SubmitFinalResponse.Command Command { get; set; }
+    [Parameter] public string? CpmComments { get; set; }
+
+    private void CopyFromVerification()
+    {
+        if (!string.IsNullOrWhiteSpace(CpmComments))
+        {
+            Command.Comments = CpmComments;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor.cs
+++ b/src/Server.UI/Pages/Analytics/Components/SubmitFinalResponseComponent.razor.cs
@@ -9,6 +9,7 @@ public partial class SubmitFinalResponseComponent
 {
     private MudForm _form = new();
     private bool ReadOnly { get; set; } = true;
+    private bool _showCpmComments = false;
 
     [Inject] private IAuthorizationService AuthorizationService { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
@@ -20,8 +21,22 @@ public partial class SubmitFinalResponseComponent
     [Parameter][EditorRequired] public required SubmitFinalResponse.Command Command { get; set; }
     [Parameter] public string? CpmComments { get; set; }
 
-    private void CopyFromVerification()
+    private async Task CopyFromVerification()
     {
+        if (!string.IsNullOrWhiteSpace(Command.Comments))
+        {
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Confirm Copy",
+                "This will replace your current comments. Do you want to continue?",
+                yesText: "Yes, Replace",
+                cancelText: "Cancel");
+            
+            if (result != true)
+            {
+                return;
+            }
+        }
+
         if (!string.IsNullOrWhiteSpace(CpmComments))
         {
             Command.Comments = CpmComments;

--- a/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
+++ b/src/Server.UI/Pages/Analytics/OutcomeQualityDipSample/ParticipantDetails.razor
@@ -68,12 +68,18 @@
                         </MudTabPanel>
                         <AuthorizeView Policy="@SecurityPolicies.OutcomeQualityDipVerification">
                             <MudTabPanel Text="Verification" Disabled="_participant.CsoAnswer.IsAnswer is false">
-                                <SubmitCpmResponseComponent Command="@SubmitCpmCommand" OnFormSubmit="CpmResponseSubmitted" Status="_participant.DipSampleStatus"/>
+                                <SubmitCpmResponseComponent Command="@SubmitCpmCommand" 
+                                                            OnFormSubmit="CpmResponseSubmitted" 
+                                                            Status="_participant.DipSampleStatus" 
+                                                            CsoComments="@_participant.CsoComments"/>
                             </MudTabPanel>
                         </AuthorizeView>
                         <AuthorizeView Policy="@SecurityPolicies.OutcomeQualityDipFinalise">
                             <MudTabPanel Text="Finalise" Disabled="_participant.CpmAnswer.IsAnswer is false">
-                                <SubmitFinalResponseComponent Command="@SubmitFinalCommand" Status="_participant.DipSampleStatus" OnFormSubmit="FinalResponseSubmitted"/>
+                                <SubmitFinalResponseComponent Command="@SubmitFinalCommand" 
+                                                             Status="_participant.DipSampleStatus" 
+                                                             OnFormSubmit="FinalResponseSubmitted"
+                                                             CpmComments="@_participant.CpmComments"/>
                             </MudTabPanel>
                         </AuthorizeView>
                     </MudTabs>


### PR DESCRIPTION
This pull request introduces a user experience improvement to the dip sample workflow by allowing users to quickly copy previous review comments into the current comment field in both the verification and finalisation steps. This is achieved by adding "Copy from Review" and "Copy from Verification" buttons, streamlining the process and reducing repetitive typing.

**Enhancements to comment copying functionality:**

* Added a "Copy from Review" button to the `SubmitCpmResponseComponent` that allows users to copy `CsoComments` into the current comments field if available and not read-only. Supporting logic and parameter were added to the component's code-behind. [[1]](diffhunk://#diff-92015d899f787d17797f5c51b4ae1373d4f63f2c887743dd80e63ef8c28eb305L24-R44) [[2]](diffhunk://#diff-207c77affbf2eb5a9f4f8ad5b279dff52cf2952e6636fa7c6af2544fc6d840c0R18-R26)
* Added a "Copy from Verification" button to the `SubmitFinalResponseComponent` that allows users to copy `CpmComments` into the current comments field if available and not read-only. Supporting logic and parameter were added to the component's code-behind. [[1]](diffhunk://#diff-605434c11548861ab94cc36b7149796c335fb0e6e064d6fc9c5d3b4fe7446d42L18-R36) [[2]](diffhunk://#diff-7e6cc2f3b712e8d2b2019f53deb52feca689135e1078cd5467194c0b48aa8076R21-R29)

**Integration into participant details workflow:**

* Passed the relevant previous comments (`CsoComments` and `CpmComments`) as parameters to the respective components in `ParticipantDetails.razor`, enabling the new copy functionality in the UI.

## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)
