### PR TITLE
Persist Enrolment PQA list filters and refactor UI

### DIFF
--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportPqaEnrolmentsIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportPqaEnrolmentsIntegrationEventConsumer.cs
@@ -41,7 +41,7 @@ public class DocumentExportPqaEnrolmentsIntegrationEventConsumer(
             // Hack: call handler directly (skips Authorization pipeline, as we're outside of the HttpContext).
             var data = await new PqaQueueWithPagination.Handler(unitOfWork, mapper).Handle(request!, CancellationToken.None);
 
-            var results = await excelService.ExportAsync(data.Items!,
+            var results = await excelService.ExportAsync(data.Data!.Items!,
                 new Dictionary<string, Func<EnrolmentQueueEntryDto, object?>>
                 {
                     { "Participant Id", item => item.ParticipantId },

--- a/src/Application/Features/QualityAssurance/Queries/PqaQueueWithPagination.cs
+++ b/src/Application/Features/QualityAssurance/Queries/PqaQueueWithPagination.cs
@@ -15,7 +15,7 @@ public static class PqaQueueWithPagination
     {
         public Query()
         {
-            SortDirection = "Desc";
+            SortDirection = "Descending";
             OrderBy = "Created";
             PageSize = 50;
         }

--- a/src/Application/Features/QualityAssurance/Queries/PqaQueueWithPagination.cs
+++ b/src/Application/Features/QualityAssurance/Queries/PqaQueueWithPagination.cs
@@ -11,21 +11,22 @@ namespace Cfo.Cats.Application.Features.QualityAssurance.Queries;
 public static class PqaQueueWithPagination
 {
     [RequestAuthorize(Policy = SecurityPolicies.Pqa)]
-    public class Query : QueueEntryFilter, IRequest<PaginatedData<EnrolmentQueueEntryDto>>
+    public class Query : QueueEntryFilter, IRequest<Result<PaginatedData<EnrolmentQueueEntryDto>>>
     {
         public Query()
         {
             SortDirection = "Desc";
             OrderBy = "Created";
+            PageSize = 50;
         }
 
         [JsonIgnore]
         public EnrolmentPqaQueueEntrySpecification Specification => new(this);
     }
 
-    public class Handler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<Query, PaginatedData<EnrolmentQueueEntryDto>>
+    public class Handler(IUnitOfWork unitOfWork, IMapper mapper) : IRequestHandler<Query, Result<PaginatedData<EnrolmentQueueEntryDto>>>
     {
-        public async Task<PaginatedData<EnrolmentQueueEntryDto>> Handle(Query request, CancellationToken cancellationToken)
+        public async Task<Result<PaginatedData<EnrolmentQueueEntryDto>>> Handle(Query request, CancellationToken cancellationToken)
         {
             var query = unitOfWork.DbContext
                 .EnrolmentPqaQueue

--- a/src/Application/Features/QualityAssurance/Specifications/EnrolmentPqaQueueEntrySpecification.cs
+++ b/src/Application/Features/QualityAssurance/Specifications/EnrolmentPqaQueueEntrySpecification.cs
@@ -6,9 +6,10 @@ public class EnrolmentPqaQueueEntrySpecification : Specification<EnrolmentPqaQue
 {
     public EnrolmentPqaQueueEntrySpecification(QueueEntryFilter filter)
     {
-        Query.Where(e => e.TenantId
-                .StartsWith(filter.CurrentUser!.TenantId!))
-            .Where(e => e.IsCompleted == false);
+        Query.Where(e => e.TenantId.StartsWith(filter.CurrentUser!.TenantId!));
+        Query.Where(e => e.TenantId == filter.TenantId, filter.TenantId is not null);
+
+        Query.Where(e => e.IsCompleted == false);
 
         if (!string.IsNullOrWhiteSpace(filter.Keyword))
         {

--- a/src/Application/Features/QualityAssurance/Specifications/QueueEntryFilter.cs
+++ b/src/Application/Features/QualityAssurance/Specifications/QueueEntryFilter.cs
@@ -7,4 +7,6 @@ public class QueueEntryFilter
 {
     public UserProfile? CurrentUser { get; set; }
     public string? SupportWorkerId { get; set; }
+
+    public string? TenantId { get; set; }
 }

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -15,6 +15,7 @@ using ActualLab.Fusion.Extensions;
 using Cfo.Cats.Server.UI.Middlewares;
 using ApexCharts;
 using Cfo.Cats.Server.UI.Pages.Participants;
+using Cfo.Cats.Server.UI.Pages.QA.Enrolments;
 
 namespace Cfo.Cats.Server.UI;
 
@@ -125,6 +126,7 @@ public static class DependencyInjection
         });
 
         services.AddScoped<ParticipantsSessionStorage>();
+        services.AddScoped<PQASessionStorage>();
         
         return builder;
     }

--- a/src/Server.UI/Pages/QA/Enrolments/PQASessionStorage.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/PQASessionStorage.cs
@@ -1,0 +1,38 @@
+using Cfo.Cats.Application.Features.QualityAssurance.Specifications;
+using Cfo.Cats.Server.UI.Services;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Cfo.Cats.Server.UI.Pages.QA.Enrolments;
+
+public class PQASessionStorage(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService)
+    : CatsSessionStorage<PQASessionData>(protectedSessionStorage, currentUserService)
+{
+    
+}
+
+public record PQASessionData
+{
+    public PQASessionData()
+    {
+    }
+
+    public required string? SupportWorkerId { get; init; }
+
+    public required string? TenantId { get; init; }
+    public required string? Keyword { get; init; }
+    public required string OrderBy { get; init; }
+    public required string SortDirection { get; init; }
+    public required int PageNumber { get; init; }
+
+    internal static PQASessionData FromQuery(QueueEntryFilter query)
+        => new()
+        {
+            SupportWorkerId = query.SupportWorkerId,
+            TenantId = query.TenantId,
+            Keyword = query.Keyword,
+            OrderBy = query.OrderBy,
+            SortDirection = query.SortDirection,
+            PageNumber = query.PageNumber
+        };
+
+}

--- a/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
@@ -5,117 +5,137 @@
 @using Cfo.Cats.Application.SecurityConstants
 @using Humanizer
 
-@inherits CatsComponentBase;
+@inherits OwningComponentBase<IMediator>;
 
 @inject IStringLocalizer<PQA> L
 
 @attribute [Authorize(Policy = SecurityPolicies.Pqa)]
 
-<MudDataGrid ServerData="@(ServerReload)"
-             T="EnrolmentQueueEntryDto"
-             FixedHeader="true"
-             FixedFooter="true"
-             Virtualize="true"
-             @bind-RowsPerPage="_defaultPageSize"
-             Height="calc(100vh - 330px)"
-             Loading="@_loading"
-             MultiSelection="true"
-             @bind-SelectedItem="_currentDto"
-             Hover="true"
-             RowClick="@RowClicked"
-             RowClass="pointer-cursor"
-             @ref="_table"
-             BreakPoint="Breakpoint.Sm"
-			 Striped="true"
-			 Dense="true">
-    <ToolBarContent>
-        <div class="d-flex align-start flex-grow-1">
-            <div class="d-flex gap-4">
-                <MudIcon Icon="@Icons.Material.Filled.People" Size="Size.Large"/>
-                <div class="d-flex flex-column">
-					<MudText Typo="Typo.h5">Enrolment Provider QA</MudText>
-                </div>
-            </div>
-            <div class="flex-grow-1"></div>
-            <div class="d-flex flex-column justify-end">
+<MudContainer MaxWidth="MaxWidth.ExtraExtraLarge">
+    <MudStack>
+        <!-- Header/Filter Row -->
+        <MudStack Row="true" Justify="Justify.FlexEnd">
+            @*
+                Buttons and search text goes here                
+            *@
+            <MudTextField T="string" Value="@Query.Keyword" Placeholder="@ConstantString.Search"
+                          ValueChanged="@(OnSearch)" Clearable="true" ShrinkLabel="true"
+                          AdornmentIcon="@Icons.Material.Filled.Search" Adornment="Adornment.Start"
+                          AdornmentColor="Color.Secondary">
+            </MudTextField>
+            <MudSpacer />
+            <MudLoadingButton Variant="Variant.Filled" Size="Size.Small"   
+                      Loading="@_loading"
+                      OnClick="OnRefreshClicked"
+                      StartIcon="@Icons.Material.Filled.Refresh"
+                      Color="Color.Secondary">
+                        @ConstantString.Refresh
+            </MudLoadingButton>
+            <MudLoadingButton Loading="@_downloading"
+                        Variant="Variant.Filled"
+                        Color="Color.Secondary"
+                        StartIcon="@Icons.Material.Filled.CloudDownload"
+                        Size="Size.Small"
+                        OnClick="OnExport">
+                        @ConstantString.Export
+            </MudLoadingButton>
+        </MudStack>
+        <!-- Additional filters row -->
+        <MudStack Row="true" Class="pt-4" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center">
+            <MudPagination 
+                Selected="Query.PageNumber"
+                Count="@_totalPages"
+                MiddleCount="2"
+                BoundaryCount="1"
+                SelectedChanged="PageChanged"
+                Size="Size.Small">
+            </MudPagination>
+
+            <MudText>
+                @_totalItems records
+            </MudText>
+
+            <MudSpacer />
+
+            <!-- Tenant -->
+            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ShowTenantDialog" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                @if(string.IsNullOrEmpty(Query.TenantId))
+                {
+                    @("All Tenants")
+                }
+                else
+                {
+                    @_tenants[Query.TenantId]
+                }
+            </MudButton>
+
+            <!-- Support Worker -->
+
+            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ShowSupportWorkerDialog" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                @if(string.IsNullOrEmpty(Query.SupportWorkerId))
+                {
+                    @("All Assignees")
+                }
+                else 
+                {
+                    @_users[Query.SupportWorkerId]
+                }
+            </MudButton>
+
+            <MudTooltip Text="Clear search parameters">
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Clear" OnClick="@(() => ClearSearch())" />
+            </MudTooltip>
+
+        </MudStack>
+    </MudStack>
+
+    <MudTable T="EnrolmentQueueEntryDto" Items="@_data" Hover="true" Striped="true" SelectOnRowClick="true" OnRowClick="@OnRowClick">
+        <HeaderContent>
+            <MudTh>
+                @L["Participant"]
+            </MudTh>
+            <MudTh>
+                @L["Support Worker"]
+            </MudTh>
+            <MudTh>
+                @L["Tenant"]
+            </MudTh>
+            <MudTh>
+                @L["Submitted"]
+            </MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>
                 <MudStack>
-                    <MudStack Row="true" AlignItems="AlignItems.Center">
-                        <MudHidden Breakpoint="Breakpoint.SmAndDown">
-                            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ShowTenantDialog" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
-                                @SelectedDisplayName
-                            </MudButton>
-                            <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ShowSupportWorkerDialog" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
-                                @SelectedSupportWorkerName
-                            </MudButton>
-                            <MudButton Variant="Variant.Filled"
-                                       Size="Size.Small"
-                                       Disabled="@_loading"
-                                       OnClick="@(() => OnRefresh())"
-                                       StartIcon="@Icons.Material.Filled.Refresh"
-                                       Color="Color.Secondary">
-                                @ConstantString.Refresh
-                            </MudButton>
-                            <MudLoadingButton Loading="@_downloading"
-                                       Variant="Variant.Filled"
-                                       Color="Color.Secondary"
-                                       StartIcon="@Icons.Material.Filled.CloudDownload"
-                                       Size="Size.Small"
-                                       OnClick="OnExport">
-                                       @ConstantString.Export
-                            </MudLoadingButton>
-                            <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true"></MudHidden>
-                        </MudHidden>
-                    </MudStack>
-                    <MudTextField T="string" ValueChanged="@(OnSearch)" Value="@Query.Keyword" Placeholder="@ConstantString.Search" Adornment="Adornment.End"
-                                 Clearable="true" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Small" Style="width: 350px; align-self: flex-end;">
-                    </MudTextField>
+                    <MudText>
+                        @context.ParticipantName
+                    </MudText>
+                    <MudText>
+                        @context.ParticipantId
+                    </MudText>
                 </MudStack>
-            </div>
-        </div>
-    </ToolBarContent>
-    <Columns>
-       
-        <PropertyColumn Property="x => x.ParticipantId" Title="@L["Participant"]">
-            <CellTemplate>
-                <div class="d-flex flex-column">
-                    <MudText Typo="Typo.body2">@context.Item.ParticipantName</MudText>
-                    <MudText Typo="Typo.body2">@context.Item.ParticipantId</MudText>
-                </div>
-            </CellTemplate>
-        </PropertyColumn>
-        <PropertyColumn Property="x => x.SupportWorker" Title="@L["Support Worker"]">
-            <CellTemplate>
-                <MudText Typo="Typo.body2">@context.Item.SupportWorker</MudText>                    
-            </CellTemplate>
-        </PropertyColumn>
-        <PropertyColumn Property="x => x.TenantId" Title="@L["Tenant"]">
-            <CellTemplate>
-                <div class="d-flex flex-column">
-                    <MudText Typo="Typo.body2">@context.Item.TenantName</MudText>
-                    <MudText Typo="Typo.body2">@context.Item.TenantId</MudText>
-                </div>
-            </CellTemplate>
-        </PropertyColumn>
-        <PropertyColumn Property="x => x.Created" Title="@L["Submitted"]">
-            <CellTemplate>
-                <div class="d-flex flex-column">
+            </MudTd>
+            <MudTd>
+                <MudText>
+                    @context.SupportWorker
+                </MudText>
+            </MudTd>
+            <MudTd>
+                <MudStack>
+                    <MudText>@context.TenantName</MudText>
+                    <MudText>@context.TenantId</MudText>
+                </MudStack>
+            </MudTd>
+            <MudTd>
+                <MudStack>
                     <MudText Typo="Typo.body2">
-                        @context.Item.Created.Date.ToString("d")                        
+                            @context.Created.Date.ToString("d")                        
                     </MudText>
                     <MudText Typo="Typo.body2">                        
-                        @context.Item.Created.Humanize()
+                        @context.Created.Humanize()
                     </MudText>
-                </div>
-            </CellTemplate>
-        </PropertyColumn>        
-    </Columns>
-    <NoRecordsContent>
-        <MudText>@ConstantString.NoRecords</MudText>
-    </NoRecordsContent>
-    <LoadingContent>
-        <MudText>@ConstantString.Loading</MudText>
-    </LoadingContent>
-    <PagerContent>
-        <MudDataGridPager PageSizeOptions="@(new[] { 10, 15, 30, 50 })"/>
-    </PagerContent>
-</MudDataGrid>
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+</MudContainer>

--- a/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/PqaList.razor
@@ -82,6 +82,13 @@
                 }
             </MudButton>
 
+            <MudMenu Size="Size.Small" Label="Sort By" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                <MudMenuItem Label="Participant" OnClick="@(() => SortBy("ParticipantId"))" />
+                <MudMenuItem Label="Support Worker" OnClick="@(() => SortBy("SupportWorker"))" />
+                <MudMenuItem Label="Tenant" OnClick="@(() => SortBy("TenantId"))" />
+                <MudMenuItem Label="Submitted" OnClick="@(() => SortBy("Created"))" />
+            </MudMenu>
+
             <MudTooltip Text="Clear search parameters">
                 <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Clear" OnClick="@(() => ClearSearch())" />
             </MudTooltip>

--- a/src/Server.UI/Pages/QA/Enrolments/PqaList.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/PqaList.razor.cs
@@ -1,4 +1,3 @@
-using System.Data.Entity.Core.Metadata.Edm;
 using Cfo.Cats.Application.Common.Interfaces.Identity;
 using Cfo.Cats.Application.Common.Interfaces.MultiTenant;
 using Cfo.Cats.Application.Common.Security;
@@ -104,21 +103,29 @@ public partial class PqaList
 
     private async Task OnRefresh()
     {
-        Query.CurrentUser = UserProfile;
-        var results = await Service.Send(Query);
-        if(results is { Succeeded: true, Data: not null})
+        try
         {
-            _data = results.Data.Items.ToArray();
-            _totalPages = results.Data.TotalPages;    
-            _totalItems = results.Data.TotalItems;
+            _loading = true;
+            Query.CurrentUser = UserProfile;
+            var results = await Service.Send(Query);
+            if(results is { Succeeded: true, Data: not null})
+            {
+                _data = results.Data.Items.ToArray();
+                _totalPages = results.Data.TotalPages;    
+                _totalItems = results.Data.TotalItems;
+            }
+            else
+            {
+                _data = [];
+                _totalPages = 0;
+                _totalItems = 0;
+            }
+            await SessionStorage.SetAsync(PQASessionData.FromQuery(Query));
         }
-        else
+        finally
         {
-            _data = [];
-            _totalPages = 0;
-            _totalItems = 0;
+            _loading = false;
         }
-        await SessionStorage.SetAsync(PQASessionData.FromQuery(Query));
     }
 
     private async Task OnExport()
@@ -183,5 +190,22 @@ public partial class PqaList
             Query.SupportWorkerId = user.UserId;
             await OnRefresh();
         }
+    }
+
+    private async Task SortBy(string key)
+    {
+        if (Query.OrderBy == key)
+        {
+            Query.SortDirection = Query.SortDirection == SortDirection.Ascending.ToString()
+                ? SortDirection.Descending.ToString()
+                : SortDirection.Ascending.ToString();
+        }
+        else
+        {
+            Query.OrderBy = key;
+            Query.SortDirection = SortDirection.Ascending.ToString();
+        }
+
+        await OnRefresh();
     }
 }

--- a/src/Server.UI/Pages/QA/Enrolments/PqaList.razor.cs
+++ b/src/Server.UI/Pages/QA/Enrolments/PqaList.razor.cs
@@ -1,3 +1,6 @@
+using System.Data.Entity.Core.Metadata.Edm;
+using Cfo.Cats.Application.Common.Interfaces.Identity;
+using Cfo.Cats.Application.Common.Interfaces.MultiTenant;
 using Cfo.Cats.Application.Common.Security;
 using Cfo.Cats.Application.Features.QualityAssurance.Commands;
 using Cfo.Cats.Application.Features.QualityAssurance.DTOs;
@@ -9,153 +12,113 @@ namespace Cfo.Cats.Server.UI.Pages.QA.Enrolments;
 
 public partial class PqaList
 {
-    [CascadingParameter] private UserProfile? UserProfile { get; set; }
+    [CascadingParameter] private UserProfile UserProfile { get; set; } = null!;
+    
+    [Inject]
+    public IUserService UserService { get; set; } = null!;
+
+    [Inject]
+    public ITenantService TenantService { get; set; } = null!;
+
+    [Inject]
+    public PQASessionStorage SessionStorage { get; set; } = null!;
+
+    private IDictionary<string, string> _users = null!;
+
+    private IDictionary<string, string> _tenants = null!;
+
+    private int _totalPages = 0;
+    private int _totalItems = 0;
 
     private bool _loading = false;
     private bool _downloading;
-    private int _defaultPageSize = 30;
-    private MudDataGrid<EnrolmentQueueEntryDto> _table = default!;
+    
+    private EnrolmentQueueEntryDto[] _data = [];
 
     private PqaQueueWithPagination.Query Query { get; set; } = new();
     private EnrolmentQueueEntryDto _currentDto = new();
     
-    public string? SelectedTenantId { get; set; }
-    public string? SelectedDisplayName { get; set; }
-    public string? SelectedSupportWorkerId { get; set; }
-    public string? SelectedSupportWorkerName { get; set; }
-    
-    private List<(string Id, string Name)> _availableSupportWorkers = new();
-
     protected override async Task OnInitializedAsync()
     {
-        SelectedTenantId = UserProfile?.TenantId;
-        SelectedDisplayName = UserProfile?.TenantName;
-        SelectedSupportWorkerId = null;
-        SelectedSupportWorkerName = "All Support Workers";
-        
-        await LoadAvailableSupportWorkers();
+        _users = UserService.DataSource
+            .Where(d => d.TenantId!.StartsWith(UserProfile.TenantId!))
+            .ToDictionary(a => a.Id, e => e.DisplayName);
+
+        _tenants = TenantService.GetVisibleTenants(UserProfile.TenantId!)
+                    .ToDictionary(k => k.Id, k => k.Name);
+
+        var cached = await SessionStorage.GetAsync();
+
+        if(cached is { Succeeded: true, Data: { } sd })
+        {
+            Query.Keyword = sd.Keyword;
+            Query.OrderBy = sd.OrderBy;
+            Query.PageNumber = sd.PageNumber;
+            Query.PageSize = 50;
+            Query.SortDirection = sd.SortDirection;
+            Query.SupportWorkerId = sd.SupportWorkerId;
+            Query.TenantId = sd.TenantId;
+        }
+
+        await OnRefresh();
     }
 
-    private async Task LoadAvailableSupportWorkers()
+    private void OnRowClick(TableRowClickEventArgs<EnrolmentQueueEntryDto> args)
     {
-        try
+        if(args?.Item is not null)
         {
-            // Load all support workers for the selected tenant (without support worker filter)
-            var effectiveUser = new UserProfile
-            {
-                UserId = UserProfile?.UserId ?? string.Empty,
-                UserName = UserProfile?.UserName ?? string.Empty,
-                Email = UserProfile?.Email ?? string.Empty,
-                TenantId = SelectedTenantId,
-                TenantName = SelectedDisplayName,
-                AssignedRoles = UserProfile?.AssignedRoles ?? [],
-                Contracts = UserProfile?.Contracts ?? []
-            };
-            
-            var query = new PqaQueueWithPagination.Query
-            {
-                CurrentUser = effectiveUser,
-                SupportWorkerId = null, // Don't filter by support worker
-                PageNumber = 1,
-                PageSize = 1000, // Get a large set to capture all support workers
-                OrderBy = "Created",
-                SortDirection = "Descending"
-            };
-            
-            var result = await GetNewMediator().Send(query);
-            
-            _availableSupportWorkers = result.Items
-                .Where(x => !string.IsNullOrEmpty(x.SupportWorkerId))
-                .Select(x => (x.SupportWorkerId, x.SupportWorker))
-                .Distinct()
-                .OrderBy(x => x.SupportWorker)
-                .ToList();
-        }
-        catch
-        {
-            // If loading fails, just use empty list
-            _availableSupportWorkers = new();
+            Navigation.NavigateTo($"/pages/qa/enrolments/pqa/{args.Item.Id}");
         }
     }
 
-    private void RowClicked(DataGridRowClickEventArgs<EnrolmentQueueEntryDto> args) => Navigation.NavigateTo($"/pages/qa/enrolments/pqa/{args.Item.Id}");
-
-    private async Task<GridData<EnrolmentQueueEntryDto>> ServerReload(GridState<EnrolmentQueueEntryDto> state, CancellationToken cancellationToken)
+    private Task PageChanged(int page)
     {
-        try
-        {
-            _loading = true;
-            
-            // Create a user profile with the selected tenant for filtering
-            var effectiveUser = new UserProfile
-            {
-                UserId = UserProfile?.UserId ?? string.Empty,
-                UserName = UserProfile?.UserName ?? string.Empty,
-                Email = UserProfile?.Email ?? string.Empty,
-                TenantId = SelectedTenantId,
-                TenantName = SelectedDisplayName,
-                AssignedRoles = UserProfile?.AssignedRoles ?? [],
-                Contracts = UserProfile?.Contracts ?? []
-            };
-            
-            Query.CurrentUser = effectiveUser;
-            Query.SupportWorkerId = SelectedSupportWorkerId;
-            Query.OrderBy = state.SortDefinitions.FirstOrDefault()?.SortBy ?? "Created";
-            Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
-            Query.PageNumber = state.Page + 1;
-            Query.PageSize = state.PageSize;
-
-            var result = await GetNewMediator().Send(Query);
-            
-            return new GridData<EnrolmentQueueEntryDto> { TotalItems = result.TotalItems, Items = result.Items };
-        }
-        finally
-        {
-            _loading = false;
-        }
+        Query.PageNumber = page;
+        return OnRefresh();
     }
 
-    private async Task OnSearch(string text)
+    private async Task ClearSearch()
     {
-        if (_loading)
-        {
-            return;
-        }
-        
+        ResetQuery();
+        await OnRefresh();
+    }
+
+    private void ResetQuery()
+    {
+        Query.SupportWorkerId = null;
+        Query.TenantId = null;
+        Query.OrderBy = "ParticipantId";
+        Query.SortDirection = SortDirection.Ascending.ToString();
+        Query.PageNumber = 1;
+        Query.Keyword = null;
+    }
+
+    private Task OnSearch(string text)
+    {
         Query.Keyword = text;
-        await _table.ReloadServerData();
+        return OnRefresh();
     }
+
+    private Task OnRefreshClicked()
+        => OnRefresh();
 
     private async Task OnRefresh()
     {
-        Query.Keyword = string.Empty;
-        SelectedTenantId = UserProfile?.TenantId;
-        SelectedDisplayName = UserProfile?.TenantName;
-        SelectedSupportWorkerId = null;
-        SelectedSupportWorkerName = "All Support Workers";
-        await LoadAvailableSupportWorkers();
-        await _table.ReloadServerData();
-    }
-
-    private async Task OnSupportWorkerChanged(string? supportWorkerId)
-    {
-        if (_loading)
+        Query.CurrentUser = UserProfile;
+        var results = await Service.Send(Query);
+        if(results is { Succeeded: true, Data: not null})
         {
-            return;
-        }
-        
-        SelectedSupportWorkerId = supportWorkerId;
-        if (string.IsNullOrEmpty(supportWorkerId))
-        {
-            SelectedSupportWorkerName = "All Support Workers";
+            _data = results.Data.Items.ToArray();
+            _totalPages = results.Data.TotalPages;    
+            _totalItems = results.Data.TotalItems;
         }
         else
         {
-            SelectedSupportWorkerName = _availableSupportWorkers
-                .FirstOrDefault(x => x.Id == supportWorkerId).Name ?? "Unknown";
+            _data = [];
+            _totalPages = 0;
+            _totalItems = 0;
         }
-        
-        await _table.ReloadServerData();
+        await SessionStorage.SetAsync(PQASessionData.FromQuery(Query));
     }
 
     private async Task OnExport()
@@ -163,7 +126,7 @@ public partial class PqaList
         try
         {
             _downloading = true;
-            var result = await GetNewMediator().Send(new ExportPqaEnrolments.Command()
+            var result = await Service.Send(new ExportPqaEnrolments.Command()
             {
                 Query = Query
             });
@@ -199,17 +162,8 @@ public partial class PqaList
 
         if (result is { Canceled: false, Data: SelectedTenant tenant })
         {
-            SelectedTenantId = tenant.TenantId;
-            SelectedDisplayName = tenant.DisplayName;
-            
-            // Reload support workers list for the new tenant
-            await LoadAvailableSupportWorkers();
-            
-            // Reset support worker filter when tenant changes
-            SelectedSupportWorkerId = null;
-            SelectedSupportWorkerName = "All Support Workers";
-            
-            await _table.ReloadServerData();
+            Query.TenantId = tenant.TenantId;
+            await OnRefresh();
         }
     }
     
@@ -226,9 +180,8 @@ public partial class PqaList
 
         if (result is { Canceled: false, Data: SelectedUser user })
         {
-            SelectedSupportWorkerId = user.UserId;
-            SelectedSupportWorkerName = user.DisplayName;
-            await _table.ReloadServerData();
+            Query.SupportWorkerId = user.UserId;
+            await OnRefresh();
         }
     }
 }


### PR DESCRIPTION
## 🔗 Related Work
- Closes: # CFODEV-1704
- Related: #

---

## 📌 Summary

Adds session storage for enrolment PQA screen,


---

## 🎯 Purpose / Motivation

At present searched for elements are not persisted between page visits. This adds that functionality.
---

## 🧠 Approach

Query is serialised and stored in user local session storage. This is encrypted and destroyed when the browser is closed.



## 🧪 How to Test
> Step-by-step instructions to verify this works.

1. Filter Enrolment PQA screen
2. Navigate away
3. Go back to screen, page filter should be persisted.

Expected result:
> What should happen if everything is correct?

---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

---

## ⚠️ Risks & Impact
- [x] Breaking change
- [ ] Database change
- [x] Performance impact
- [x] Security impact


