### PR TITLE
hotfix: initiatives menu item not visible to users without UserManagement permission

### DIFF
--- a/src/Server.UI/Services/Navigation/AsyncMenuService.cs
+++ b/src/Server.UI/Services/Navigation/AsyncMenuService.cs
@@ -122,7 +122,6 @@ public class AsyncMenuService(IAuthorizationService authorizationService) : IAsy
                     });
                 }
 
-                menuItems.Add(management);
             }
 
             if(await PassesPolicy(principal, SecurityPolicies.Initiatives))
@@ -135,6 +134,11 @@ public class AsyncMenuService(IAuthorizationService authorizationService) : IAsy
                    Href = "/pages/initiatives",
                    PageStatus = PageStatus.Wip
                 });
+            }
+
+            if(management.SectionItems.Any())
+            {
+                menuItems.Add(management);
             }
 
         }


### PR DESCRIPTION
The "Initiatives" item in the Management section of the side navigation was never visible to users who had the `Initiatives` permission but not the `UserManagement` permission (e.g. CMPSM, CSO, CPM roles).
 
This was caused by conditional logic in `AsyncMenuService`. The `menuItems.Add(management)` call, which adds the Management section to the nav, was placed inside the `UserManagement` policy block. The `Initiatives` policy check sat outside that block (at the`Internal` level), but since the `management` object had never been added to `menuItems`, any items appended to it were silently discarded.

## PR Type
- [ ] Feature
- [x] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [x] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [x] Required → completed
- [ ] Not required (explain below)
