### PR TITLE
View recently assigned cases

### DIFF
--- a/src/Application/Features/Participants/DTOs/ParticipantPaginationDto.cs
+++ b/src/Application/Features/Participants/DTOs/ParticipantPaginationDto.cs
@@ -47,4 +47,7 @@ public class ParticipantPaginationDto
     
     public DateOnly? ConsentGranted { get; set; }
     
+    [Description("Assigned On")]
+    public DateTime? AssignedOn { get; set; }
+    
 }

--- a/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
+++ b/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
@@ -37,8 +37,9 @@ public static class ParticipantsWithPagination
         public LabelId? Label { get; set; }
         public string? OwnerId { get; set; }
         public string? TenantId { get; set; }
-        public DateTime? RiskDue { get; set; }
-    }
+        public DateTime? RiskDue { get; set; }        
+        public RecentlyAssignedFilter RecentlyAssigned { get; set; } = RecentlyAssignedFilter.All;    
+        }
 
     public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<PaginatedData<ParticipantPaginationDto>>>
     {
@@ -130,58 +131,141 @@ public static class ParticipantsWithPagination
             {
                 query = query.Where(p => p.RiskDue <= request.RiskDue);
             }
+
+            // Apply recently assigned filter
+            DateTime? recentlyAssignedCutoff = request.RecentlyAssigned switch
+            {
+                RecentlyAssignedFilter.Last10Days => DateTime.UtcNow.AddDays(-10),
+                RecentlyAssignedFilter.Last30Days => DateTime.UtcNow.AddDays(-30),
+                _ => null
+            };
+
+            if (recentlyAssignedCutoff.HasValue)
+            {
+                // Filter participants who have ownership history within the date range and are currently assigned
+                var participantIdsWithRecentOwnership = context.ParticipantOwnershipHistories
+                    .Where(oh => oh.OwnerId == request.CurrentUser!.UserId
+                                 && oh.From >= recentlyAssignedCutoff.Value
+                                 && oh.To == null)
+                    .Select(oh => oh.ParticipantId)
+                    .Distinct();
+
+                query = query.Where(p => participantIdsWithRecentOwnership.Contains(p.Id));
+            }
     
             var count = await query.AsNoTracking().CountAsync(cancellationToken);
 
-            var transformedQuery =
-                from p in query
-                select new ParticipantPaginationDto()
-                {
-                    EnrolmentStatus = p.EnrolmentStatus!,
-                    Owner = p.Owner!.DisplayName!,
-                    ConsentStatus = p.ConsentStatus!,
-                    CurrentLocation = new LocationDto
-                    {
-                        Id = p.CurrentLocation.Id,
-                        Name = p.CurrentLocation.Name,
-                        GenderProvision = p.CurrentLocation.GenderProvision,
-                        LocationType = p.CurrentLocation.LocationType,
-                        ContractName = p.CurrentLocation.Contract!.Description
-                    },
-                    Id = p.Id,
-                    EnrolmentLocation = p.EnrolmentLocation == null
-                        ? null
-                        : new LocationDto
-                        {
-                            Name = p.EnrolmentLocation.Name,
-                            GenderProvision = p.EnrolmentLocation.GenderProvision,
-                            LocationType = p.EnrolmentLocation.LocationType,
-                            Id = p.EnrolmentLocation.Id,
-                            ContractName = p.EnrolmentLocation.Contract!.Description
-                        },
-                    FirstName = p.FirstName,
-                    LastName = p.LastName,
-                    RiskDue = p.RiskDue,
-                    RiskDueReason = p.RiskDueReason!,
-                    Tenant = p.Owner!.TenantName!,
-                    Labels = (
-                            from pl in context.ParticipantLabels
-                            where EF.Property<string>(pl, "_participantId") == p.Id
-                                && pl.Lifetime.EndDate > DateTime.UtcNow
-                            orderby pl.Lifetime.StartDate descending
-                            select new LabelDto
-                            {
-                                Name = pl.Label.Name,
-                                Description = pl.Label.Description,
-                                Scope = pl.Label.Scope,
-                                Contract = pl.Label.ContractId!,
-                                Id = pl.Label.Id.Value,
-                                AppIcon = pl.Label.AppIcon,
-                                Colour = pl.Label.Colour,
-                                Variant = pl.Label.Variant
-                            }).ToArray(),
-                    ConsentGranted = p.DateOfFirstConsent
-                };
+            // Get the latest ownership assignment date for each participant if recently assigned filter is active
+            var transformedQuery = recentlyAssignedCutoff.HasValue
+                ? from p in query
+                  join oh in (
+                      from h in context.ParticipantOwnershipHistories
+                      where h.OwnerId == request.CurrentUser!.UserId
+                            && h.To == null
+                      group h by h.ParticipantId into g
+                      select new
+                      {
+                          ParticipantId = g.Key,
+                          MostRecentFrom = g.Max(x => x.From)
+                      }
+                  ) on p.Id equals oh.ParticipantId into ownershipGroup
+                  from ownership in ownershipGroup.DefaultIfEmpty()
+                  select new ParticipantPaginationDto()
+                  {
+                      AssignedOn = ownership != null ? ownership.MostRecentFrom : (DateTime?)null,
+                      EnrolmentStatus = p.EnrolmentStatus!,
+                      Owner = p.Owner!.DisplayName!,
+                      ConsentStatus = p.ConsentStatus!,
+                      CurrentLocation = new LocationDto
+                      {
+                          Id = p.CurrentLocation.Id,
+                          Name = p.CurrentLocation.Name,
+                          GenderProvision = p.CurrentLocation.GenderProvision,
+                          LocationType = p.CurrentLocation.LocationType,
+                          ContractName = p.CurrentLocation.Contract!.Description
+                      },
+                      Id = p.Id,
+                      EnrolmentLocation = p.EnrolmentLocation == null
+                          ? null
+                          : new LocationDto
+                          {
+                              Name = p.EnrolmentLocation.Name,
+                              GenderProvision = p.EnrolmentLocation.GenderProvision,
+                              LocationType = p.EnrolmentLocation.LocationType,
+                              Id = p.EnrolmentLocation.Id,
+                              ContractName = p.EnrolmentLocation.Contract!.Description
+                          },
+                      FirstName = p.FirstName,
+                      LastName = p.LastName,
+                      RiskDue = p.RiskDue,
+                      RiskDueReason = p.RiskDueReason!,
+                      Tenant = p.Owner!.TenantName!,
+                      Labels = (
+                              from pl in context.ParticipantLabels
+                              where EF.Property<string>(pl, "_participantId") == p.Id
+                                  && pl.Lifetime.EndDate > DateTime.UtcNow
+                              orderby pl.Lifetime.StartDate descending
+                              select new LabelDto
+                              {
+                                  Name = pl.Label.Name,
+                                  Description = pl.Label.Description,
+                                  Scope = pl.Label.Scope,
+                                  Contract = pl.Label.ContractId!,
+                                  Id = pl.Label.Id.Value,
+                                  AppIcon = pl.Label.AppIcon,
+                                  Colour = pl.Label.Colour,
+                                  Variant = pl.Label.Variant
+                              }).ToArray(),
+                      ConsentGranted = p.DateOfFirstConsent
+                  }
+                : from p in query
+                  select new ParticipantPaginationDto()
+                  {
+                      EnrolmentStatus = p.EnrolmentStatus!,
+                      Owner = p.Owner!.DisplayName!,
+                      ConsentStatus = p.ConsentStatus!,
+                      CurrentLocation = new LocationDto
+                      {
+                          Id = p.CurrentLocation.Id,
+                          Name = p.CurrentLocation.Name,
+                          GenderProvision = p.CurrentLocation.GenderProvision,
+                          LocationType = p.CurrentLocation.LocationType,
+                          ContractName = p.CurrentLocation.Contract!.Description
+                      },
+                      Id = p.Id,
+                      EnrolmentLocation = p.EnrolmentLocation == null
+                          ? null
+                          : new LocationDto
+                          {
+                              Name = p.EnrolmentLocation.Name,
+                              GenderProvision = p.EnrolmentLocation.GenderProvision,
+                              LocationType = p.EnrolmentLocation.LocationType,
+                              Id = p.EnrolmentLocation.Id,
+                              ContractName = p.EnrolmentLocation.Contract!.Description
+                          },
+                      FirstName = p.FirstName,
+                      LastName = p.LastName,
+                      RiskDue = p.RiskDue,
+                      RiskDueReason = p.RiskDueReason!,
+                      Tenant = p.Owner!.TenantName!,
+                      Labels = (
+                              from pl in context.ParticipantLabels
+                              where EF.Property<string>(pl, "_participantId") == p.Id
+                                  && pl.Lifetime.EndDate > DateTime.UtcNow
+                              orderby pl.Lifetime.StartDate descending
+                              select new LabelDto
+                              {
+                                  Name = pl.Label.Name,
+                                  Description = pl.Label.Description,
+                                  Scope = pl.Label.Scope,
+                                  Contract = pl.Label.ContractId!,
+                                  Id = pl.Label.Id.Value,
+                                  AppIcon = pl.Label.AppIcon,
+                                  Colour = pl.Label.Colour,
+                                  Variant = pl.Label.Variant
+                              }).ToArray(),
+                      ConsentGranted = p.DateOfFirstConsent
+                  };
 
             var sortColumn = request.OrderBy.Trim().ToLowerInvariant() switch
             {
@@ -195,6 +279,7 @@ public static class ParticipantsWithPagination
                 "tenant" => "Tenant",
                 "riskdue" => "RiskDue",
                 "lastname" => "LastName",
+                "assignedon" => "AssignedOn",
                 _ => "Id"
             };
 

--- a/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
+++ b/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
@@ -135,8 +135,8 @@ public static class ParticipantsWithPagination
             // Apply recently assigned filter
             DateTime? recentlyAssignedCutoff = request.RecentlyAssigned switch
             {
-                RecentlyAssignedFilter.Last10Days => DateTime.UtcNow.AddDays(-10),
-                RecentlyAssignedFilter.Last30Days => DateTime.UtcNow.AddDays(-30),
+                RecentlyAssignedFilter.Last10Days => DateTime.UtcNow.Date.AddDays(-10),
+                RecentlyAssignedFilter.Last30Days => DateTime.UtcNow.Date.AddDays(-30),
                 _ => null
             };
 

--- a/src/Application/Features/Participants/Specifications/RecentlyAssignedFilter.cs
+++ b/src/Application/Features/Participants/Specifications/RecentlyAssignedFilter.cs
@@ -1,0 +1,14 @@
+namespace Cfo.Cats.Application.Features.Participants.Specifications;
+
+public enum RecentlyAssignedFilter
+{
+    [Description("All")]
+    All,
+    
+    [Description("Last 10 Days")]
+    Last10Days,
+    
+    [Description("Last 30 Days")]
+    Last30Days,
+
+}

--- a/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
@@ -43,7 +43,7 @@ public record ParticipantsSessionData
     public required LabelId? LabelId { get; init; }
     public required string? OwnerId { get; init; } 
     public required DateTime? RiskDue { get; init; } 
-    public required RecentlyAssignedFilter RecentlyAssigned { get; init; }
+    public RecentlyAssignedFilter RecentlyAssigned { get; init; } = RecentlyAssignedFilter.All;
 
     public bool Tabular {get; init; }
     

--- a/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
@@ -29,6 +29,7 @@ public record ParticipantsSessionData
             LabelId = query.Label,
             OwnerId = query.OwnerId,
             RiskDue = query.RiskDue,
+            RecentlyAssigned = query.RecentlyAssigned,
             Tabular = tabular
         };
 
@@ -42,6 +43,7 @@ public record ParticipantsSessionData
     public required LabelId? LabelId { get; init; }
     public required string? OwnerId { get; init; } 
     public required DateTime? RiskDue { get; init; } 
+    public required RecentlyAssignedFilter RecentlyAssigned { get; init; }
 
     public bool Tabular {get; init; }
     

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor
@@ -145,6 +145,12 @@
                 }
             </MudMenu>
 
+            <MudMenu Size="Size.Small" Label="@Query.RecentlyAssigned.GetDescription()" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                <MudMenuItem Label="All" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.All))" />
+                <MudMenuItem Label="Last 10 Days" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last10Days))" />
+                <MudMenuItem Label="Last 30 Days" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last30Days))" />
+            </MudMenu>
+
             <MudMenu Size="Size.Small" Label="Sort By" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
                 <MudMenuItem Label="Id" OnClick="@(() => SortBy("Id"))"/>
                 <MudMenuItem Label="First Name" OnClick="@(() => SortBy("FirstName"))"/>
@@ -152,6 +158,10 @@
                 <MudMenuItem Label="Assignee" OnClick="@(() => SortBy("Owner"))"/>
                 <MudMenuItem Label="Tenant" OnClick="@(() => SortBy("Tenant"))"/>
                 <MudMenuItem Label="Risk Due" OnClick="@(() => SortBy("RiskDue"))"/>
+                @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                {
+                    <MudMenuItem Label="Assigned On" OnClick="@(() => SortBy("AssignedOn"))"/>
+                }
                 <MudMenuItem Label="Current Location" OnClick="@(() => SortBy("CurrentLocation"))"/>
                 <MudMenuItem Label="Enrolment Location" OnClick="@(() => SortBy("EnrolmentLocation"))"/>
                 <MudMenuItem Label="Enrolment Status" OnClick="@(() => SortBy("EnrolmentStatus"))"/>
@@ -180,6 +190,10 @@
                     <MudTh>Location</MudTh>
                     <MudTh>Enrolled At</MudTh>
                     <MudTh>Assignee</MudTh>
+                    @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                    {
+                        <MudTh>Assigned On</MudTh>
+                    }
                     <MudTh>Risk Due</MudTh>
                 </HeaderContent>
                 <RowTemplate>
@@ -198,6 +212,10 @@
                     <MudTd>@context.CurrentLocation.Name</MudTd>
                     <MudTd>@context.EnrolmentLocation?.Name</MudTd>
                     <MudTd>@context.Owner</MudTd>
+                    @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                    {
+                        <MudTd>@context.AssignedOn?.ToShortDateString()</MudTd>
+                    }
                     <MudTd>
                         @context.RiskDue.ToShortDateOrEmptyString()
                     </MudTd>
@@ -242,7 +260,10 @@
                                     }
                                 <MudSpacer />
                                 <MudText Typo="Typo.body2">
-                                    Assigned to @item.Owner (@item.Tenant)
+                                    Assigned to @item.Owner (@item.Tenant)@if (Query.RecentlyAssigned != RecentlyAssignedFilter.All && item.AssignedOn.HasValue)
+                                    {
+                                        @($" on {item.AssignedOn.Value.ToShortDateString()}")
+                                    }
                                 </MudText>
                             </MudStack>
                             <MudStack Row="true" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center">

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor
@@ -26,9 +26,12 @@
     <MudStack>
         <!-- Header/Filter row -->
         <MudStack Row="true" Justify="Justify.FlexEnd">
-            <MudMenu Label="Filters" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+            <MudMenu Label="@($"Filters: {GetCurrentFilterLabel()}")" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                <MudMenuItem OnClick="@(() => ClearQuickFilter())">All</MudMenuItem>
                 <MudMenuItem OnClick="@(() => ApplyMyParticipantsFilter())">My Participants</MudMenuItem>
                 <MudMenuItem OnClick="@(() => ApplyOverdueRiskFilter())">Overdue risk</MudMenuItem>
+                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last10Days))">Assigned (Last 10 Days)</MudMenuItem>
+                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last30Days))">Assigned (Last 30 Days)</MudMenuItem>            
             </MudMenu>
             <MudTextField T="string" Value="@Query.Keyword" Placeholder="@ConstantString.Search"
                           ValueChanged="@(OnSearch)" Clearable="true" ShrinkLabel="true"
@@ -143,12 +146,6 @@
                 {
                     <MudMenuItem Label="@l.Name" Icon="@l.AppIcon.AsMudIcon()" IconColor="@l.Colour.AsMudColour()" OnClick="@(() => LabelsValueChanged(l))"></MudMenuItem>
                 }
-            </MudMenu>
-
-            <MudMenu Size="Size.Small" Label="@Query.RecentlyAssigned.GetDescription()" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
-                <MudMenuItem Label="All" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.All))" />
-                <MudMenuItem Label="Last 10 Days" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last10Days))" />
-                <MudMenuItem Label="Last 30 Days" OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last30Days))" />
             </MudMenu>
 
             <MudMenu Size="Size.Small" Label="Sort By" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
@@ -26,6 +26,15 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Cfo.Cats.Server.UI.Pages.Participants;
 
+public enum QuickFilter
+{
+    All,
+    MyParticipants,
+    OverdueRisk,
+    Last10Days,
+    Last30Days
+}
+
 public partial class ParticipantsV2
 {
 
@@ -64,6 +73,7 @@ public partial class ParticipantsV2
     private bool _downloading = false;
     private bool _canReassign;
     private readonly HashSet<string> _selectedParticipantIds = [];
+    private QuickFilter _currentFilter = QuickFilter.All;
 
     private ParticipantPaginationDto[] _data = [];
 
@@ -152,6 +162,14 @@ public partial class ParticipantsV2
     {
         Query.RecentlyAssigned = filter;
         
+        // Update the current filter tracking
+        _currentFilter = filter switch
+        {
+            RecentlyAssignedFilter.Last10Days => QuickFilter.Last10Days,
+            RecentlyAssignedFilter.Last30Days => QuickFilter.Last30Days,
+            _ => QuickFilter.All
+        };
+        
         // If switching to "All" and currently sorted by AssignedOn, reset to default sort
         if (filter == RecentlyAssignedFilter.All && Query.OrderBy.Equals("AssignedOn", StringComparison.OrdinalIgnoreCase))
         {
@@ -183,6 +201,7 @@ public partial class ParticipantsV2
     private async Task ClearSearch()
     {
         ResetQuery();
+        _currentFilter = QuickFilter.All;
         await OnRefresh();
     }
 
@@ -331,6 +350,7 @@ public partial class ParticipantsV2
     private async Task ApplyMyParticipantsFilter()
     {
         ResetQuery();
+        _currentFilter = QuickFilter.MyParticipants;
         Query.OwnerId = UserProfile.UserId;
         await OnRefresh();
     }
@@ -338,9 +358,17 @@ public partial class ParticipantsV2
     private async Task ApplyOverdueRiskFilter()
     {
         ResetQuery();
+        _currentFilter = QuickFilter.OverdueRisk;
         Query.RiskDue = DateTime.UtcNow.Date;
         Query.SortDirection = SortDirection.Ascending.ToString();
         Query.OrderBy = "RiskDue";
+        await OnRefresh();
+    }
+
+    private async Task ClearQuickFilter()
+    {
+        ResetQuery();
+        _currentFilter = QuickFilter.All;
         await OnRefresh();
     }
 
@@ -355,9 +383,21 @@ public partial class ParticipantsV2
         Query.PageNumber = 1;
         Query.Label = null;
         Query.OwnerId = null;
+        Query.RiskDue = null;
         Query.RecentlyAssigned = RecentlyAssignedFilter.All;
+        Query.JustMyCases = false;
         Tabular = false;
     }
+
+    private string GetCurrentFilterLabel()
+        => _currentFilter switch
+        {
+            QuickFilter.MyParticipants => "My Participants",
+            QuickFilter.OverdueRisk => "Overdue Risk",
+            QuickFilter.Last10Days => "Assigned (Last 10 Days)",
+            QuickFilter.Last30Days => "Assigned (Last 30 Days)",
+            _ => "All"
+        };
     
     private void OnEnrol() => Navigation.NavigateTo("/pages/candidates/search");
 

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
@@ -135,6 +135,16 @@ public partial class ParticipantsV2
             Query.RiskDue = sd.RiskDue;
             Query.RecentlyAssigned = sd.RecentlyAssigned;
             Tabular = sd.Tabular;
+            
+            // Sync _currentFilter based on restored state
+            _currentFilter = sd.RecentlyAssigned switch
+            {
+                RecentlyAssignedFilter.Last10Days => QuickFilter.Last10Days,
+                RecentlyAssignedFilter.Last30Days => QuickFilter.Last30Days,
+                _ when sd.RiskDue.HasValue => QuickFilter.OverdueRisk,
+                _ when !string.IsNullOrEmpty(sd.OwnerId) => QuickFilter.MyParticipants,
+                _ => QuickFilter.All
+            };
         }
 
         await OnRefresh();
@@ -160,6 +170,9 @@ public partial class ParticipantsV2
 
     private async Task RecentlyAssignedFilterChanged(RecentlyAssignedFilter filter)
     {
+        // Reset query like other quick filters to avoid unintended filter combinations
+        ResetQuery();
+        
         Query.RecentlyAssigned = filter;
         
         // Update the current filter tracking
@@ -169,13 +182,6 @@ public partial class ParticipantsV2
             RecentlyAssignedFilter.Last30Days => QuickFilter.Last30Days,
             _ => QuickFilter.All
         };
-        
-        // If switching to "All" and currently sorted by AssignedOn, reset to default sort
-        if (filter == RecentlyAssignedFilter.All && Query.OrderBy.Equals("AssignedOn", StringComparison.OrdinalIgnoreCase))
-        {
-            Query.OrderBy = "Id";
-            Query.SortDirection = SortDirection.Ascending.ToString();
-        }
         
         await OnRefresh();
     }

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
@@ -123,6 +123,7 @@ public partial class ParticipantsV2
             Query.OwnerId = sd.OwnerId;
             Query.TenantId = sd.TenantId;
             Query.RiskDue = sd.RiskDue;
+            Query.RecentlyAssigned = sd.RecentlyAssigned;
             Tabular = sd.Tabular;
         }
 
@@ -144,6 +145,20 @@ public partial class ParticipantsV2
     private async Task LabelsValueChanged(LabelDto? labelDto)
     {
         Query.Label = labelDto is not null ? new LabelId(labelDto.Id) : null;
+        await OnRefresh();
+    }
+
+    private async Task RecentlyAssignedFilterChanged(RecentlyAssignedFilter filter)
+    {
+        Query.RecentlyAssigned = filter;
+        
+        // If switching to "All" and currently sorted by AssignedOn, reset to default sort
+        if (filter == RecentlyAssignedFilter.All && Query.OrderBy.Equals("AssignedOn", StringComparison.OrdinalIgnoreCase))
+        {
+            Query.OrderBy = "Id";
+            Query.SortDirection = SortDirection.Ascending.ToString();
+        }
+        
         await OnRefresh();
     }
 
@@ -340,6 +355,7 @@ public partial class ParticipantsV2
         Query.PageNumber = 1;
         Query.Label = null;
         Query.OwnerId = null;
+        Query.RecentlyAssigned = RecentlyAssignedFilter.All;
         Tabular = false;
     }
     


### PR DESCRIPTION
## 🔗 Related Work
- Closes: # https://dsdmoj.atlassian.net/browse/CFODEV-1170
- Related: #

---

## 📌 Summary
> Displays filter options to show recently assigned cases

---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?
Allows user to view cases recently assigned to them 
---

## 🧠 Approach
The query to join with OwnershipHistory is only executed when the 'Assigned (Last 10 days)' or 'Assigned (Last 30 days)' is selected

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1. log in as different users view the cases assigned them recently
2. It should only display the cases which are currently assigned to the logged in user
3. Filter should display the selected option

Expected result:
> What should happen if everything is correct?
Should display cases assigned to the logged in user in last 10 or 30 days, depending on the selected option
---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.
<img width="1521" height="441" alt="image" src="https://github.com/user-attachments/assets/ba0abf8f-d807-4c96-bc3b-839f25f34578" />

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.

---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"
This pull request introduces a "Recently Assigned" filter and display to the Participants list, allowing users to filter participants based on recent assignment (last 10 or 30 days), sort and display the assignment date, and improves filter tracking and UI feedback. The changes span backend filtering logic, data transfer objects, and frontend UI/UX.

**Backend: Filtering and Data Model Enhancements**
- Added a `RecentlyAssignedFilter` enum and filter logic to query participants assigned to the current user within the last 10 or 30 days, including calculation of the most recent assignment date and exposing it as `AssignedOn` in the `ParticipantPaginationDto`. [[1]](diffhunk://#diff-9eaffff3f56992ba95325b696654a2bf3df028513664a24c906720d911c1ceebR1-R14) [[2]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR41) [[3]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR135-R221) [[4]](diffhunk://#diff-462814561075d1b1b7ed15625e5e574445aa84734e3db58ea23977fcef9f8577R50-R52)
- Enabled sorting by the new `AssignedOn` field when the recently assigned filter is active.

**Frontend: UI and Filter State**
- Updated the participants page to include new quick filters for "Assigned (Last 10 Days)" and "Assigned (Last 30 Days)" in the filter menu, and display the current filter in the menu label. [[1]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L29-R34) [[2]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR29-R37) [[3]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR76) [[4]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR353-R374) [[5]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR386-R401)
- Conditionally displays the "Assigned On" column and data in the table and participant cards when the recently assigned filter is active. [[1]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R158-R161) [[2]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R190-R193) [[3]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R212-R215) [[4]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L245-R263)
- Added logic to synchronize filter state between session, query, and UI, including clearing/resetting filters and updating the filter label. [[1]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69R32) [[2]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69R46) [[3]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR136) [[4]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR161-R182) [[5]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR204)

**Summary of most important changes:**

**Backend filtering and data model:**
- Added `RecentlyAssignedFilter` enum and logic to filter participants by recent assignment (last 10 or 30 days) in the backend query, and expose the most recent assignment date as `AssignedOn` in `ParticipantPaginationDto`. [[1]](diffhunk://#diff-9eaffff3f56992ba95325b696654a2bf3df028513664a24c906720d911c1ceebR1-R14) [[2]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR41) [[3]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR135-R221) [[4]](diffhunk://#diff-462814561075d1b1b7ed15625e5e574445aa84734e3db58ea23977fcef9f8577R50-R52)
- Enabled sorting by the `AssignedOn` field when the recently assigned filter is active.

**Frontend UI/UX:**
- Added new quick filters for "Assigned (Last 10 Days)" and "Assigned (Last 30 Days)" to the filter menu, and display the current filter label in the UI. [[1]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L29-R34) [[2]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR353-R374) [[3]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR386-R401)
- Conditionally render the "Assigned On" column in the participants table and participant cards when the filter is active, displaying the assignment date. [[1]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R158-R161) [[2]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R190-R193) [[3]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256R212-R215) [[4]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L245-R263)
- Updated session storage and filter state management to support the new filter, including reset/clear logic and state synchronization between backend and frontend. [[1]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69R32) [[2]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69R46) [[3]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR136) [[4]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR161-R182) [[5]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cR204)