### PR TITLE
Standardize .NET SDK versioning in CI workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Dotnet Cake Script
         run: dotnet cake.cs --target Publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Cake Script
         run: dotnet cake.cs --Target Test

--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Install sqlpackage
         run: dotnet tool install --global microsoft.sqlpackage

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 ﻿{
   "sdk": {
-    "version": "10.0.0",
-    "rollForward": "latestMajor",
+    "version": "10.0.300",
+    "rollForward": "disable",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Update `global.json` to specify .NET SDK version `10.0.300` and disable roll-forward. Configure all GitHub Actions workflows to use `global.json` for .NET SDK setup, ensuring consistent and precise SDK usage across development and CI/CD environments.