### PR TITLE
Add initiatives document export

### DIFF
--- a/src/Application/Features/Dashboard/Commands/ExportInitiativeObjectivesDashboard.cs
+++ b/src/Application/Features/Dashboard/Commands/ExportInitiativeObjectivesDashboard.cs
@@ -1,0 +1,77 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Validators;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Entities.Documents;
+using Humanizer;
+using Newtonsoft.Json;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Commands;
+
+public static class ExportInitiativeObjectivesDashboard
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Command : IRequest<Result>
+    {
+        public required InitiativeObjectivesDashboardExportRequest Request { get; init; }
+    }
+
+    public class Handler(
+        IUnitOfWork unitOfWork,
+        ICurrentUserService currentUser) : IRequestHandler<Command, Result>
+    {
+        public async Task<Result> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var json = JsonConvert.SerializeObject(request.Request);
+
+            var document = GeneratedDocument.Create(
+                DocumentTemplate.InitiativeObjectivesDashboard,
+                "InitiativeObjectivesDashboard.xlsx",
+                "Initiative Objectives Dashboard Export",
+                currentUser.UserId!,
+                currentUser.TenantId!,
+                json);
+
+            await unitOfWork.DbContext.Documents.AddAsync(document, cancellationToken);
+
+            return Result.Success();
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        private readonly ICurrentUserService _currentUserService;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly TimeSpan _cooldown = TimeSpan.FromSeconds(30);
+
+        public Validator(IUnitOfWork unitOfWork, ICurrentUserService currentUserService)
+        {
+            _currentUserService = currentUserService;
+            _unitOfWork = unitOfWork;
+
+            RuleSet(ValidationConstants.RuleSet.MediatR, () =>
+            {
+                RuleFor(c => c)
+                    .Must(WaitBeforeRequestingDocumentAgain)
+                    .WithMessage($"You must wait {_cooldown.Humanize()} between requesting documents.");
+            });
+        }
+
+        private bool WaitBeforeRequestingDocumentAgain(Command c)
+        {
+            var cooldownPeriod = DateTime.UtcNow - _cooldown;
+
+            var hasRecentlyRequestedDocument = _unitOfWork.DbContext.GeneratedDocuments
+                .Any(d => d.CreatedBy == _currentUserService.UserId && d.Created > cooldownPeriod);
+
+            return hasRecentlyRequestedDocument is false;
+        }
+    }
+
+    public class InitiativeObjectivesDashboardExportRequest
+    {
+        public string? UserId { get; init; }
+        public string? TenantId { get; init; }
+        public string? InitiativeCode { get; init; }
+        public bool ShowActiveOnly { get; init; }
+    }
+}

--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInductionPaymentsIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInductionPaymentsIntegrationEventConsumer.cs
@@ -35,7 +35,7 @@ public class DocumentExportInductionPaymentsIntegrationEventConsumer(
         try
         {
             var request = JsonConvert.DeserializeObject<GetInductionPayments.Query>(context.SearchCriteria!)
-                          ?? throw new InvalidOperationException("Failed to deserialize initiatives export search criteria.");
+                          ?? throw new InvalidOperationException("Failed to deserialize induction payments export search criteria.");
 
             // Hack: call handler directly (skips Authorization pipeline, as we're outside of the HttpContext).
             var data = await new GetInductionPayments.Handler(unitOfWork, targetsProvider).Handle(request!, CancellationToken.None);

--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInductionPaymentsIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInductionPaymentsIntegrationEventConsumer.cs
@@ -35,7 +35,7 @@ public class DocumentExportInductionPaymentsIntegrationEventConsumer(
         try
         {
             var request = JsonConvert.DeserializeObject<GetInductionPayments.Query>(context.SearchCriteria!)
-                ?? throw new Exception();
+                          ?? throw new InvalidOperationException("Failed to deserialize initiatives export search criteria.");
 
             // Hack: call handler directly (skips Authorization pipeline, as we're outside of the HttpContext).
             var data = await new GetInductionPayments.Handler(unitOfWork, targetsProvider).Handle(request!, CancellationToken.None);

--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer.cs
@@ -1,0 +1,110 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Features.Dashboard.Commands;
+using Cfo.Cats.Application.Features.Dashboard.Queries;
+using Cfo.Cats.Application.Features.Documents.IntegrationEvents;
+using Cfo.Cats.Domain.Entities.Documents;
+using Newtonsoft.Json;
+using Rebus.Handlers;
+
+namespace Cfo.Cats.Application.Features.Documents.IntegrationEventHandlers;
+
+public class DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer(
+    IUnitOfWork unitOfWork,
+    IExcelService excelService,
+    IUploadService uploadService,
+    IDomainEventDispatcher domainEventDispatcher,
+    ILogger<DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer> logger) : IHandleMessages<ExportDocumentIntegrationEvent>
+{
+    public async Task Handle(ExportDocumentIntegrationEvent context)
+    {
+        if (context.Key != DocumentTemplate.InitiativeObjectivesDashboard.Name)
+        {
+            logger.LogDebug("Export document not supported by this handler");
+            return;
+        }
+
+        var document = await unitOfWork.DbContext.GeneratedDocuments.FindAsync(context.DocumentId);
+
+        if (document is null)
+        {
+            logger.LogError("Initiative objectives dashboard export event raised for a document that does not exist. ({DocumentId})", context.DocumentId);
+            return;
+        }
+
+        try
+        {
+            var request = JsonConvert.DeserializeObject<ExportInitiativeObjectivesDashboard.InitiativeObjectivesDashboardExportRequest>(context.SearchCriteria!)
+                ?? throw new Exception("Failed to deserialise export request.");
+
+            var stubUser = new UserProfile
+            {
+                UserName = "system",
+                Email = "system@system",
+                UserId = context.UserId,
+                TenantId = context.TenantId
+            };
+
+            var query = new GetInitiativeObjectivesDashboard.Query
+            {
+                CurrentUser = stubUser,
+                UserId = request.UserId,
+                TenantId = request.TenantId
+            };
+
+            var data = await new GetInitiativeObjectivesDashboard.Handler(unitOfWork).Handle(query, CancellationToken.None);
+
+            if (data is not { Succeeded: true, Data: not null })
+            {
+                throw new ApplicationException(data.ErrorMessage ?? "Failed to fetch initiative objectives dashboard data");
+            }
+
+            var rows = data.Data
+                .Where(r => string.IsNullOrWhiteSpace(request.InitiativeCode) || r.InitiativeCode == request.InitiativeCode)
+                .Where(r => !request.ShowActiveOnly || !r.IsObjectiveCompleted)
+                .ToArray();
+
+            var results = await excelService.ExportAsync(
+                rows,
+                new Dictionary<string, Func<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto, object?>>
+                {
+                    { "Participant", item => item.ParticipantName },
+                    { "Participant Id", item => item.ParticipantId },
+                    { "Assignee", item => item.OwnerDisplayName },
+                    { "Assignee Tenant", item => item.OwnerTenantName },
+                    { "Objective", item => item.ObjectiveDescription },
+                    { "Created By", item => item.InitiativeObjectiveCreatedBy },
+                    { "Initiative", item => item.InitiativeCode },
+                    { "Initiative Description", item => item.InitiativeDescription },
+                    { "Objective Status", item => item.IsObjectiveCompleted ? "Completed" : "Active" },
+                    { "Task Status", item => item.TaskSummary },
+                    { "Completed Tasks", item => item.CompletedTasks },
+                    { "Total Tasks", item => item.TotalTasks },
+                    { "Activities", item => item.ActivityCount }
+                });
+
+            var uploadRequest = new UploadRequest(document.Title!, UploadType.Document, results);
+            var result = await uploadService.UploadAsync($"MyDocuments/{context.UserId}", uploadRequest);
+
+            if (result.Succeeded)
+            {
+                document
+                    .WithStatus(DocumentStatus.Available)
+                    .SetURL(result);
+            }
+            else
+            {
+                logger.LogError("Failed to upload initiative objectives dashboard document {DocumentId}: {Errors}", context.DocumentId, string.Join(", ", result.Errors));
+                document.WithStatus(DocumentStatus.Error);
+            }
+
+            await domainEventDispatcher.DispatchEventsAsync(unitOfWork.DbContext, CancellationToken.None);
+            await unitOfWork.CommitTransactionAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error exporting initiative objectives dashboard document {DocumentId}: {ErrorMessage}", context.DocumentId, ex.Message);
+            document.WithStatus(DocumentStatus.Error);
+            await unitOfWork.CommitTransactionAsync();
+        }
+    }
+}

--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer.cs
@@ -76,9 +76,9 @@ public class DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer
                     { "Initiative", item => item.InitiativeCode },
                     { "Initiative Description", item => item.InitiativeDescription },
                     { "Objective Status", item => item.IsObjectiveCompleted ? "Completed" : "Active" },
-                    { "Task Status", item => item.TaskSummary },
                     { "Completed Tasks", item => item.CompletedTasks },
                     { "Total Tasks", item => item.TotalTasks },
+                    { "Outstanding Tasks", item => item.TotalTasks - item.CompletedTasks },
                     { "Activities", item => item.ActivityCount }
                 });
 

--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativesIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportInitiativesIntegrationEventConsumer.cs
@@ -1,0 +1,84 @@
+using Cfo.Cats.Application.Features.Documents.IntegrationEvents;
+using Cfo.Cats.Application.Features.Initiatives.DTOs;
+using Cfo.Cats.Application.Features.Initiatives.Queries;
+using Cfo.Cats.Domain.Entities.Documents;
+using Newtonsoft.Json;
+using Rebus.Handlers;
+
+namespace Cfo.Cats.Application.Features.Documents.IntegrationEventHandlers;
+
+public class DocumentExportInitiativesIntegrationEventConsumer(
+    ISqlConnectionFactory sqlConnectionFactory,
+    IUnitOfWork unitOfWork,
+    IExcelService excelService,
+    IUploadService uploadService,
+    IDomainEventDispatcher domainEventDispatcher,
+    ILogger<DocumentExportInitiativesIntegrationEventConsumer> logger) : IHandleMessages<ExportDocumentIntegrationEvent>
+{
+    public async Task Handle(ExportDocumentIntegrationEvent context)
+    {
+        if (context.Key != DocumentTemplate.Initiatives.Name)
+        {
+            logger.LogDebug("Export document not supported by this handler");
+            return;
+        }
+
+        var document = await unitOfWork.DbContext.GeneratedDocuments.FindAsync(context.DocumentId);
+
+        if (document is null)
+        {
+            logger.LogError("Export initiatives document event raised for a document that does not exist. ({DocumentId})", context.DocumentId);
+            return;
+        }
+
+        try
+        {
+            var request = JsonConvert.DeserializeObject<GetInitiatives.Query>(context.SearchCriteria!)
+                ?? throw new Exception();
+
+            // Hack: call handler directly (skips Authorization pipeline, as we're outside of the HttpContext).
+            var data = await new GetInitiatives.Handler(sqlConnectionFactory).Handle(request, CancellationToken.None);
+
+            if (!data.Succeeded || data.Data is null)
+            {
+                throw new ApplicationException("Failed to fetch initiatives data");
+            }
+
+            var results = await excelService.ExportAsync(
+                data.Data,
+                new Dictionary<string, Func<InitiativeDto, object?>>
+                {
+                    { "Code", item => item.Code },
+                    { "Description", item => item.Description },
+                    { "Contract", item => item.Contract },
+                    { "Start Date", item => item.LifetimeStart },
+                    { "End Date", item => item.LifetimeEnd }
+                });
+
+            var uploadRequest = new UploadRequest(document.Title!, UploadType.Document, results);
+
+            var result = await uploadService.UploadAsync($"MyDocuments/{context.UserId}", uploadRequest);
+
+            if (result.Succeeded)
+            {
+                document
+                    .WithStatus(DocumentStatus.Available)
+                    .SetURL(result);
+            }
+            else
+            {
+                logger.LogError("Failed to upload initiatives document {DocumentId}: {Errors}", context.DocumentId, string.Join(", ", result.Errors));
+                document.WithStatus(DocumentStatus.Error);
+            }
+
+            await domainEventDispatcher.DispatchEventsAsync(unitOfWork.DbContext, CancellationToken.None);
+            await unitOfWork.CommitTransactionAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error exporting initiatives document {DocumentId}: {ErrorMessage}", context.DocumentId, ex.Message);
+            document.WithStatus(DocumentStatus.Error);
+            await unitOfWork.CommitTransactionAsync();
+        }
+    }
+}

--- a/src/Application/Features/Initiatives/Commands/Export/ExportInitiatives.cs
+++ b/src/Application/Features/Initiatives/Commands/Export/ExportInitiatives.cs
@@ -1,0 +1,71 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Validators;
+using Cfo.Cats.Application.Features.Initiatives.Queries;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Entities.Documents;
+using Humanizer;
+using Newtonsoft.Json;
+
+namespace Cfo.Cats.Application.Features.Initiatives.Commands.Export;
+
+public static class ExportInitiatives
+{
+    [RequestAuthorize(Policy = SecurityPolicies.Initiatives)]
+    public class Command : IRequest<Result>
+    {
+        public required GetInitiatives.Query Query { get; init; }
+    }
+
+    private class Handler(
+        IUnitOfWork unitOfWork,
+        ICurrentUserService currentUser) : IRequestHandler<Command, Result>
+    {
+        public async Task<Result> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var json = JsonConvert.SerializeObject(request.Query);
+
+            var document = GeneratedDocument
+                .Create(
+                    DocumentTemplate.Initiatives,
+                    "Initiatives.xlsx",
+                    "Initiatives Export",
+                    currentUser.UserId!,
+                    currentUser.TenantId!,
+                    json);
+
+            await unitOfWork.DbContext.Documents.AddAsync(document, cancellationToken);
+
+            return Result.Success();
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        private readonly ICurrentUserService _currentUserService;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly TimeSpan _cooldown = TimeSpan.FromSeconds(30);
+
+        public Validator(IUnitOfWork unitOfWork, ICurrentUserService currentUserService)
+        {
+            _currentUserService = currentUserService;
+            _unitOfWork = unitOfWork;
+
+            RuleSet(ValidationConstants.RuleSet.MediatR, () =>
+            {
+                RuleFor(c => c)
+                    .Must(WaitBeforeRequestingDocumentAgain)
+                    .WithMessage($"You must wait {_cooldown.Humanize()} between requesting documents.");
+            });
+        }
+
+        private bool WaitBeforeRequestingDocumentAgain(Command c)
+        {
+            var cooldownPeriod = DateTime.UtcNow - _cooldown;
+
+            var hasRecentlyRequestedDocument = _unitOfWork.DbContext.GeneratedDocuments
+                .Any(d => d.CreatedBy == _currentUserService.UserId && d.Created > cooldownPeriod);
+
+            return hasRecentlyRequestedDocument is false;
+        }
+    }
+}

--- a/src/Domain/Entities/Documents/GeneratedDocument.cs
+++ b/src/Domain/Entities/Documents/GeneratedDocument.cs
@@ -75,4 +75,6 @@ public class DocumentTemplate : SmartEnum<DocumentTemplate>
     public static readonly DocumentTemplate PerformanceDashboard = new(nameof(PerformanceDashboard), 17);
     public static readonly DocumentTemplate CumulativeFigures = new(nameof(CumulativeFigures), 100);
     public static readonly DocumentTemplate OutcomeQualityDipSample = new(nameof(OutcomeQualityDipSample), 500);
+    public static readonly DocumentTemplate Initiatives = new(nameof(Initiatives), 900);
+
 }

--- a/src/Domain/Entities/Documents/GeneratedDocument.cs
+++ b/src/Domain/Entities/Documents/GeneratedDocument.cs
@@ -76,5 +76,6 @@ public class DocumentTemplate : SmartEnum<DocumentTemplate>
     public static readonly DocumentTemplate CumulativeFigures = new(nameof(CumulativeFigures), 100);
     public static readonly DocumentTemplate OutcomeQualityDipSample = new(nameof(OutcomeQualityDipSample), 500);
     public static readonly DocumentTemplate Initiatives = new(nameof(Initiatives), 900);
+    public static readonly DocumentTemplate InitiativeObjectivesDashboard = new(nameof(InitiativeObjectivesDashboard), 1300);
 
 }

--- a/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
@@ -37,6 +37,7 @@ internal class DocumentsBackgroundService(IServiceProvider provider, IConfigurat
        _activator.Handle<DocumentExportOutcomeQualityDipSampleIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportProviderFeedbackIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportPerformanceDashboardIntegrationEventConsumer>(provider);
+       _activator.Handle<DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportInitiativesIntegrationEventConsumer>(provider);
 
         _bus = Configure.With(_activator)

--- a/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
@@ -1,4 +1,3 @@
-using Amazon;
 using Cfo.Cats.Application.Features.Documents.IntegrationEventHandlers;
 using Cfo.Cats.Application.Features.Documents.IntegrationEvents;
 using Microsoft.Extensions.Configuration;
@@ -38,6 +37,7 @@ internal class DocumentsBackgroundService(IServiceProvider provider, IConfigurat
        _activator.Handle<DocumentExportOutcomeQualityDipSampleIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportProviderFeedbackIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportPerformanceDashboardIntegrationEventConsumer>(provider);
+       _activator.Handle<DocumentExportInitiativesIntegrationEventConsumer>(provider);
 
         _bus = Configure.With(_activator)
             .Transport(t => t.UseRabbitMq(configuration.GetConnectionString("rabbit"), options.Value.DocumentService)

--- a/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor
@@ -1,4 +1,3 @@
-@using ApexCharts
 @using Cfo.Cats.Application.Features.Dashboard.Queries
 
 @inherits CatsComponent<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto[]>
@@ -29,6 +28,15 @@
                                            Label="Initiative" />
                 }
                 <MudSwitch T="bool" @bind-Value="ShowActiveOnly" Color="Color.Primary" Label="Show active only" />
+                <MudLoadingButton Variant="Variant.Filled"
+                                  Size="MudBlazor.Size.Small"
+                                  Loading="@_downloading"
+                                  Disabled="@Loading"
+                                  OnClick="@OnExport"
+                                  StartIcon="@Icons.Material.Filled.Download"
+                                  Color="Color.Secondary">
+                    @ConstantString.Export
+                </MudLoadingButton>
             </div>
         </MudItem>
         <MudItem xs="12">
@@ -161,5 +169,5 @@
 }
 else
 {
-    <MudText Typo="Typo.body2" Color="Color.Secondary" Align="MudBlazor.Align.Center">No data available</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center">No data available</MudText>
 }

--- a/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/InitiativeObjectivesDashboardComponent.razor.cs
@@ -1,6 +1,8 @@
 using ApexCharts;
+using Cfo.Cats.Application.Features.Dashboard.Commands;
 using Cfo.Cats.Application.Features.Dashboard.Queries;
 using Cfo.Cats.Application.Features.Initiatives.DTOs;
+using Cfo.Cats.Infrastructure.Constants;
 
 namespace Cfo.Cats.Server.UI.Components.Dashboard;
 
@@ -18,6 +20,7 @@ public partial class InitiativeObjectivesDashboardComponent
     public bool IsDarkMode { get; set; }
 
     private InitiativeDto? _initiativeFilter;
+    private bool _downloading;
     private bool ShowActiveOnly { get; set; } = false;
 
     protected override IRequest<Result<GetInitiativeObjectivesDashboard.InitiativeObjectiveRowDto[]>> CreateQuery()
@@ -28,23 +31,23 @@ public partial class InitiativeObjectivesDashboardComponent
          TenantId = TenantId
      };
 
-    private ApexCharts.ApexChartOptions<InitiativeChartPoint> Options => new()
+    private ApexChartOptions<InitiativeChartPoint> Options => new()
     {
-        Chart = new ApexCharts.Chart
+        Chart = new Chart
         {
             Stacked = true
         },
-        PlotOptions = new ApexCharts.PlotOptions
+        PlotOptions = new PlotOptions
         {
-            Bar = new ApexCharts.PlotOptionsBar
+            Bar = new PlotOptionsBar
             {
                 Horizontal = false,
-                DataLabels = new ApexCharts.PlotOptionsBarDataLabels
+                DataLabels = new PlotOptionsBarDataLabels
                 {
-                    Total = new ApexCharts.BarTotalDataLabels
+                    Total = new BarTotalDataLabels
                     {
                         Enabled = true,
-                        Style = new ApexCharts.BarDataLabelsStyle
+                        Style = new BarDataLabelsStyle
                         {
                             FontWeight = "800",
                             Color = IsDarkMode ? "#FFFFFF" : "#000000",
@@ -69,9 +72,9 @@ public partial class InitiativeObjectivesDashboardComponent
                 RotateAlways = true
             }
         },
-        Theme = new ApexCharts.Theme
+        Theme = new Theme
         {
-            Mode = IsDarkMode ? ApexCharts.Mode.Dark : ApexCharts.Mode.Light
+            Mode = IsDarkMode ? Mode.Dark : Mode.Light
         },
         Colors = new List<string> { "#1976d2", "#5cb85c" }
     };
@@ -104,4 +107,41 @@ public partial class InitiativeObjectivesDashboardComponent
         ShowActiveOnly && Data is not null
             ? ChartData.Where(x => x.ActiveCount > 0).ToArray()
             : ChartData ?? Array.Empty<InitiativeChartPoint>();
+
+    private async Task OnExport()
+    {
+        try
+        {
+            _downloading = true;
+
+            var result = await Service.Send(new ExportInitiativeObjectivesDashboard.Command
+            {
+                Request = new ExportInitiativeObjectivesDashboard.InitiativeObjectivesDashboardExportRequest
+                {
+                    UserId = UserId,
+                    TenantId = TenantId,
+                    InitiativeCode = _initiativeFilter?.Code,
+                    ShowActiveOnly = ShowActiveOnly
+                }
+            });
+
+            if (result.Succeeded)
+            {
+                Snackbar.Add(ConstantString.ExportSuccess, Severity.Info);
+            }
+            else
+            {
+                Snackbar.Add(result.ErrorMessage, Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "An error has occurred while generating the initiative objectives dashboard export");
+            Snackbar.Add("An error has occurred while generating the initiative objectives dashboard export.", Severity.Error);
+        }
+        finally
+        {
+            _downloading = false;
+        }
+    }
 }

--- a/src/Server.UI/Components/Initiatives/InitiativesTable.razor
+++ b/src/Server.UI/Components/Initiatives/InitiativesTable.razor
@@ -18,11 +18,19 @@
             <MudText Typo="Typo.h6">Initiatives</MudText>
             <MudSpacer />
             <MudCheckBox @bind-Value="_showExpired" @bind-Value:after="RefreshAsync" Label="Show expired" Color="Color.Default" Size="Size.Small" Class="mr-2" />
+            <MudButton Variant="Variant.Filled"
+                       Size="Size.Small"
+                       Disabled="@Loading"
+                       OnClick="@OnExport"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       Color="Color.Secondary">
+                @ConstantString.Export
+            </MudButton>
             <AuthorizeView Policy="@SecurityPolicies.ManageInitiatives">
                 <MudButton Variant="Variant.Filled"
                            Size="Size.Small"
                            Disabled="@Loading"
-                           OnClick="@(() => OnAdd())"
+                           OnClick="@OnAdd"
                            StartIcon="@Icons.Material.Filled.Add"
                            Color="Color.Primary">
                     Add Initiative

--- a/src/Server.UI/Components/Initiatives/InitiativesTable.razor.cs
+++ b/src/Server.UI/Components/Initiatives/InitiativesTable.razor.cs
@@ -3,6 +3,7 @@ using Cfo.Cats.Application.Features.Initiatives.Commands.AddInitiative;
 using Cfo.Cats.Application.Features.Initiatives.Commands.AmendInitiativeLifetime;
 using Cfo.Cats.Application.Features.Initiatives.Commands.DeactivateInitiative;
 using Cfo.Cats.Application.Features.Initiatives.Commands.EditInitiative;
+using Cfo.Cats.Application.Features.Initiatives.Commands.Export;
 using Cfo.Cats.Application.Features.Initiatives.DTOs;
 using Cfo.Cats.Application.Features.Initiatives.Queries;
 using Cfo.Cats.Infrastructure.Constants;
@@ -14,10 +15,35 @@ public partial class InitiativesTable
 {
     [Inject] private IContractService ContractService { get; set; } = null!;
 
-    private bool _showExpired = false;
+    private bool _showExpired;
 
     protected override IRequest<Result<InitiativeDto[]>> CreateQuery()
         => new GetInitiatives.Query { IncludeExpired = _showExpired };
+
+    private async Task OnExport()
+    {
+        try
+        {
+            var result = await Service.Send(new ExportInitiatives.Command
+            {
+                Query = new GetInitiatives.Query { IncludeExpired = _showExpired }
+            });
+
+            if (result.Succeeded)
+            {
+                Snackbar.Add(ConstantString.ExportSuccess, Severity.Info);
+            }
+            else
+            {
+                Snackbar.Add(result.ErrorMessage, Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "An error has occurred while generating the initiatives export");
+            Snackbar.Add("An error has occurred while generating the initiatives export.", Severity.Error);
+        }
+    }
 
     private async Task OnAdd()
     {


### PR DESCRIPTION
- Add export command for initiatives using the generated document workflow
- Register initiatives as a supported document template
- Add background consumer to generate and upload initiatives Excel exports
- Add export action to the initiatives table UI
- Wire the initiatives export consumer into document message handling

## PR Type
- [ ] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [ ] Code builds locally
- [ ] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)
