### PR TITLE
fix: override prCreation to immediate so Renovate creates PRs without…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "github>ministryofjustice/hmpps-renovate-config:base"
   ],
   "baseBranches": ["develop"],
+  "prCreation": "immediate",
   "packageRules": [
     {
       "matchPackagePatterns": ["^AutoMapper", "^MediatR"],


### PR DESCRIPTION
… waiting for branch CI

The MoJ base config sets prCreation: not-pending, but CI only runs on PRs not branches, causing a deadlock where PRs are never created.

## PR Type
- [ ] Feature
- [x] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [x] Not required (explain below)

---

This pull request makes a small configuration change to the `renovate.json` file. The change sets pull request creation to "immediate", which means Renovate will open PRs as soon as updates are detected rather than waiting for a scheduled time.
