### PR TITLE
Remove secondary tenant filter from the Tenant Initiatives Dashboard

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetInitiativeObjectivesDashboard.cs
+++ b/src/Application/Features/Dashboard/Queries/GetInitiativeObjectivesDashboard.cs
@@ -28,8 +28,10 @@ public static class GetInitiativeObjectivesDashboard
                             join o in context.Objectives on pp.Id equals o.PathwayPlanId
                             join io in context.InitiativeObjectives on o.Id equals io.ObjectiveId
                             join i in context.Initiatives on io.InitiativeId equals i.Id
+                            join creator in context.Users on io.CreatedBy equals creator.Id into creatorJoin
+                            from creator in creatorJoin.DefaultIfEmpty()
                             where p.EnrolmentStatus != EnrolmentStatus.ArchivedStatus.Value
-                            select new { p, u, t, o, io, i };
+                            select new { p, u, t, o, io, i, creator };
 
             baseQuery = request switch
             {
@@ -56,6 +58,7 @@ public static class GetInitiativeObjectivesDashboard
                                   InitiativeId = data.i.Id,
                                   InitiativeCode = data.i.Code,
                                   InitiativeDescription = data.i.Description,
+                                  InitiativeObjectiveCreatedBy = data.creator != null ? data.creator.DisplayName : null,
                                   TotalTasks = data.o.Tasks.Count(),
                                   CompletedTasks = data.o.Tasks.Count(t => t.Completed != null),
                                   ActivityCount = context.Activities.Count(a => a.ObjectiveId == data.o.Id)
@@ -84,6 +87,7 @@ public static class GetInitiativeObjectivesDashboard
         public required Guid InitiativeId { get; init; }
         public required string InitiativeCode { get; init; }
         public required string InitiativeDescription { get; init; }
+        public string? InitiativeObjectiveCreatedBy { get; init; }
         public int TotalTasks { get; init; }
         public int CompletedTasks { get; init; }
         public int ActivityCount { get; init; }

--- a/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
@@ -21,10 +21,13 @@
         <MudItem xs="12" Class="d-flex justify-space-between align-center">
             <MudText Typo="Typo.h6">Initiative Objectives</MudText>
             <div class="d-flex align-center gap-3">
-                <InitiativeAutoComplete @bind-Value="_initiativeFilter" @bind-Value:after="StateHasChanged"
-                                       ActiveOnly="false"
-                                       Style="max-width: 260px;" 
-                                       Label="Initiative" />
+                @if (!VisualMode)
+                {
+                    <InitiativeAutoComplete @bind-Value="_initiativeFilter" @bind-Value:after="StateHasChanged"
+                                           ActiveOnly="false"
+                                           Style="max-width: 260px;" 
+                                           Label="Initiative" />
+                }
                 <MudSwitch T="bool" @bind-Value="ShowActiveOnly" Color="Color.Primary" Label="Show active only" />
             </div>
         </MudItem>

--- a/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
@@ -18,12 +18,19 @@
 @if (Data is not null && Data.Any())
 {
     <MudGrid Spacing="2" Class="mb-3">
-        <MudItem xs="12" sm="6">
+        <MudItem xs="12" Class="d-flex justify-space-between align-center">
+            <MudText Typo="Typo.h6">Initiative Objectives</MudText>
+            <div class="d-flex align-center gap-3">
+                <InitiativeAutoComplete @bind-Value="_initiativeFilter" @bind-Value:after="StateHasChanged"
+                                       ActiveOnly="false"
+                                       Style="max-width: 260px;" 
+                                       Label="Initiative" />
+                <MudSwitch T="bool" @bind-Value="ShowActiveOnly" Color="Color.Primary" Label="Show active only" />
+            </div>
+        </MudItem>
+        <MudItem xs="12">
             <MudChip T="string">Active (@TotalActive)</MudChip>
             <MudChip T="string">Completed (@TotalCompleted)</MudChip>
-        </MudItem>
-        <MudItem xs="12" sm="6" Class="d-flex justify-end align-center">
-            <MudSwitch T="bool" @bind-Value="ShowActiveOnly" Color="Color.Primary" Label="Show active only" />
         </MudItem>
     </MudGrid>
 
@@ -58,22 +65,6 @@
                   Striped="true"
                   Dense="true"
                   SortLabel="Sort By">
-            <ToolBarContent>
-                <MudText Typo="Typo.h6">Initiative Objectives</MudText>
-                <MudSpacer />
-                <MudSelect T="string" @bind-Value="_tenantFilter" @bind-Value:after="StateHasChanged"
-                           Label="Tenant" Clearable="true" AnchorOrigin="Origin.BottomLeft"
-                           Style="max-width: 260px;" Class="mr-2">
-                    @foreach (var tenant in _tenants)
-                    {
-                        <MudSelectItem T="string" Value="@tenant.Id">@tenant.Name</MudSelectItem>
-                    }
-                </MudSelect>
-                <InitiativeAutoComplete @bind-Value="_initiativeFilter" @bind-Value:after="StateHasChanged"
-                                       ActiveOnly="false"
-                                       Style="max-width: 260px;" 
-                                       Label="Initiative" />
-            </ToolBarContent>
             <HeaderContent>
                 <MudTh>
                     <MudTableSortLabel SortBy="new Func<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto, object>(x => x.ParticipantName)">
@@ -90,6 +81,11 @@
                         Objective
                     </MudTableSortLabel>
                 </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto, object>(x => x.InitiativeObjectiveCreatedBy ?? string.Empty)">
+                        Created By
+                    </MudTableSortLabel>
+                </MudTh>                
                 <MudTh>
                     <MudTableSortLabel SortBy="new Func<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto, object>(x => x.InitiativeCode)">
                         Initiative
@@ -128,6 +124,9 @@
                 </MudTd>
                 <MudTd DataLabel="Objective">
                     <MudText Typo="Typo.body2">@context.ObjectiveDescription</MudText>
+                </MudTd>
+                <MudTd DataLabel="Created By">
+                    <MudText Typo="Typo.body2">@context.InitiativeObjectiveCreatedBy</MudText>
                 </MudTd>
                 <MudTd DataLabel="Initiative">
                     <MudTooltip Text="@context.InitiativeDescription">

--- a/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor.cs
@@ -1,9 +1,6 @@
 using ApexCharts;
-using Cfo.Cats.Application.Common.Interfaces.Initiatives;
-using Cfo.Cats.Application.Common.Interfaces.MultiTenant;
 using Cfo.Cats.Application.Features.Dashboard.Queries;
 using Cfo.Cats.Application.Features.Initiatives.DTOs;
-using Cfo.Cats.Application.Features.Tenants.DTOs;
 
 namespace Cfo.Cats.Server.UI.Components.Dashboard;
 
@@ -20,20 +17,8 @@ public partial class InitiativeObjectivesDashboardComponent
     [CascadingParameter(Name = "IsDarkMode")]
     public bool IsDarkMode { get; set; }
 
-    [Inject]
-    private ITenantService TenantService { get; set; } = null!;
-
     private InitiativeDto? _initiativeFilter;
-    private string _tenantFilter = string.Empty;
     private bool ShowActiveOnly { get; set; } = false;
-
-    private IReadOnlyList<TenantDto> _tenants = [];
-
-    protected override void OnInitialized()
-    {
-        base.OnInitialized();
-        _tenants = TenantService.GetVisibleTenants(TenantId ?? CurrentUser.TenantId!).ToList();
-    }
 
     protected override IRequest<Result<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto[]>> CreateQuery()
      => new GetInitiativeObjectivesDashboard.Query
@@ -96,7 +81,6 @@ public partial class InitiativeObjectivesDashboardComponent
             ? Array.Empty<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto>()
             : Data
                 .Where(r => _initiativeFilter is null || r.InitiativeCode == _initiativeFilter.Code)
-                .Where(r => string.IsNullOrEmpty(_tenantFilter) || r.OwnerTenantId == _tenantFilter)
                 .Where(r => !ShowActiveOnly || !r.IsObjectiveCompleted);
 
     public record InitiativeChartPoint(string InitiativeCode, int ActiveCount, int CompletedCount);


### PR DESCRIPTION
This pull request enhances the Initiative Objectives Dashboard by adding visibility into the creator of each initiative objective and simplifying the filtering UI. The backend now includes the creator's display name in the data, and the frontend displays this information in a new "Created By" column. Additionally, tenant filtering has been removed from the UI, and related code has been cleaned up.

**Backend Enhancements:**

* Added a join to the `Users` table in the dashboard query to retrieve the display name of the user who created each initiative objective, and included this information in the returned data model (`InitiativeObjectiveRowDto`). [[1]](diffhunk://#diff-f95eb42eb10e33c73a4f8712bde887fded22875382e95fb4a7772c7341b9fa77R31-R34) [[2]](diffhunk://#diff-f95eb42eb10e33c73a4f8712bde887fded22875382e95fb4a7772c7341b9fa77R61) [[3]](diffhunk://#diff-f95eb42eb10e33c73a4f8712bde887fded22875382e95fb4a7772c7341b9fa77R90)

**Frontend UI/UX Improvements:**

* Added a new "Created By" column to the dashboard table to display the creator's name for each initiative objective. [[1]](diffhunk://#diff-94a52167e11a71d35b641b80bba2b54f5143f389aa151a48c5e086fec7c50641R84-R88) [[2]](diffhunk://#diff-94a52167e11a71d35b641b80bba2b54f5143f389aa151a48c5e086fec7c50641R128-R130)
* Refactored the dashboard filter controls: moved the initiative filter and "Show active only" switch into a single header row, and removed the tenant filter from the UI. [[1]](diffhunk://#diff-94a52167e11a71d35b641b80bba2b54f5143f389aa151a48c5e086fec7c50641L21-L27) [[2]](diffhunk://#diff-94a52167e11a71d35b641b80bba2b54f5143f389aa151a48c5e086fec7c50641L61-L76)

**Code Cleanup:**

* Removed unused tenant filtering logic and related service dependencies from the component code-behind, including the `TenantService` and tenant DTO references. [[1]](diffhunk://#diff-9ffdff3bce26811fa7559de0b02438ec67582a61140dba590dcf821910fa928eL2-L6) [[2]](diffhunk://#diff-9ffdff3bce26811fa7559de0b02438ec67582a61140dba590dcf821910fa928eL23-L37) [[3]](diffhunk://#diff-9ffdff3bce26811fa7559de0b02438ec67582a61140dba590dcf821910fa928eL99)

## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [ ] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)
