### PR TITLE
CFODEV-1674: Amend labels in payment data view to reflect the data being shown

### DIFF
--- a/src/Server.UI/Pages/Payments/Components/EducationPayments.razor
+++ b/src/Server.UI/Pages/Payments/Components/EducationPayments.razor
@@ -23,7 +23,7 @@
             Loading="@_loading" 
             LoadingProgressColor="Color.Info">
                 <ToolBarContent>
-                    <MudText Typo="Typo.h6">Activities</MudText>
+                    <MudText Typo="Typo.h6">Education & Training</MudText>
                     <MudSpacer />
                     <MudStack Row="true">
                         <MudTextField @bind-Value="_searchString" @bind-Value:after="OnSearch" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/Server.UI/Pages/Payments/Components/EmploymentPayments.razor
+++ b/src/Server.UI/Pages/Payments/Components/EmploymentPayments.razor
@@ -24,7 +24,7 @@
             Loading="@_loading"
             LoadingProgressColor="Color.Info">
                 <ToolBarContent>
-                    <MudText Typo="Typo.h6">Activities</MudText>
+                    <MudText Typo="Typo.h6">Employment</MudText>
                     <MudSpacer />
                     <MudStack Row="true">
                         <MudTextField @bind-Value="_searchString" @bind-Value:after="OnSearch" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/Server.UI/Pages/Payments/Components/EnrolmentPayments.razor
+++ b/src/Server.UI/Pages/Payments/Components/EnrolmentPayments.razor
@@ -26,7 +26,7 @@
             Loading="@_loading"
             LoadingProgressColor="Color.Info">
                 <ToolBarContent>
-                    <MudText Typo="Typo.h6">Activities</MudText>
+                    <MudText Typo="Typo.h6">Enrolments</MudText>
                     <MudSpacer />
                     <MudStack Row="true">
                         <MudTextField @bind-Value="_searchString" @bind-Value:after="OnSearch" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/Server.UI/Pages/Payments/Components/InductionPayments.razor
+++ b/src/Server.UI/Pages/Payments/Components/InductionPayments.razor
@@ -26,7 +26,7 @@
             Loading="@_loading"
             LoadingProgressColor="Color.Info">
                 <ToolBarContent>
-                    <MudText Typo="Typo.h6">Activities</MudText>
+                    <MudText Typo="Typo.h6">Inductions</MudText>
                     <MudSpacer />
                     <MudStack Row="true">
                         <MudTextField @bind-Value="_searchString" @bind-Value:after="OnSearch" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/Server.UI/Pages/Payments/Components/SupportAndReferral.razor
+++ b/src/Server.UI/Pages/Payments/Components/SupportAndReferral.razor
@@ -25,7 +25,7 @@
             Loading="@_loading"
             LoadingProgressColor="Color.Info">
                 <ToolBarContent>
-                    <MudText Typo="Typo.h6">Activities</MudText>
+                    <MudText Typo="Typo.h6">Support & Referral</MudText>
                     <MudSpacer />
                     <MudStack Row="true">
                         <MudTextField @bind-Value="_searchString" @bind-Value:after="OnSearch" Placeholder="Search" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>


### PR DESCRIPTION
This pull request updates the section headers across several payment component pages to use more specific and descriptive titles instead of the generic "Activities" label. This improves clarity for users by accurately reflecting the content of each section.

**UI Improvements:**

* Changed the section header in `EducationPayments.razor` from "Activities" to "Education & Training"
* Changed the section header in `EmploymentPayments.razor` from "Activities" to "Employment"
* Changed the section header in `EnrolmentPayments.razor` from "Activities" to "Enrolments"
* Changed the section header in `InductionPayments.razor` from "Activities" to "Inductions"
* Changed the section header in `SupportAndReferral.razor` from "Activities" to "Support & Referral"

## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)
