### PR TITLE
Adjust Bio to be stored in tabular format rather than json

### DIFF
--- a/src/Application/Features/Bios/Commands/BeginBio.cs
+++ b/src/Application/Features/Bios/Commands/BeginBio.cs
@@ -5,7 +5,6 @@ using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.ChildhoodExperiences;
 using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.RecentExperiences;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Entities.Bios;
-using Newtonsoft.Json;
 using Cfo.Cats.Application.Common.Validators;
 
 namespace Cfo.Cats.Application.Features.Bios.Commands;
@@ -26,48 +25,55 @@ public static class BeginBio
 
         public async Task<Result<Guid>> Handle(Command request, CancellationToken cancellationToken)
         {
-            var oldBio = await GetPreviousBio(request);
+            var oldBio = await GetPreviousBio(request, cancellationToken);
 
-            Bio bio = new Bio()
-            {
-                Id = Guid.CreateVersion7(),
-                ParticipantId = request.ParticipantId,
-                Pathways =
-                [
-                    oldBio?.Pathways[0] ?? new DiversityPathway(),
-                    oldBio?.Pathways[1] ?? new ChildhoodExperiencesPathway(),                    
-                    oldBio?.Pathways[2] ?? new RecentExperiencesPathway(),
-                ]
-            };
-
-            string json = JsonConvert.SerializeObject(bio, new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Auto
-            });
+            Guid bioId = Guid.CreateVersion7();
             
-            ParticipantBio bioSurvey = ParticipantBio.Create(bio.Id, request.ParticipantId, bioJson: json);
+            ParticipantBio bioEntity = ParticipantBio.Create(bioId, request.ParticipantId);
 
-            await _unitOfWork.DbContext.ParticipantBios.AddAsync(bioSurvey);
+            // Copy answers from previous bio if it exists
+            if (oldBio != null)
+            {
+                foreach (var pathway in oldBio.Pathways)
+                {
+                    foreach (var question in pathway.Questions())
+                    {
+                        if (question is SingleChoiceQuestion single && single.Answer is not null)
+                        {
+                            bioEntity.SetAnswer(single.Code, single.Answer);
+                        }
+                    }
+                }
+            }
 
-            return Result<Guid>.Success(bio.Id);
+            await _unitOfWork.DbContext.ParticipantBios.AddAsync(bioEntity);
+
+            return Result<Guid>.Success(bioId);
         }
 
-        private async Task<Bio?> GetPreviousBio(Command request)
+        private async Task<Bio?> GetPreviousBio(Command request, CancellationToken cancellationToken)
         {
-            var oldBio = await _unitOfWork.DbContext.ParticipantBios.Where(b => b.ParticipantId == request.ParticipantId)
-                           .OrderByDescending(b => b.Created)
-                           .FirstOrDefaultAsync();
+            var oldBioEntity = await _unitOfWork.DbContext.ParticipantBios
+                .Where(b => b.ParticipantId == request.ParticipantId)
+                .OrderByDescending(b => b.Created)
+                .FirstOrDefaultAsync(cancellationToken);
 
-            if (oldBio == null)
+            if (oldBioEntity == null)
             {
                 return null;
             }
 
-            var bio = JsonConvert.DeserializeObject<Bio>(oldBio.BioJson,
-            new JsonSerializerSettings
+            var bio = new Bio
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            })!;
+                Id = oldBioEntity.Id,
+                ParticipantId = oldBioEntity.ParticipantId,
+                Pathways =
+                [
+                    new DiversityPathway(),
+                    new ChildhoodExperiencesPathway(),
+                    new RecentExperiencesPathway(),
+                ]
+            }.WithAnswers(oldBioEntity.Answers.ToLookup(a => a.QuestionCode, a => a.Answer));
 
             return bio;
         }

--- a/src/Application/Features/Bios/Commands/SaveBio.cs
+++ b/src/Application/Features/Bios/Commands/SaveBio.cs
@@ -3,7 +3,6 @@ using Cfo.Cats.Application.Common.Validators;
 using Cfo.Cats.Application.Features.Bios.DTOs;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Entities.Bios;
-using Newtonsoft.Json;
 
 namespace Cfo.Cats.Application.Features.Bios.Commands;
 
@@ -28,11 +27,17 @@ public static class SaveBio
             {
                 return Result.Failure("Bio not found");
             }
-            
-            bio.UpdateJson(JsonConvert.SerializeObject(request.Bio, new JsonSerializerSettings
+
+            foreach (var pathway in request.Bio.Pathways)
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            }));
+                foreach (var question in pathway.Questions())
+                {
+                    if (question is SingleChoiceQuestion single && single.Answer is not null)
+                    {
+                        bio.SetAnswer(single.Code, single.Answer);
+                    }
+                }
+            }
 
             bio.UpdateStatus(BioStatus.InProgress);
 

--- a/src/Application/Features/Bios/DTOs/Bio.cs
+++ b/src/Application/Features/Bios/DTOs/Bio.cs
@@ -5,4 +5,26 @@ public class Bio
     public required Guid Id { get; set; }
     public required string ParticipantId { get; set; }
     public required PathwayBase[] Pathways { get; set; }
+
+    /// <summary>
+    /// Populates question answers from tabular storage.
+    /// For each question across all pathways, the matching answers are looked up
+    /// by <see cref="QuestionBase.Code"/> and applied to <see cref="SingleChoiceQuestion.Answer"/>
+    /// or <see cref="MultipleChoiceQuestion.Answers"/> as appropriate.
+    /// </summary>
+    public Bio WithAnswers(ILookup<string, string> answers)
+    {
+        foreach (var pathway in Pathways)
+        {
+            foreach (var question in pathway.Questions())
+            {
+                if (question is SingleChoiceQuestion single)
+                {
+                    var questionAnswers = answers[question.Code].ToList();
+                    single.Answer = questionAnswers.FirstOrDefault();
+                }
+            }
+        }
+        return this;
+    }
 }

--- a/src/Application/Features/Bios/DTOs/QuestionBase.cs
+++ b/src/Application/Features/Bios/DTOs/QuestionBase.cs
@@ -43,6 +43,12 @@ public abstract partial class QuestionBase
     public string[] Options { get; }
 
     /// <summary>
+    ///     A stable identifier for this question (e.g. "A1", "B2", "C3").
+    ///     Used as the key when persisting answers in tabular storage.
+    /// </summary>
+    public abstract string Code { get; }
+
+    /// <summary>
     ///     Is the answer valid
     /// </summary>
     /// <returns>True if the answer has a valid return value</returns>

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B1.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B1.cs
@@ -6,6 +6,7 @@ public class B1() : SingleChoiceQuestion("Spent time in care as a child",
     NA
 ])
 {
+    public override string Code => nameof(B1);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B10.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B10.cs
@@ -6,6 +6,7 @@ public class B10() : SingleChoiceQuestion("Felt safe at home",
     NA
 ])
 {
+    public override string Code => nameof(B10);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B11.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B11.cs
@@ -6,6 +6,7 @@ public class B11() : SingleChoiceQuestion("Enjoyed going to school",
     NA
 ])
 {
+    public override string Code => nameof(B11);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B12.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B12.cs
@@ -6,6 +6,7 @@ public class B12() : SingleChoiceQuestion("Parent or guardian had a drug / alcoh
     NA
 ])
 {
+    public override string Code => nameof(B12);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B13.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B13.cs
@@ -6,6 +6,7 @@ public class B13() : SingleChoiceQuestion("Parent or guardian was seriously ill 
     NA
 ])
 {
+    public override string Code => nameof(B13);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B14.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B14.cs
@@ -6,6 +6,7 @@ public class B14() : SingleChoiceQuestion("Had a close friend you could confide 
     NA
 ])
 {
+    public override string Code => nameof(B14);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B15.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B15.cs
@@ -6,6 +6,7 @@ public class B15() : SingleChoiceQuestion("Had someone you looked up to",
     NA
 ])
 {
+    public override string Code => nameof(B15);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B2.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B2.cs
@@ -6,6 +6,7 @@ public class B2() : SingleChoiceQuestion("Spent most of childhood in the same fa
     NA
 ])
 {
+    public override string Code => nameof(B2);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B3.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B3.cs
@@ -6,6 +6,7 @@ public class B3() : SingleChoiceQuestion("Suffered abuse or neglect as a child",
     NA
 ])
 {
+    public override string Code => nameof(B3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B4.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B4.cs
@@ -6,6 +6,7 @@ public class B4() : SingleChoiceQuestion("Had a difficult childhood",
     NA
 ])
 {
+    public override string Code => nameof(B4);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B5.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B5.cs
@@ -6,6 +6,7 @@ public class B5() : SingleChoiceQuestion("Both parents/guardians were mostly pre
     NA
 ])
 {
+    public override string Code => nameof(B5);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B6.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B6.cs
@@ -6,6 +6,7 @@ public class B6() : SingleChoiceQuestion("At least one parent or guardian was mo
     NA
 ])
 {
+    public override string Code => nameof(B6);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B7.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B7.cs
@@ -6,6 +6,7 @@ public class B7() : SingleChoiceQuestion("A parent or guardian was in trouble wi
     NA
 ])
 {
+    public override string Code => nameof(B7);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B8.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B8.cs
@@ -6,6 +6,7 @@ public class B8() : SingleChoiceQuestion("A parent or guardian spent time in pri
     NA
 ])
 {
+    public override string Code => nameof(B8);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B9.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B9.cs
@@ -6,6 +6,7 @@ public class B9() : SingleChoiceQuestion("Felt loved and cared for at home",
     NA
 ])
 {
+    public override string Code => nameof(B9);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A1.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A1.cs
@@ -7,6 +7,7 @@ public class A1() : SingleChoiceQuestion("Consider yourself a religious person",
     NA
 ])
 {
+    public override string Code => nameof(A1);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A10.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A10.cs
@@ -7,6 +7,7 @@ public class A10() : SingleChoiceQuestion("Are/have been a member of a gang",
     NA
 ])
 {
+    public override string Code => nameof(A10);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A11.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A11.cs
@@ -7,6 +7,7 @@ public class A11() : SingleChoiceQuestion("Have carried an illegal weapon at som
     NA
 ])
 {
+    public override string Code => nameof(A11);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A12.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A12.cs
@@ -7,6 +7,7 @@ public class A12() : SingleChoiceQuestion("Have undertaken prostitution or sex w
     NA
 ])
 {
+    public override string Code => nameof(A12);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A13.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A13.cs
@@ -7,6 +7,7 @@ public class A13() : SingleChoiceQuestion("Feel you are being taken advantage of
     NA
 ])
 {
+    public override string Code => nameof(A13);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A14.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A14.cs
@@ -7,6 +7,7 @@ public class A14() : SingleChoiceQuestion("Feel you are part of a community ",
     NA
 ])
 {
+    public override string Code => nameof(A14);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A15.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A15.cs
@@ -7,6 +7,7 @@ public class A15() : SingleChoiceQuestion("Feel you have been discriminated agai
     NA
 ])
 {
+    public override string Code => nameof(A15);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A16.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A16.cs
@@ -6,6 +6,7 @@ public class A16() : SingleChoiceQuestion("Feel you generally share the same vie
     NA
 ])
 {
+    public override string Code => nameof(A16);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A17.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A17.cs
@@ -7,6 +7,7 @@ public class A17() : SingleChoiceQuestion("Feel you are always getting into trou
     NA
 ])
 {
+    public override string Code => nameof(A17);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A18.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A18.cs
@@ -7,6 +7,7 @@ public class A18() : SingleChoiceQuestion("Regret the offence(s) you committed",
     NA
 ])
 {
+    public override string Code => nameof(A18);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A19.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A19.cs
@@ -7,6 +7,7 @@ public class A19() : SingleChoiceQuestion("Feel your current situation is not yo
     NA
 ])
 {
+    public override string Code => nameof(A19);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A2.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A2.cs
@@ -7,6 +7,7 @@ public class A2() : SingleChoiceQuestion("Practise your faith regularly",
     NA
 ])
 {
+    public override string Code => nameof(A2);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A20.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A20.cs
@@ -7,6 +7,7 @@ public class A20() : SingleChoiceQuestion("Feel you are a better person than you
     NA
 ])
 {
+    public override string Code => nameof(A20);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A21.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A21.cs
@@ -8,6 +8,7 @@ namespace Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.Diversity;
 
 public class A21() : SingleChoiceQuestion("Have carried or used a knife or blade when committing crime", [Yes, No, NA])
 {
+    public override string Code => nameof(A21);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A22.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A22.cs
@@ -2,6 +2,7 @@
 
 public class A22() : SingleChoiceQuestion("Have carried a knife or blade for the purpose of self-defence or to harm others", [Yes, No, NA])
 {
+    public override string Code => nameof(A22);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A3.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A3.cs
@@ -7,6 +7,7 @@ public class A3() : SingleChoiceQuestion("Gay, lesbian, bisexual, or other non-h
     NA
 ])
 {
+    public override string Code => nameof(A3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A4.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A4.cs
@@ -7,6 +7,7 @@ public class A4() : SingleChoiceQuestion("Gender you identify with is different 
     NA
 ])
 {
+    public override string Code => nameof(A4);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A5.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A5.cs
@@ -7,6 +7,7 @@ public class A5() : SingleChoiceQuestion("A member of a Gypsy or Irish traveller
     NA
 ])
 {
+    public override string Code => nameof(A5);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A6.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A6.cs
@@ -7,6 +7,7 @@ public class A6() : SingleChoiceQuestion("A member of the Roma community",
     NA
 ])
 {
+    public override string Code => nameof(A6);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A7.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A7.cs
@@ -7,6 +7,7 @@ public class A7() : SingleChoiceQuestion("Served in the British Armed Forces, in
     NA
 ])
 {
+    public override string Code => nameof(A7);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A8.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A8.cs
@@ -7,6 +7,7 @@ public class A8() : SingleChoiceQuestion("Undertook an operational tour with the
     NA
 ])
 {
+    public override string Code => nameof(A8);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A9.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/Diversity/A9.cs
@@ -7,6 +7,7 @@ public class A9() : SingleChoiceQuestion("Have seen combat while a member of the
     NA
 ])
 {
+    public override string Code => nameof(A9);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C1.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C1.cs
@@ -6,6 +6,7 @@ public class C1() : SingleChoiceQuestion("Had a loved one become seriously ill o
     NA
 ])
 {
+    public override string Code => nameof(C1);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C10.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C10.cs
@@ -6,6 +6,7 @@ public class C10() : SingleChoiceQuestion("Found a new hobby or interest",
     NA
 ])
 {
+    public override string Code => nameof(C10);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C2.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C2.cs
@@ -6,6 +6,7 @@ public class C2() : SingleChoiceQuestion("Got engaged, married, entered a civil 
     NA
 ])
 {
+    public override string Code => nameof(C2);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C3.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C3.cs
@@ -6,6 +6,7 @@ public class C3() : SingleChoiceQuestion("Became a parent",
     NA
 ])
 {
+    public override string Code => nameof(C3);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C4.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C4.cs
@@ -6,6 +6,7 @@ public class C4() : SingleChoiceQuestion("Started a new personal relationship",
     NA
 ])
 {
+    public override string Code => nameof(C4);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C5.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C5.cs
@@ -6,6 +6,7 @@ public class C5() : SingleChoiceQuestion("Left a significant long-term relations
     NA
 ])
 {
+    public override string Code => nameof(C5);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C6.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C6.cs
@@ -6,6 +6,7 @@ public class C6() : SingleChoiceQuestion("Subject to verbal abuse or harassment"
     NA
 ])
 {
+    public override string Code => nameof(C6);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C7.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C7.cs
@@ -6,6 +6,7 @@ public class C7() : SingleChoiceQuestion("Subject to violence or harm by another
     NA
 ])
 {
+    public override string Code => nameof(C7);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C8.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C8.cs
@@ -6,6 +6,7 @@ public class C8() : SingleChoiceQuestion("Lost your job",
     NA
 ])
 {
+    public override string Code => nameof(C8);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C9.cs
+++ b/src/Application/Features/Bios/DTOs/V1/Pathways/RecentExperiences/C9.cs
@@ -6,6 +6,7 @@ public class C9() : SingleChoiceQuestion("Started a new job",
     NA
 ])
 {
+    public override string Code => nameof(C9);
     public const string Yes = "Yes";
     public const string No = "No";
     public const string NA = "PNTS";

--- a/src/Application/Features/Bios/Queries/GetBio.cs
+++ b/src/Application/Features/Bios/Queries/GetBio.cs
@@ -2,7 +2,9 @@
 using Cfo.Cats.Application.Common.Validators;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Application.Features.Bios.DTOs;
-using Newtonsoft.Json;
+using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.Diversity;
+using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.ChildhoodExperiences;
+using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.RecentExperiences;
 
 namespace Cfo.Cats.Application.Features.Bios.Queries;
 
@@ -35,19 +37,26 @@ public static class GetBio
                 query = query.Where(p => p.Id == request.BioId);
             }
 
-            var bioSurvey = await query.OrderByDescending(bioSurvey => bioSurvey.Created)
+            var bioEntity = await query.OrderByDescending(bioEntity => bioEntity.Created)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (bioSurvey is null)
+            if (bioEntity is null)
             {
                 return Result<Bio>.Failure(["Participant not found"]);
             }
 
-            Bio bio = JsonConvert.DeserializeObject<Bio>(bioSurvey.BioJson,
-            new JsonSerializerSettings
+            var bio = new Bio
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            })!;
+                Id = bioEntity.Id,
+                ParticipantId = bioEntity.ParticipantId,
+                Pathways =
+                [
+                    new DiversityPathway(),
+                    new ChildhoodExperiencesPathway(),
+                    new RecentExperiencesPathway(),
+                ]
+            }.WithAnswers(bioEntity.Answers.ToLookup(a => a.QuestionCode, a => a.Answer));
+
             return Result<Bio>.Success(bio);
         }
     }

--- a/src/Application/Features/ParticipantLabels/IntegrationEventHandlers/RecordVeteranLabelStatusConsumer.cs
+++ b/src/Application/Features/ParticipantLabels/IntegrationEventHandlers/RecordVeteranLabelStatusConsumer.cs
@@ -1,10 +1,11 @@
 using Cfo.Cats.Application.Features.Bios.DTOs;
 using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.Diversity;
+using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.ChildhoodExperiences;
+using Cfo.Cats.Application.Features.Bios.DTOs.V1.Pathways.RecentExperiences;
 using Cfo.Cats.Application.Features.Bios.IntegrationEvents;
 using Cfo.Cats.Domain.Labels;
 using Cfo.Cats.Domain.ParticipantLabels;
 using Cfo.Cats.Domain.Participants;
-using Newtonsoft.Json;
 using Rebus.Handlers;
 
 namespace Cfo.Cats.Application.Features.ParticipantLabels.IntegrationEventHandlers;
@@ -26,10 +27,17 @@ public class RecordVeteranLabelStatusConsumer(IUnitOfWork unitOfWork, IParticipa
                 return;
             }
 
-            var bio = JsonConvert.DeserializeObject<Bio>(participantBio.BioJson, new JsonSerializerSettings
+            var bio = new Bio
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            })!;
+                Id = participantBio.Id,
+                ParticipantId = participantBio.ParticipantId,
+                Pathways =
+                [
+                    new DiversityPathway(),
+                    new ChildhoodExperiencesPathway(),
+                    new RecentExperiencesPathway(),
+                ]
+            }.WithAnswers(participantBio.Answers.ToLookup(a => a.QuestionCode, a => a.Answer));
 
             var pathway = bio.Pathways.OfType<DiversityPathway>().First();
 

--- a/src/Database/CatsDb/Participant/Tables/Bio.sql
+++ b/src/Database/CatsDb/Participant/Tables/Bio.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [Participant].[Bio] (
     [Id]             UNIQUEIDENTIFIER NOT NULL,
     [ParticipantId]  NVARCHAR (9)     NOT NULL,
-    [BioJson]        NVARCHAR (MAX)   NOT NULL,
+    [BioJson]        NVARCHAR (MAX)   NULL,
     [Status]         INT              NOT NULL,
     [Created]        DATETIME2 (7)    NULL,
     [CreatedBy]      NVARCHAR (36)    NULL,

--- a/src/Database/CatsDb/Participant/Tables/BioAnswer.sql
+++ b/src/Database/CatsDb/Participant/Tables/BioAnswer.sql
@@ -1,0 +1,30 @@
+CREATE TABLE [Participant].[BioAnswer] (
+    [Id] INT IDENTITY(1,1) NOT NULL,
+    [BioId]              UNIQUEIDENTIFIER NOT NULL,
+    [QuestionCode]       NVARCHAR(3)   NOT NULL,
+    [Answer]             NVARCHAR(80)  NOT NULL,
+
+    CONSTRAINT [PK_BioAnswer]
+        PRIMARY KEY CLUSTERED ([Id])
+);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [UQ_BioAnswer_BusinessKey]
+ON [Participant].[BioAnswer]
+(
+    [BioId],
+    [QuestionCode],
+    [Answer]
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_BioAnswer_BioId]
+ON [Participant].[BioAnswer] ([BioId]);
+GO
+
+ALTER TABLE [Participant].[BioAnswer]
+ADD CONSTRAINT [FK_BioAnswer_Bio_BioId]
+FOREIGN KEY ([BioId])
+REFERENCES [Participant].[Bio] ([Id])
+ON DELETE CASCADE;
+GO

--- a/src/DatabaseSeeding/Scripts/0064_PopulateBioAnswers.sql
+++ b/src/DatabaseSeeding/Scripts/0064_PopulateBioAnswers.sql
@@ -1,0 +1,20 @@
+IF NOT EXISTS (SELECT TOP(1) 1 FROM [Participant].[BioAnswer])
+BEGIN
+
+    -- Single-choice questions: each question object has { "Answer": "..." }
+    -- A third OPENJSON level opens each question object; filtering on ans.[key] = 'Answer'
+    -- naturally excludes the pathway-level $type row (non-JSON value produces no rows via CROSS APPLY)
+    -- and there are no multi-choice questions for Bio.
+    INSERT INTO [Participant].[BioAnswer] ([BioId], [QuestionCode], [Answer])
+    SELECT
+        a.[Id],
+        q.[key],
+        ans.[value]
+    FROM [Participant].[Bio] a
+    CROSS APPLY OPENJSON(a.[BioJson], '$.Pathways') pathways
+    CROSS APPLY OPENJSON(pathways.[value]) q
+    CROSS APPLY OPENJSON(q.[value]) ans
+    WHERE q.[key] != '$type'
+      AND ans.[key] = 'Answer'
+      AND ans.[value] is not null;
+END

--- a/src/DatabaseSeeding/Scripts/0065_NullBiojson.sql
+++ b/src/DatabaseSeeding/Scripts/0065_NullBiojson.sql
@@ -1,0 +1,6 @@
+IF EXISTS (SELECT TOP(1) [Id] FROM [Participant].[Bio] WHERE [BioJson] IS NOT NULL)
+BEGIN
+  -- This is in a separate file to ensure it doesn't run if the previous step fails due to timeout.
+  UPDATE [Participant].[Bio]
+    SET [BioJson] = NULL;
+END

--- a/src/Domain/Entities/Bios/ParticipantBio.cs
+++ b/src/Domain/Entities/Bios/ParticipantBio.cs
@@ -2,6 +2,7 @@ using Cfo.Cats.Domain.Common.Contracts;
 using Cfo.Cats.Domain.Common.Entities;
 using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Domain.Events;
+using Cfo.Cats.Domain.ValueObjects;
 
 namespace Cfo.Cats.Domain.Entities.Bios;
 
@@ -13,37 +14,56 @@ public class ParticipantBio : BaseAuditableEntity<Guid>, IAuditTrial
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
+    private readonly List<BioAnswer> _answers = new();
+
     public string ParticipantId { get; private set; }
     public DateTime? Completed { get; private set; }
     public string? CompletedBy { get; private set; }
-    public string BioJson { get; private set; }
     public BioStatus Status { get; private set; } = BioStatus.NotStarted;
 
-    private ParticipantBio(Guid id, string participantId, string bioJson, BioStatus status)
+    public IReadOnlyCollection<BioAnswer> Answers => _answers.AsReadOnly();
+
+    private ParticipantBio(Guid id, string participantId, BioStatus status)
     {
         Id = id;
         ParticipantId = participantId;
-        BioJson = bioJson;
         Status = status;          
         AddDomainEvent(new BioCreatedDomainEvent(this));          
     }
 
-    public ParticipantBio UpdateJson(string json)
+    public ParticipantBio SetAnswer(string questionCode, string answer)
     {
-        BioJson = json;
+        _answers.RemoveAll(a => a.QuestionCode == questionCode);
+        _answers.Add(new BioAnswer(questionCode, answer));
         return this;
     }
 
+    public ParticipantBio SetAnswers(string questionCode, IEnumerable<string> answers)
+    {
+        _answers.RemoveAll(a => a.QuestionCode == questionCode);
+        foreach (var answer in answers)
+        {
+            _answers.Add(new BioAnswer(questionCode, answer));
+        }
+        return this;
+    }
+
+    public string? GetAnswer(string questionCode)
+        => _answers.FirstOrDefault(a => a.QuestionCode == questionCode)?.Answer;
+
+    public IEnumerable<string> GetAnswers(string questionCode)
+        => _answers.Where(a => a.QuestionCode == questionCode).Select(a => a.Answer);
+
     public ParticipantBio Submit(string completedBy)
     {
-        Completed = DateTime.Now;
+        Completed = DateTime.UtcNow;
         CompletedBy = completedBy;
         AddDomainEvent(new BioSubmittedDomainEvent(this));
         return this;
     }
 
-    public static ParticipantBio Create(Guid id, string participantId, string bioJson) 
-        => new(id, participantId, bioJson, BioStatus.InProgress);
+    public static ParticipantBio Create(Guid id, string participantId) 
+        => new(id, participantId, BioStatus.InProgress);
 
     public ParticipantBio UpdateStatus(BioStatus status)
     {
@@ -53,4 +73,6 @@ public class ParticipantBio : BaseAuditableEntity<Guid>, IAuditTrial
         }
         return this;
     }
+
+    public bool IsCompleted => Completed is not null;
 }

--- a/src/Domain/ValueObjects/BioAnswer.cs
+++ b/src/Domain/ValueObjects/BioAnswer.cs
@@ -1,0 +1,22 @@
+namespace Cfo.Cats.Domain.ValueObjects;
+
+public class BioAnswer(string questionCode, string answer) : ValueObject
+{
+    /// <summary>
+    /// The stable code identifying the question (e.g. "A1", "B2", "C3").
+    /// </summary>
+    public string QuestionCode { get; private set; } = questionCode;
+
+    /// <summary>
+    /// One answer value. For single-choice questions there will be exactly one
+    /// row per question; for multiple-choice questions there will be one row per
+    /// selected answer.
+    /// </summary>
+    public string Answer { get; private set; } = answer;
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return QuestionCode;
+        yield return Answer;
+    }
+}

--- a/src/Infrastructure/Constants/Database/DatabaseConstants.cs
+++ b/src/Infrastructure/Constants/Database/DatabaseConstants.cs
@@ -24,6 +24,7 @@ internal static class DatabaseConstants
         public const string Participant = nameof(Participant);
         public const string Assessment = nameof(Assessment);
         public const string Bio = nameof(Bio);
+        public const string BioAnswer = nameof(BioAnswer);
         public const string Note = nameof(Note);
         public const string ExternalIdentifier = nameof(ExternalIdentifier);
         public const string Tenant = nameof(Tenant);

--- a/src/Infrastructure/Persistence/Configurations/Participants/BioEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Participants/BioEntityTypeConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Domain.Entities.Bios;
+using Cfo.Cats.Domain.ValueObjects;
 using Cfo.Cats.Infrastructure.Constants.Database;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -22,11 +23,24 @@ public class BioEntityTypeConfiguration : IEntityTypeConfiguration<ParticipantBi
 
         builder.Property(x => x.ParticipantId)
             .HasMaxLength(DatabaseConstants.FieldLengths.ParticipantId);
+        
         builder.Property(x => x.Status)
             .HasConversion(
             x => x!.Value,
             x => BioStatus.FromValue(x)
             );
+
+        builder.OwnsMany(p => p.Answers, answer => {
+            answer.WithOwner().HasForeignKey("BioId");
+            answer.HasKey("Id");
+            answer.HasIndex("BioId", nameof(BioAnswer.QuestionCode), nameof(BioAnswer.Answer)).IsUnique();
+            answer.ToTable(
+                DatabaseConstants.Tables.BioAnswer,
+                DatabaseConstants.Schemas.Participant
+            );
+            answer.Property(x => x.QuestionCode).HasMaxLength(3).IsRequired();
+            answer.Property(x => x.Answer).HasMaxLength(80).IsRequired();
+        });
 
         builder.Property(x => x.CreatedBy).HasMaxLength(DatabaseConstants.FieldLengths.GuidId);
         builder.Property(x => x.LastModifiedBy).HasMaxLength(DatabaseConstants.FieldLengths.GuidId);


### PR DESCRIPTION
This pull request refactors how participant bio answers are persisted and retrieved, moving from JSON serialization to a tabular storage model keyed by question codes. It introduces a stable `Code` property for each question, updates the logic for saving and loading answers, and removes the dependency on `Newtonsoft.Json` for bios. This makes the system more robust, maintainable, and future-proof when handling participant responses.

**Persistence and Retrieval Refactor:**

* Bio answers are now stored and loaded using a tabular model keyed by a new `Code` property on each question, rather than serializing the entire bio object as JSON. (`src/Application/Features/Bios/Commands/BeginBio.cs`, `src/Application/Features/Bios/Commands/SaveBio.cs`, `src/Application/Features/Bios/DTOs/Bio.cs`, [[1]](diffhunk://#diff-29b4bf2ff709eeb54c1e85a7d675c389753ead0026b87f620e243ae6f37315dcL29-R76) [[2]](diffhunk://#diff-e006192c690354cab0db3be0daebdf29a5a65662fefb2222c7737c89e56db92cL32-R40) [[3]](diffhunk://#diff-44e0a20130f6ebbf3bd56df153be2b29cc1a71b1bbda42d4fbf790e546a5f01cR8-R29)
* The `WithAnswers` method is added to the `Bio` class to populate answers from tabular storage based on question codes. (`src/Application/Features/Bios/DTOs/Bio.cs`, [src/Application/Features/Bios/DTOs/Bio.csR8-R29](diffhunk://#diff-44e0a20130f6ebbf3bd56df153be2b29cc1a71b1bbda42d4fbf790e546a5f01cR8-R29))
* The dependency on `Newtonsoft.Json` is removed from bio command files. (`src/Application/Features/Bios/Commands/BeginBio.cs`, `src/Application/Features/Bios/Commands/SaveBio.cs`, [[1]](diffhunk://#diff-29b4bf2ff709eeb54c1e85a7d675c389753ead0026b87f620e243ae6f37315dcL8) [[2]](diffhunk://#diff-e006192c690354cab0db3be0daebdf29a5a65662fefb2222c7737c89e56db92cL6)

**Question Model Improvements:**

* A new abstract `Code` property is added to `QuestionBase`, and implemented for all `SingleChoiceQuestion` subclasses (e.g., `A1`, `B1`–`B15`), ensuring each question has a stable identifier for answer storage. (`src/Application/Features/Bios/DTOs/QuestionBase.cs`, `src/Application/Features/Bios/DTOs/V1/Pathways/ChildhoodExperiences/B1.cs`, ..., [[1]](diffhunk://#diff-1e2231a926611a4897ab6acdbe49079c8fa61b4a0451d5e43fab8e30e32e0c16R45-R50) [[2]](diffhunk://#diff-0bf0628d02bbeff7bc12eb7f7edffe92a6f8babcd5b592c89b7a497a7635fb8fR9) [[3]](diffhunk://#diff-a75cab40e3f5197b65c26b56337270c0d8856777dfc28949020196141b441fdaR9) [[4]](diffhunk://#diff-07db4b933bc23d03a4a257d96807067992051c4a07645fa8b855a49218db82b8R9) [[5]](diffhunk://#diff-ded51aba9ba9d3fd0fe0c20bcb9bbfa9d85a1058b6829a60619ca6ded86d14fcR9) [[6]](diffhunk://#diff-1ef8f388d848f075680f093235d9041beaf0c424c74583b2246f59475e856d24R9) [[7]](diffhunk://#diff-4d15e8d625589aef74c5b7dc52fbf4ce841900a4d33d9abd0a92c411ba7c0451R9) [[8]](diffhunk://#diff-30fb6a018302041905d27a415d23785db93e805cf7654eea4c216f738b229c30R9) [[9]](diffhunk://#diff-c45db9b1cf7fa9c2dc66a4a3140de74d181fac703e3b15411a49bc52fa31cf74R9) [[10]](diffhunk://#diff-a5f1de535138687cdb00726d1973c7ca335e015e0143bc52f245083e95e92517R9) [[11]](diffhunk://#diff-6a3fa26971d71520cd84498f81ee7dfd2f86691fdfade749d1c7aa5a48dd3c97R9) [[12]](diffhunk://#diff-77a419adba8a1b07bcadfdabe65e0eecc0b0ba8859e185f7662e4c515136b9ffR9) [[13]](diffhunk://#diff-a2e909000c1798da0d40309c6eff2c5ffec03babd8d720dfe4468cc81d446ca6R9) [[14]](diffhunk://#diff-53a3314daf7462b789a86fabc406244ed0e2783863d882685020dd8f075c8de5R9) [[15]](diffhunk://#diff-063d7aef785b439f0d50bb51d500fc50ec51066006a2466b0ea2f84631864625R9) [[16]](diffhunk://#diff-b8110bd6754218306dcf0c13fb5b35be0f0099e2f3279079a3685dab25d9a144R9) [[17]](diffhunk://#diff-dea4a3ae907148b1ab07ea1675618abc78570c8f47b8757c8fe9821f7394a1e9R10)

**Code Simplification:**

* The logic for copying answers from a previous bio is now explicit and operates at the question level, rather than via JSON round-tripping. (`src/Application/Features/Bios/Commands/BeginBio.cs`, [src/Application/Features/Bios/Commands/BeginBio.csL29-R76](diffhunk://#diff-29b4bf2ff709eeb54c1e85a7d675c389753ead0026b87f620e243ae6f37315dcL29-R76))

These changes collectively improve data integrity, make migrations and future changes easier, and clarify the codebase.

## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)
