### PR TITLE
Add pagination to case notes

### DIFF
--- a/src/Application/Features/Participants/Queries/GetParticipantNotes.cs
+++ b/src/Application/Features/Participants/Queries/GetParticipantNotes.cs
@@ -1,6 +1,7 @@
 ﻿using Cfo.Cats.Application.Common.Security;
 using Cfo.Cats.Application.Common.Validators;
 using Cfo.Cats.Application.Features.Participants.DTOs;
+using Cfo.Cats.Application.Features.Participants.Specifications;
 using Cfo.Cats.Application.SecurityConstants;
 
 namespace Cfo.Cats.Application.Features.Participants.Queries;
@@ -8,26 +9,35 @@ namespace Cfo.Cats.Application.Features.Participants.Queries;
 public static class GetParticipantNotes
 {
     [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
-    public class Query : IRequest<Result<ParticipantNoteDto[]>>
+    public class Query : ParticipantNotesFilter, IRequest<PaginatedData<ParticipantNoteDto>>
     {
-        public required string ParticipantId { get; set; }
+        public ParticipantNotesSpecification Specification => new();
     }
 
-    public class Handler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<Query, Result<ParticipantNoteDto[]>>
+    public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, PaginatedData<ParticipantNoteDto>>
     {
-        public async Task<Result<ParticipantNoteDto[]>> Handle(Query request, CancellationToken cancellationToken)
-        {
-            var query = unitOfWork.DbContext.Participants
+        public async Task<PaginatedData<ParticipantNoteDto>> Handle(Query request, CancellationToken cancellationToken) =>
+            await unitOfWork.DbContext.Participants
                 .Where(p => p.Id == request.ParticipantId)
-                .SelectMany(p => p.Notes);
-
-            var notes = await query.ProjectTo<ParticipantNoteDto>(mapper.ConfigurationProvider)
-                .ToArrayAsync(cancellationToken) ?? [];
-
-            return Result<ParticipantNoteDto[]>.Success(notes);
-        }
+                .SelectMany(p => p.Notes)
+                .OrderByDescending(n => n.Created)
+                .ProjectToPaginatedDataAsync<Domain.ValueObjects.Note, ParticipantNoteDto>(
+                    request.Specification,
+                    request.PageNumber,
+                    request.PageSize,
+                    n => new ParticipantNoteDto
+                    {
+                        Id = n.CreatedBy ?? string.Empty,
+                        Message = n.Message,
+                        CallReference = n.CallReference,
+                        ParticipantId = request.ParticipantId,
+                        CreatedBy = n.CreatedByUser!.DisplayName!,
+                        CreatedByEmail = n.CreatedByUser!.Email!,
+                        Created = n.Created ?? DateTime.UtcNow
+                    },
+                    cancellationToken);
     }
-  
+    
     public class Validator : AbstractValidator<Query>
     {
         private readonly IUnitOfWork _unitOfWork;

--- a/src/Application/Features/Participants/Specifications/ParticipantNotesFilter.cs
+++ b/src/Application/Features/Participants/Specifications/ParticipantNotesFilter.cs
@@ -1,0 +1,6 @@
+namespace Cfo.Cats.Application.Features.Participants.Specifications;
+
+public class ParticipantNotesFilter : PaginationFilter
+{
+    public required string ParticipantId { get; init; }
+}

--- a/src/Application/Features/Participants/Specifications/ParticipantNotesSpecification.cs
+++ b/src/Application/Features/Participants/Specifications/ParticipantNotesSpecification.cs
@@ -1,0 +1,11 @@
+using Cfo.Cats.Domain.ValueObjects;
+
+namespace Cfo.Cats.Application.Features.Participants.Specifications;
+
+public class ParticipantNotesSpecification : Specification<Note>
+{
+    public ParticipantNotesSpecification() =>
+        Query
+            .AsNoTracking()
+            .OrderByDescending(n => n.Created);
+}

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
@@ -1,4 +1,4 @@
-﻿@using Humanizer;Does
+@using Humanizer;
 
 @inherits CatsComponentBase
 

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
@@ -1,19 +1,30 @@
-﻿@using Cfo.Cats.Application.Features.Participants.Commands
-@using Cfo.Cats.Application.Features.Participants.DTOs
-@using Cfo.Cats.Application.Features.Participants.Queries
-@using Humanizer;
+﻿@using Humanizer;
 
 @inherits CatsComponentBase
 
 @if(_notes is not null)
 {
+    @if (_notes.Any())
+    {
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-2">
+            <MudText Typo="Typo.body1">
+                @TotalNotes notes
+            </MudText>
+            <MudPagination Count="@TotalPages"
+                           ShowFirstButton="true"
+                           ShowLastButton="true"
+                           SelectedChanged="OnPaginationChanged">
+            </MudPagination>
+        </MudStack>
+    }
+
     <MudTimeline TimelinePosition="TimelinePosition.Start" Modifiers="true">
         @if (AllowAddNote)
         {
             <MudTimelineItem TimelineAlign="TimelineAlign.Start">
                 <div class="d-flex gap-4 align-center mud-list-subheader">
                     <MudTooltip Text="New">
-                        <MudIconButton Icon="@Icons.Material.Filled.Add" Variant="Variant.Filled" OnClick="OnAddNote" Class="rounded-circle"></MudIconButton>
+                        <MudIconButton Icon="@Icons.Material.Filled.Add" Variant="Variant.Filled" OnClick="@OnAddNote" Class="rounded-circle"></MudIconButton>
                     </MudTooltip>
                     <MudText>New note</MudText>
                 </div>
@@ -35,7 +46,7 @@
             }
         }
 
-        @foreach (var note in _notes.OrderByDescending(x => x.Created))
+        @foreach (var note in PagedNotes)
         {
             <MudTimelineItem Size="Size.Medium" Color="Color.Info" Elevation="25">
                 <MudCard>

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor
@@ -1,14 +1,15 @@
-﻿@using Humanizer;
+﻿@using Humanizer;Does
 
 @inherits CatsComponentBase
 
-@if(_notes is not null)
+@if(_paginatedNotes is not null)
 {
-    @if (_notes.Any())
+    @if (_paginatedNotes.TotalItems > 0)
     {
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-2">
             <MudText Typo="Typo.body1">
-                @TotalNotes notes
+                @TotalNotes @(TotalNotes == 1 ? "note" : "notes")
+
             </MudText>
             <MudPagination Count="@TotalPages"
                            ShowFirstButton="true"
@@ -32,7 +33,7 @@
         }
         else
         {
-            if (!_notes.Any())
+            if (_paginatedNotes.TotalItems == 0)
             {
                 <MudTimelineItem Size="Size.Medium" Color="Color.Info" Elevation="25">
                     <MudCard>

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor.cs
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor.cs
@@ -7,7 +7,7 @@ namespace Cfo.Cats.Server.UI.Pages.Participants.Components;
 
 public partial class CaseNotes
 {
-    private ParticipantNoteDto[]? _notes;
+    private PaginatedData<ParticipantNoteDto>? _paginatedNotes;
     private const int PageSize = 5;
     private int _pageNumber = 1;
 
@@ -33,36 +33,24 @@ public partial class CaseNotes
         }
     }
 
-    private IEnumerable<ParticipantNoteDto> OrderedNotes =>
-        _notes?
-            .OrderByDescending(x => x.Created)!;
+    private IEnumerable<ParticipantNoteDto> PagedNotes => _paginatedNotes?.Items ?? [];
 
-    private IEnumerable<ParticipantNoteDto> PagedNotes =>
-        OrderedNotes
-            .Skip((_pageNumber - 1) * PageSize)
-            .Take(PageSize);
+    private int TotalNotes => _paginatedNotes?.TotalItems ?? 0;
 
-    private int TotalNotes => _notes?.Length ?? 0;
+    private int TotalPages => _paginatedNotes?.TotalPages ?? 0;
 
-    private int TotalPages => Math.Max(1, (int)Math.Ceiling(TotalNotes / (double)PageSize));
-
-    private async Task OnRefresh()
-    {
-        _notes = await GetNewMediator().Send(new GetParticipantNotes.Query()
+    private async Task OnRefresh() =>
+        _paginatedNotes = await GetNewMediator().Send(new GetParticipantNotes.Query()
         {
-            ParticipantId = ParticipantId
+            ParticipantId = ParticipantId,
+            PageNumber = _pageNumber,
+            PageSize = PageSize
         });
 
-        if (_pageNumber > TotalPages)
-        {
-            _pageNumber = TotalPages;
-        }
-    }
-
-    private Task OnPaginationChanged(int page)
+    private async Task OnPaginationChanged(int page)
     {
         _pageNumber = page;
-        return Task.CompletedTask;
+        await OnRefresh();
     }
 
     private async Task OnAddNote()

--- a/src/Server.UI/Pages/Participants/Components/CaseNotes.razor.cs
+++ b/src/Server.UI/Pages/Participants/Components/CaseNotes.razor.cs
@@ -7,13 +7,15 @@ namespace Cfo.Cats.Server.UI.Pages.Participants.Components;
 
 public partial class CaseNotes
 {
-    private ParticipantNoteDto[]? _notes = null;
+    private ParticipantNoteDto[]? _notes;
+    private const int PageSize = 5;
+    private int _pageNumber = 1;
 
     [Parameter, EditorRequired]
-    public string ParticipantId { get; set; } = default!;
+    public string ParticipantId { get; set; } = null!;
 
     [Parameter]
-    public bool AllowAddNote { get; set; } = false;
+    public bool AllowAddNote { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -31,12 +33,39 @@ public partial class CaseNotes
         }
     }
 
-    private async Task OnRefresh() => _notes = await GetNewMediator().Send(new GetParticipantNotes.Query()
-    {
-        ParticipantId = ParticipantId
-    });
+    private IEnumerable<ParticipantNoteDto> OrderedNotes =>
+        _notes?
+            .OrderByDescending(x => x.Created)!;
 
-    public async Task OnAddNote()
+    private IEnumerable<ParticipantNoteDto> PagedNotes =>
+        OrderedNotes
+            .Skip((_pageNumber - 1) * PageSize)
+            .Take(PageSize);
+
+    private int TotalNotes => _notes?.Length ?? 0;
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling(TotalNotes / (double)PageSize));
+
+    private async Task OnRefresh()
+    {
+        _notes = await GetNewMediator().Send(new GetParticipantNotes.Query()
+        {
+            ParticipantId = ParticipantId
+        });
+
+        if (_pageNumber > TotalPages)
+        {
+            _pageNumber = TotalPages;
+        }
+    }
+
+    private Task OnPaginationChanged(int page)
+    {
+        _pageNumber = page;
+        return Task.CompletedTask;
+    }
+
+    private async Task OnAddNote()
     {
         // Show Dialog
         var parameters = new DialogParameters<AddNoteDialog>
@@ -53,13 +82,8 @@ public partial class CaseNotes
 
         if (!state!.Canceled)
         {
+            _pageNumber = 1;
             await OnRefresh();
         }
-    }
-
-    public async Task OnExpandNote(string message)
-    {
-        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small, FullWidth = true };
-        await DialogService.ShowMessageBoxAsync("Note", message, options: options);
     }
 }


### PR DESCRIPTION
Paginate participant case notes in the timeline view, showing five notes per page with first and last page controls.

Keep notes ordered newest first and reset to the first page when a new note is added.

## PR Type
- [ ] Feature
- [ ] Hotfix
- [ ] Release
- [ ] Documentation

---

## Checklist
- [ ] Code builds locally
- [ ] Tests added or updated
- [ ] CI is green
- [ ] Peer review completed

---

### UAT
- [ ] Required → completed
- [ ] Not required (explain below)
