### PR TITLE
Allow users to set their default home page

### DIFF
--- a/.github/workflows/schema-diff.yml
+++ b/.github/workflows/schema-diff.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          global-json-file: global.json
+          global-json-file: pr/global.json
 
       - name: Install sqlpackage
         run: dotnet tool install --global microsoft.sqlpackage

--- a/src/Application/Features/Identity/Commands/SetHomePage.cs
+++ b/src/Application/Features/Identity/Commands/SetHomePage.cs
@@ -1,0 +1,48 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Identity.Commands;
+
+public static class SetHomePage
+{
+    private const int HomePageMaxLength = 50;
+
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Command : IRequest<Result>
+    {
+        public required string HomePage { get; set; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork, ICurrentUserService currentUserService) : IRequestHandler<Command, Result>
+    {
+        public async Task<Result> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var userId = currentUserService.UserId;
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Result.Failure("User is not authenticated");
+            }
+
+            var user = await unitOfWork.DbContext.Users.FirstOrDefaultAsync(x => x.Id == userId, cancellationToken);
+            if (user is null)
+            {
+                return Result.Failure("User not found");
+            }
+
+            user.HomePage = request.HomePage;
+            return Result.Success();
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.HomePage)
+                .NotEmpty()
+                .MaximumLength(HomePageMaxLength)
+                .Must(x => x.StartsWith('/'))
+                .WithMessage("Home page must start with '/'");
+        }
+    }
+}

--- a/src/Database/CatsDb/Identity/Tables/User.sql
+++ b/src/Database/CatsDb/Identity/Tables/User.sql
@@ -31,7 +31,8 @@ CREATE TABLE [Identity].[User] (
     [LockoutEnd]             DATETIMEOFFSET (7) NULL,
     [LockoutEnabled]         BIT                NOT NULL,
     [AccessFailedCount]      INT                NOT NULL,
-    [LastLogin]              DATETIME2 (7)      NULL
+    [LastLogin]              DATETIME2 (7)      NULL,
+    [HomePage]               NVARCHAR(50)       NULL
 );
 GO
 

--- a/src/Domain/Identity/ApplicationUser.cs
+++ b/src/Domain/Identity/ApplicationUser.cs
@@ -46,6 +46,8 @@ public class ApplicationUser : IdentityUser, IAuditable
     public string? LastModifiedBy { get; set; }
     public DateTime? LastLogin { get; set; }
 
+    public string? HomePage { get; set; }
+
     public ApplicationUser AddNote(Note note)
     {
         if(_notes.Contains(note) is false)

--- a/src/Infrastructure/Constants/Database/DatabaseConstants.cs
+++ b/src/Infrastructure/Constants/Database/DatabaseConstants.cs
@@ -179,5 +179,7 @@ internal static class DatabaseConstants
         /// The maximum length for the description of an initiative.
         /// </summary>
         public const int InitiativeDescription = 256;
+
+        public const int Fifty = 50;
     }
 }

--- a/src/Infrastructure/Persistence/Configurations/Identity/ApplicationUserConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/Identity/ApplicationUserConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography.X509Certificates;
 using Cfo.Cats.Domain.Identity;
 using Cfo.Cats.Infrastructure.Constants.Database;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -54,6 +55,8 @@ public class ApplicationUserConfiguration : IEntityTypeConfiguration<Application
         builder.Property(x => x.PhoneNumber)
             .HasMaxLength(20);
         
+        builder.Property(u => u.HomePage)
+            .HasMaxLength(DatabaseConstants.FieldLengths.Fifty);
         
         // Each User can have many UserLogins
         builder.HasMany(e => e.Logins).WithOne().HasForeignKey(ul => ul.UserId).IsRequired();

--- a/src/Server.UI/Components/Shared/Layout/UserMenu.razor
+++ b/src/Server.UI/Components/Shared/Layout/UserMenu.razor
@@ -47,12 +47,22 @@
 
                 <MudDivider Class="my-2" />
                 <MudMenuItem Href="/user/profile">
-                    <div class="d-flex">
-                        <MudIcon Class="mx-2"
-                                 Style="color: white;"
-                                 Icon="@Icons.Material.Filled.Person" />
+                    <MudStack Row="true" AlignItems="AlignItems.Center">
+                        <MudIcon 
+                            Icon="@Icons.Material.Filled.Person"
+                            Color="Color.Info" />
                         <MudText>@L["Profile"]</MudText>
-                    </div>
+                    </MudStack>
+                </MudMenuItem>
+                <MudMenuItem OnClick="SetHomePage">
+                    <MudStack Row="true" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.Home"
+                            Color="Color.Primary">
+                        </MudIcon>
+                        <MudText>
+                            @L["Set Default Page"]
+                        </MudText>
+                    </MudStack>
                 </MudMenuItem>
                 <div class="mt-4 mx-4">
                     <form action="@IdentityComponentsEndpointRouteBuilderExtensions.Logout" method="post">
@@ -75,24 +85,3 @@
     </form>
 </MudTooltip>
 
-@code
-{
-
-    [Parameter] public EventCallback<EventArgs> OnSettingClick { get; set; }
-    private bool IsLoading { get; set; }
-    private UserProfile? UserProfile { get; set; }
-    
-    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
-
-    protected override async Task OnInitializedAsync()
-    {
-        if (UserProfile is null)
-        {
-            IsLoading = true;
-            var state = await AuthState;
-            this.UserProfile = state.User.GetUserProfileFromClaim();
-            IsLoading = false;
-        }
-    }
-
-}

--- a/src/Server.UI/Components/Shared/Layout/UserMenu.razor.cs
+++ b/src/Server.UI/Components/Shared/Layout/UserMenu.razor.cs
@@ -1,0 +1,53 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Features.Identity.Commands;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Cfo.Cats.Server.UI.Components.Shared.Layout;
+
+public partial class UserMenu
+{
+
+    [Parameter] public EventCallback<EventArgs> OnSettingClick { get; set; }
+    private bool IsLoading { get; set; }
+    private UserProfile? UserProfile { get; set; }
+
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (UserProfile is null)
+        {
+            IsLoading = true;
+            var state = await AuthState;
+            UserProfile = state.User.GetUserProfileFromClaim();
+            IsLoading = false;
+        }
+    }
+
+    private async Task SetHomePage()
+    {
+        var currentPath = Navigation.ToAbsoluteUri(Navigation.Uri).AbsolutePath;
+        var homePage = string.IsNullOrWhiteSpace(currentPath) ? "/" : currentPath;
+
+        async Task OnConfirm()
+        {
+            var result = await GetNewMediator().Send(new SetHomePage.Command
+            {
+                HomePage = homePage
+            });
+
+            if (result.Succeeded)
+            {
+                Snackbar.Add("Default page updated", Severity.Success);
+                return;
+            }
+
+            Snackbar.Add(result.ErrorMessage, Severity.Error);
+        }
+
+        await DialogServiceHelper.ShowConfirmationDialog(
+            "Confirm Home Page",
+            "Set this page as your default home page?",
+            OnConfirm);
+    }
+}

--- a/src/Server.UI/Pages/Identity/Authentication/Login.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Login.razor
@@ -141,8 +141,6 @@
     {
         var user = await UserManager.FindByNameAsync(Input.UserName);
 
-
-
         if(user is null)
         {
             await Sender.Publish( IdentityAuditNotification.UnknownUserNameNotification(Input.UserName, NetworkIpProvider.IpAddress));
@@ -157,7 +155,7 @@
         if (result.Succeeded)
         {
             await Sender.Publish(IdentityAuditNotification.LoginSucceededNoTwoFactorRequired(Input.UserName, NetworkIpProvider.IpAddress));
-            RedirectManager.RedirectTo(ReturnUrl);
+            RedirectManager.RedirectTo(user.HomePage ?? ReturnUrl);
         }
         else if(result is CustomSignInResult customSignInResult)
         {

--- a/src/Server.UI/Pages/Identity/Authentication/LoginWith2fa.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/LoginWith2fa.razor
@@ -110,7 +110,7 @@
             if (result.Succeeded)
             {
                 await Sender.Publish(IdentityAuditNotification.LoginSucceededTwoFactorRequired(user.UserName!, NetworkIpProvider.IpAddress));
-                RedirectManager.RedirectTo("/");
+                RedirectManager.RedirectTo(user.HomePage ?? "/");
             }
             else if (result.IsLockedOut)
             {


### PR DESCRIPTION
Users can now configure a specific page as their default landing page, which they will be redirected to upon successful login. A new 'Set Default Page' option has been added to the user menu, enabling users to set their current page as their home page.

## 🔗 Related Work
- Closes: # CFODEV-1693
- Related: #

---

## 📌 Summary

This PR allows a user to set the default page they go to when logging into CATS.

---

## 🎯 Purpose / Motivation

The ability to set a default home page is a minor but useful addition to the application.

---

## 🧠 Approach

This introduces a new column and a new mediator command that updates the user record based on the current page of the user.


## 🧪 How to Test

1. Navigate to any page
2. Set the default home page
3. Next time you log in as that user you will be on that page
<img width="1804" height="418" alt="image" src="https://github.com/user-attachments/assets/28e64c15-5500-4384-888e-58394232df70" />


## ⚠️ Risks & Impact
- [ ] Breaking change
- [x] Database change
- [ ] Performance impact
- [ ] Security impact
