### PR TITLE
Update the SHA to use the version of SQL Server 2022 publish 20th May…

### DIFF
--- a/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/DatabaseExtensions.cs
@@ -10,8 +10,8 @@ internal static class DatabaseExtensions
             .WithDataVolume("cats-data")
             .WithLifetime(ContainerLifetime.Persistent)
             .WithEndpointProxySupport(false)
-            // 2022-CU24-ubuntu-22.04
-            .WithImageSHA256("49b45a911dc535e9345fbfd7101a1bd8a1e190a5f29b877ef75387a061e5fcf0");
+            // 2022-CU25-ubuntu-22.04
+            .WithImageSHA256("e07b9699a2b749969f19d86563ceeea22bd3a69f7f1db85a8d1ac4bdaf0c6f56");
     
     internal static CatsDatabaseResources AddCatsDatabases(
         this IDistributedApplicationBuilder builder,


### PR DESCRIPTION
… 2026

## 🔗 Related Work
- Closes: # https://dsdmoj.atlassian.net/browse/CFODEV-1689
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

Updates SQL Server version for Aspire to SQL 2022 CU 25
---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

This uses the latest safe published container from Microsoft.


## 🔄 Changes
- Added:
- Updated:   Version of SQL Server Aspire uses
- Removed:

## ⚠️ Risks & Impact
- [ ] Breaking change
- [x] Database change
- [ ] Performance impact
- [x] Security impact

Details:
> Anything reviewers should be cautious about.

Doesn't alter CATS in anyway, just developer dependencies

---

