### PR TITLE
Fixes issue with missing advisories

### DIFF
--- a/src/Application/Features/Dashboard/Queries/GetActivitiesAdvisoriesToProvider.cs
+++ b/src/Application/Features/Dashboard/Queries/GetActivitiesAdvisoriesToProvider.cs
@@ -27,7 +27,6 @@ public static class GetActivitiesAdvisoriesToProvider
                     && (pfa.FeedbackType == ((int)FeedbackType.Advisory) || pfa.FeedbackType == ((int)FeedbackType.AcceptedByException))
                     && pfa.ActionDate >= request.StartDate
                     && pfa.ActionDate < request.EndDate.AddDays(1)
-                    && pfa.TenantId.Length > 6
                     && (!string.IsNullOrWhiteSpace(request.TenantId) ? pfa.TenantId.StartsWith(request.TenantId) : true)
                 join cfoUser in context.Users on pfa.CfoUserId equals cfoUser.Id into cfoUserJoin
                 from cfoUser in cfoUserJoin.DefaultIfEmpty()


### PR DESCRIPTION
## 🔗 Related Work
- Closes: #
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.
Some Advisories are not appearing for certain tenants, it was due to the tenant length check left by mistake
---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

---

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

---

## 🔄 Changes
- Added:
- Updated:
- Removed:

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1.
2.
3.

Expected result:
> What should happen if everything is correct?
Should display all advisories.
---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.
should we deploy this to the UAT first for User to test?
---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"
