### PR TITLE
Update docker image for rabbit to latest version.

### DIFF
--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -24,7 +24,7 @@ internal static class AppExtensions
     {
         var rabbit = builder.AddRabbitMQ("rabbit", port: 5672)
             // 4.3.0-management-alpine
-            .WithImageSHA256("8724c6573b43d315bcec914f16a509d0b5faf5f3b281a832b484ece0bbcbe914")
+            .WithImageSHA256("1a43764bdcf116542e7c8c794adc67c79461727da16d474e9e21483fe7f716d3")
             .WithDataVolume("cats-aspire-rabbit")
             .WithLifetime(ContainerLifetime.Persistent)
             .WithHttpEndpoint(port: 15672, targetPort: 15672);            


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [x] Code builds locally
- [ ] Tests added or updated
- [x] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [x] Not required (explain below)

---

This pull request updates the RabbitMQ container image used in the application host extension. The SHA256 hash for the RabbitMQ image is changed to pull a newer and more secure image version.

- **Dependency Update:**
  * Updated the SHA256 hash in `AddMessageBroker` to use a new RabbitMQ image (`AppExtensions.cs`).