### PR TITLE
Split task editing and due date adjustment

### DIFF
--- a/src/Application/Features/PathwayPlans/Commands/AdjustTaskDueDate.cs
+++ b/src/Application/Features/PathwayPlans/Commands/AdjustTaskDueDate.cs
@@ -4,7 +4,7 @@ using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.PathwayPlans.Commands;
 
-public static class EditTask
+public static class AdjustTaskDueDate
 {
     [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
     public class Command : IRequest<Result>
@@ -18,8 +18,8 @@ public static class EditTask
         [Description("Pathway Plan Id")]
         public required Guid PathwayPlanId { get; init; }
 
-        [Description("Description")]
-        public string? Description { get; set; }
+        [Description("Due")]
+        public DateTime? Due { get; set; }
     }
 
     public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Command, Result>
@@ -36,12 +36,12 @@ public static class EditTask
             var task = objective.Tasks.FirstOrDefault(x => x.Id == request.TaskId)
                        ?? throw new NotFoundException("Cannot find task", request.TaskId);
 
-            if (string.IsNullOrWhiteSpace(request.Description))
+            if (request.Due.HasValue is false)
             {
-                return Result.Failure("You must provide a Description");
+                return Result.Failure("You must provide a Due date");
             }
 
-            task.Rename(request.Description);
+            task.Extend(request.Due.Value);
 
             return Result.Success();
         }
@@ -54,7 +54,9 @@ public static class EditTask
         public Validator(IUnitOfWork unitOfWork)
         {
             _unitOfWork = unitOfWork;
-            
+
+            var today = DateTime.UtcNow;
+
             RuleFor(x => x.ObjectiveId)
                 .NotEmpty();
 
@@ -64,14 +66,19 @@ public static class EditTask
             RuleFor(x => x.PathwayPlanId)
                 .NotEmpty()
                 .WithMessage("You must provide a Pathway Plan");
-                
-            RuleFor(x => x.Description)
-                .NotEmpty()
-                .WithMessage("You must provide a description")
-                .MaximumLength(2000)
-                .WithMessage($"Maximum length of description is 2000")
-                .Matches(ValidationConstants.Notes)
-                .WithMessage(string.Format(ValidationConstants.NotesMessage, "Description"));
+
+            RuleFor(x => x.Due)
+                .Must(x => x.HasValue)
+                .WithMessage("You must provide a Due date");
+
+            When(x => x.Due.HasValue, () =>
+            {
+                RuleFor(x => x.Due)
+                    .GreaterThanOrEqualTo(new DateTime(today.Year, today.Month, 1))
+                    .WithMessage(ValidationConstants.DateMustBeInFuture)
+                    .Must(x => x!.Value.Day.Equals(1))
+                    .WithMessage("Due date must fall on the first day of the month");
+            });
 
             RuleSet(ValidationConstants.RuleSet.MediatR, () =>
             {

--- a/src/Application/Features/PathwayPlans/DTOs/ObjectiveTaskDto.cs
+++ b/src/Application/Features/PathwayPlans/DTOs/ObjectiveTaskDto.cs
@@ -4,17 +4,17 @@ namespace Cfo.Cats.Application.Features.PathwayPlans.DTOs;
 
 public class ObjectiveTaskDto
 {
-    public required Guid Id { get; set; }
-    public required string Description { get; set; }
-    public required Guid ObjectiveId { get; set; }
-    public required DateTime Due { get; set; }
-    public required DateTime Created { get; set; }
-    public required string CreatedBy { get; set; }
-    public DateTime? Completed { get; set; }
-    public string? CompletedBy { get; set; }
-    public CompletionStatus? CompletedStatus { get; set; }
-    public required int Index { get; set; }
-    public string? Justification { get; set; }
+    public required Guid Id { get; init; }
+    public required string Description { get; init; }
+    public required Guid ObjectiveId { get; init; }
+    public required DateTime Due { get; init; }
+    public required DateTime Created { get; init; }
+    public required string CreatedBy { get; init; }
+    public DateTime? Completed { get; init; }
+    public string? CompletedBy { get; init; }
+    public CompletionStatus? CompletedStatus { get; init; }
+    public required int Index { get; init; }
+    public string? Justification { get; init; }
     public string DisplayName => $"{Index}. {Description}";
     public bool IsCompleted => Completed.HasValue;
     public bool IsOverdue => IsCompleted is false
@@ -24,8 +24,8 @@ public class ObjectiveTaskDto
         && (ToFirstDayOfMonth(DateTime.UtcNow).Equals(ToFirstDayOfMonth(Due))
         || IsOverdue is false && (DateTime.UtcNow.AddDays(14) > ToFirstDayOfMonth(Due)));
 
-    public required bool IsMandatory { get; set; }
-    public bool CanBeRenamed => IsMandatory is false;
+    public required bool IsMandatory { get; init; }
+    public bool CanBeEdited => IsMandatory is false;
     public bool CanAddActivity => IsMandatory is false;
 
     public class Mapping : Profile

--- a/src/Infrastructure/Constants/ConstantString.cs
+++ b/src/Infrastructure/Constants/ConstantString.cs
@@ -197,15 +197,17 @@ public static class ConstantString
 
     public static string Active =>
      Localize("Active");
+    public static string AdjustDate =>
+        Localize("Adjust Date");
 
     public static string DateSuccessfullyAdjusted =>
-    Localize("Date Successfully Adjusted");
+        Localize("Date Successfully Adjusted");
 
-    public static string TaskSuccessfullyRenamed =>
-    Localize("Task Successfully Renamed");
+    public static string TaskSuccessfullyEdited =>
+        Localize("Task Successfully Edited");
 
     public static string TaskSuccessfullyCompleted =>
-    Localize("Task Successfully Completed");
+        Localize("Task Successfully Completed");
 
     public static string ThematicObjectiveSuccessfullyAdded =>
     Localize("Thematic Objective Successfully Added");

--- a/src/Server.UI/Pages/Objectives/Tasks/AdjustDateTaskDialog.razor.cs
+++ b/src/Server.UI/Pages/Objectives/Tasks/AdjustDateTaskDialog.razor.cs
@@ -8,7 +8,7 @@ public partial class AdjustDateTaskDialog
     private bool _saving;
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
 
-    [Parameter, EditorRequired] public required EditTask.Command Model { get; set; }
+    [Parameter, EditorRequired] public required AdjustTaskDueDate.Command Model { get; set; }
 
     private void Cancel() => MudDialog.Cancel();
 

--- a/src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor
+++ b/src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor
@@ -7,14 +7,14 @@
                           Label="@Model.GetMemberDescription(x => x.Description)"
                           For="@(() => Model.Description)"
                           Lines="4"  
-                          MaxLength=2000 
+                          MaxLength="2000" 
                           Immediate="true" 
-                          Counter=2000
+                          Counter="2000"
                           />
         </MudForm>
     </DialogContent>
     <DialogActions>
-        <MudButton Color="Color.Secondary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel">@ConstantString.Cancel</MudButton>
-        <MudLoadingButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Loading="_saving" OnClick="Submit">@ConstantString.Save</MudLoadingButton>
+        <MudButton Color="Color.Secondary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" OnClick="@Cancel">@ConstantString.Cancel</MudButton>
+        <MudLoadingButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Loading="_saving" OnClick="@Submit">@ConstantString.Save</MudLoadingButton>
     </DialogActions>
 </MudDialog>

--- a/src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor.cs
+++ b/src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor.cs
@@ -2,7 +2,7 @@ using Cfo.Cats.Application.Features.PathwayPlans.Commands;
 
 namespace Cfo.Cats.Server.UI.Pages.Objectives.Tasks;
 
-public partial class RenameTaskDialog
+public partial class EditTaskDialog
 {
     private MudForm? _form;
     private bool _saving;

--- a/src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor
+++ b/src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor
@@ -13,7 +13,7 @@
         {
             <MudTooltip Text="Mark task as completed">
                 <MudIconButton Icon="@Icons.Material.Filled.CheckBoxOutlineBlank"
-                               OnClick="Complete"
+                               OnClick="@Complete"
                                Disabled="!ParticipantIsActive"/>
             </MudTooltip>
         }
@@ -76,10 +76,10 @@
             <div class="d-flex gap-2 align-center mr-4">
                 <MudTooltip Text="Actions">
                     <MudMenu Icon="@Icons.Material.Filled.Edit" Variant="Variant.Filled" Disabled="Model.IsCompleted || !ParticipantIsActive " Size="Size.Small" Dense>
-                        <MudMenuItem OnClick="@AdjustDate">Adjust date</MudMenuItem>
-                        @if(Model.CanBeRenamed)
+                        <MudMenuItem OnClick="@AdjustDate">@ConstantString.AdjustDate</MudMenuItem>
+                        @if(Model.CanBeEdited)
                         {
-                            <MudMenuItem OnClick="@Rename">Edit</MudMenuItem>
+                            <MudMenuItem OnClick="@Edit">@ConstantString.Edit</MudMenuItem>
                         }
                     </MudMenu>
                 </MudTooltip>

--- a/src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor.cs
+++ b/src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor.cs
@@ -82,11 +82,10 @@ public partial class ObjectiveTask
 
     private async Task AdjustDate()
     {
-        var command = new EditTask.Command()
+        var command = new AdjustTaskDueDate.Command()
         {
             TaskId = Model.Id,
             ObjectiveId = Model.ObjectiveId,
-            Description = Model.Description,
             Due = Model.Due,
             PathwayPlanId = PathwayPlanId
         };
@@ -118,25 +117,24 @@ public partial class ObjectiveTask
         }
     }
 
-    private async Task Rename()
+    private async Task Edit()
     {
         var command = new EditTask.Command()
         {
             TaskId = Model.Id,
             ObjectiveId = Model.ObjectiveId,
             Description = Model.Description,
-            Due = Model.Due,
             PathwayPlanId = PathwayPlanId
         };
 
-        var parameters = new DialogParameters<RenameTaskDialog>()
+        var parameters = new DialogParameters<EditTaskDialog>()
         {
             { x => x.Model, command }
         };
 
         var options = SetDialogOptions();
-        var dialogTitle = "Rename task for " + ParticipantName + " Ref: " + ParticipantId;
-        var dialog = await DialogService.ShowAsync<RenameTaskDialog>(dialogTitle, parameters, options);
+        var dialogTitle = "Edit task for " + ParticipantName + ". Ref: " + ParticipantId;
+        var dialog = await DialogService.ShowAsync<EditTaskDialog>(dialogTitle, parameters, options);
 
         var state = await dialog.Result;
 
@@ -146,7 +144,7 @@ public partial class ObjectiveTask
 
             if (result.Succeeded)
             {
-                Snackbar.Add(ConstantString.TaskSuccessfullyRenamed, Severity.Info);
+                Snackbar.Add(ConstantString.TaskSuccessfullyEdited, Severity.Info);
                 await OnChange.InvokeAsync();
             }
             else


### PR DESCRIPTION
## PR Type
- [ ] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [ ] Code builds locally
- [ ] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)

---

This pull request refactors and separates the logic for editing a task's description and adjusting its due date in the pathway plans feature. It introduces a dedicated command and handler for adjusting task due dates, streamlines validation rules, updates relevant DTOs and UI components, and improves naming consistency throughout the codebase. The changes enhance clarity, maintainability, and user feedback for task management actions.

**Backend changes:**

* Introduced a new `AdjustTaskDueDate` command and handler to handle due date adjustments separately from editing task descriptions, including comprehensive validation for due dates (must be the first day of a future month and participant must not be archived). (`src/Application/Features/PathwayPlans/Commands/AdjustTaskDueDate.cs`)
* Refactored `EditTask` command to remove due date handling and validation, focusing solely on editing the task description. Updated validation to require non-empty fields and ensure a valid description. (`src/Application/Features/PathwayPlans/Commands/EditTask.cs`) [[1]](diffhunk://#diff-b9c0b91a54e8f746d75c8409b142df1b8c205f37490f715be24170ece521157fL23-R30) [[2]](diffhunk://#diff-b9c0b91a54e8f746d75c8409b142df1b8c205f37490f715be24170ece521157fL41-R44) [[3]](diffhunk://#diff-b9c0b91a54e8f746d75c8409b142df1b8c205f37490f715be24170ece521157fL63-R65) [[4]](diffhunk://#diff-b9c0b91a54e8f746d75c8409b142df1b8c205f37490f715be24170ece521157fL83-L95)

**DTO and constants updates:**

* Updated `ObjectiveTaskDto` to use `init` setters for immutability and renamed `CanBeRenamed` to `CanBeEdited` for clarity. (`src/Application/Features/PathwayPlans/DTOs/ObjectiveTaskDto.cs`) [[1]](diffhunk://#diff-f506615e0839901f6e8c15a811938f302f5e244fe148d74fd8c5669df3819ec2L7-R17) [[2]](diffhunk://#diff-f506615e0839901f6e8c15a811938f302f5e244fe148d74fd8c5669df3819ec2L27-R28)
* Improved constant naming for user feedback messages, e.g., `TaskSuccessfullyRenamed` → `TaskSuccessfullyEdited`, and added `AdjustDate` constant. (`src/Infrastructure/Constants/ConstantString.cs`)

**UI and dialog changes:**

* Updated dialogs and UI components to use the new commands and improved naming: 
  - Renamed `RenameTaskDialog` to `EditTaskDialog` and updated all references.
  - Adjusted the adjust-date dialog to use the new command.
  - Updated menu actions and tooltips to reflect new terminology and permissions (`CanBeEdited`). (`src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor`, `src/Server.UI/Pages/Objectives/Tasks/EditTaskDialog.razor.cs`, `src/Server.UI/Pages/Objectives/Tasks/AdjustDateTaskDialog.razor.cs`, `src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor`, `src/Server.UI/Pages/Objectives/Tasks/ObjectiveTask.razor.cs`) [[1]](diffhunk://#diff-dad2dc2302cff978c2cd49cdbfaa5a8ecb8690849cdeb5d4c9a07b422b16c910L10-R18) [[2]](diffhunk://#diff-e1ce7f21bd87361f76e550d0b0085c09e8a840726c33c5f3ad8a21afca275f5bL5-R5) [[3]](diffhunk://#diff-2ba973886564d20202341db62d885bbb4a5550479032f77e9bcda96b2a944164L16-R16) [[4]](diffhunk://#diff-2ba973886564d20202341db62d885bbb4a5550479032f77e9bcda96b2a944164L79-R82) [[5]](diffhunk://#diff-8889e07f7483bc20d8b32c05efd38e899ef19c8a1b6b51d383ec49f70a115f8eL85-L89) [[6]](diffhunk://#diff-8889e07f7483bc20d8b32c05efd38e899ef19c8a1b6b51d383ec49f70a115f8eL121-R137) [[7]](diffhunk://#diff-8889e07f7483bc20d8b32c05efd38e899ef19c8a1b6b51d383ec49f70a115f8eL149-R147)

These changes collectively improve the separation of concerns, validation, and user experience for task editing and due date adjustments.
