### PR TITLE
CFODEV-1679: Restrict an activities commencement date to the lifetime of an initiative

### DIFF
--- a/src/Application/Features/Activities/Commands/AddActivity.cs
+++ b/src/Application/Features/Activities/Commands/AddActivity.cs
@@ -289,6 +289,11 @@ public static class AddActivity
                     .When(c => c.Location is not null)
                     .WithMessage("The selected location does not belong to the linked initiative's contract");
 
+                RuleFor(c => c.CommencedOn)
+                    .Must((command, commencedOn) => BeWithinInitiativeLifetime(command.TaskId, commencedOn))
+                    .When(c => c.CommencedOn is not null)
+                    .WithMessage("The activity commencement date must fall within the linked initiative's lifetime");
+
                 RuleFor(c => c.ISWTemplate.BaselineAchievedOn)
                 .Must((command, baselineAchievedOn, token) => BeInductedAtHubForActivity(command.ParticipantId, command.Location!.Id, baselineAchievedOn))
                 .When(c =>
@@ -408,6 +413,29 @@ public static class AddActivity
 
             return unitOfWork.DbContext.Locations
                 .Any(l => l.Id == location.Id && l.Contract!.Id == initiativeContractId);
+        }
+
+        private bool BeWithinInitiativeLifetime(Guid taskId, DateTime? commencedOn)
+        {
+            if (commencedOn is null)
+            {
+                return true;
+            }
+
+            var lifetime = (
+                from task in unitOfWork.DbContext.ObjectiveTasks
+                join io in unitOfWork.DbContext.InitiativeObjectives on task.ObjectiveId equals io.ObjectiveId
+                join initiative in unitOfWork.DbContext.Initiatives on io.InitiativeId equals initiative.Id
+                where task.Id == taskId
+                select new { initiative.Lifetime.StartDate, initiative.Lifetime.EndDate }
+            ).FirstOrDefault();
+
+            if (lifetime is null)
+            {
+                return true;
+            }
+
+            return commencedOn.Value >= lifetime.StartDate && commencedOn.Value <= lifetime.EndDate;
         }
 
         private bool BeInductedAtHubForActivity(string participantId, int locationId, DateTime? date)


### PR DESCRIPTION
This pull request adds a new validation rule to ensure that an activity's commencement date falls within the lifetime of the linked initiative. The main changes include introducing a new validation rule in the `AddActivity` command validator and implementing a supporting method to check the initiative's lifetime.

---
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)