### PR TITLE
Use business rules for status transition.

### DIFF
--- a/src/Domain/Common/Exceptions/InvalidActivityTransition.cs
+++ b/src/Domain/Common/Exceptions/InvalidActivityTransition.cs
@@ -1,6 +1,0 @@
-﻿using Cfo.Cats.Domain.Common.Enums;
-
-namespace Cfo.Cats.Domain.Common.Exceptions;
-
-public class InvalidActivityTransition(ActivityStatus from, ActivityStatus to)
-    : Exception($"Activities cannot transition from {from.Name} to {to.Name}");

--- a/src/Domain/Common/Exceptions/InvalidEnrolmentTransition.cs
+++ b/src/Domain/Common/Exceptions/InvalidEnrolmentTransition.cs
@@ -1,6 +1,0 @@
-using Cfo.Cats.Domain.Common.Enums;
-
-namespace Cfo.Cats.Domain.Common.Exceptions;
-
-public class InvalidEnrolmentTransition(EnrolmentStatus from, EnrolmentStatus to) 
-    : Exception($"Participants cannot transition from {from.Name} to {to.Name}");

--- a/src/Domain/Entities/Activities/Activity.cs
+++ b/src/Domain/Entities/Activities/Activity.cs
@@ -1,6 +1,6 @@
 using Cfo.Cats.Domain.Common.Entities;
 using Cfo.Cats.Domain.Common.Enums;
-using Cfo.Cats.Domain.Common.Exceptions;
+using Cfo.Cats.Domain.Entities.Activities.Rules;
 using Cfo.Cats.Domain.Entities.Administration;
 using Cfo.Cats.Domain.Entities.Participants;
 using Cfo.Cats.Domain.Events;
@@ -85,14 +85,11 @@ public abstract class Activity : OwnerPropertyEntity<Guid>
 
     public Activity TransitionTo(ActivityStatus to)
     {
-        if(Status.CanTransitionTo(to))
-        {
-            AddDomainEvent(new ActivityTransitionedDomainEvent(this, Status, to));
-            Status = to;
-            return this;
-        }
+        CheckRule(new ActivityStatusTransitionMustBeValid(Status, to));
 
-        throw new InvalidActivityTransition(Status, to);
+        AddDomainEvent(new ActivityTransitionedDomainEvent(this, Status, to));
+        Status = to;
+        return this;
     }
 
     public Activity Approve(string? completedBy)

--- a/src/Domain/Entities/Activities/Rules/ActivityStatusTransitionMustBeValid.cs
+++ b/src/Domain/Entities/Activities/Rules/ActivityStatusTransitionMustBeValid.cs
@@ -1,0 +1,11 @@
+using Cfo.Cats.Domain.Common.Contracts;
+using Cfo.Cats.Domain.Common.Enums;
+
+namespace Cfo.Cats.Domain.Entities.Activities.Rules;
+
+public class ActivityStatusTransitionMustBeValid(ActivityStatus from, ActivityStatus to) : IBusinessRule
+{
+    public string Message => $"Activities cannot transition from {from.Name} to {to.Name}";
+
+    public bool IsBroken() => from.CanTransitionTo(to) is false;
+}

--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -2,6 +2,7 @@ using Cfo.Cats.Domain.Common.Entities;
 using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Domain.Common.Exceptions;
 using Cfo.Cats.Domain.Entities.Administration;
+using Cfo.Cats.Domain.Entities.Participants.Rules;
 using Cfo.Cats.Domain.Events;
 using Cfo.Cats.Domain.ValueObjects;
 
@@ -135,16 +136,14 @@ public class Participant : OwnerPropertyEntity<string>
     /// </summary>
     /// <param name="to">The new enrolment status</param>
     /// <returns>This entity.</returns>
-    /// <exception cref="InvalidEnrolmentTransition">If the new enrolment status is not valid</exception>
+    /// <exception cref="BusinessRuleValidationException">If the new enrolment status is not valid</exception>
     public Participant TransitionTo(EnrolmentStatus to, string? Reason, string? AdditionalInformation)
     {
-        if (EnrolmentStatus!.CanTransitionTo(to))
-        {
-            AddDomainEvent(new ParticipantTransitionedDomainEvent(this, EnrolmentStatus, to, Reason, AdditionalInformation));
-            EnrolmentStatus = to;
-            return this;
-        }
-        throw new InvalidEnrolmentTransition(EnrolmentStatus, to);
+        CheckRule(new EnrolmentStatusTransitionMustBeValid(EnrolmentStatus!, to));
+
+        AddDomainEvent(new ParticipantTransitionedDomainEvent(this, EnrolmentStatus!, to, Reason, AdditionalInformation));
+        EnrolmentStatus = to;
+        return this;
     }
 
     /// <summary>

--- a/src/Domain/Entities/Participants/Rules/EnrolmentStatusTransitionMustBeValid.cs
+++ b/src/Domain/Entities/Participants/Rules/EnrolmentStatusTransitionMustBeValid.cs
@@ -1,0 +1,11 @@
+using Cfo.Cats.Domain.Common.Contracts;
+using Cfo.Cats.Domain.Common.Enums;
+
+namespace Cfo.Cats.Domain.Entities.Participants.Rules;
+
+public class EnrolmentStatusTransitionMustBeValid(EnrolmentStatus from, EnrolmentStatus to) : IBusinessRule
+{
+    public string Message => $"Participants cannot transition from {from.Name} to {to.Name}";
+
+    public bool IsBroken() => from.CanTransitionTo(to) is false;
+}

--- a/test/Application.UnitTests/Activities/BusinessRules/ActivityStatusTransitionMustBeValidTests.cs
+++ b/test/Application.UnitTests/Activities/BusinessRules/ActivityStatusTransitionMustBeValidTests.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Cfo.Cats.Domain.Common.Enums;
+using Cfo.Cats.Domain.Entities.Activities.Rules;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Cfo.Cats.Application.UnitTests.Activities.BusinessRules;
+
+public class ActivityStatusTransitionMustBeValidTests
+{
+    [Test]
+    public void IsBroken_WhenTransitionIsAllowed_ShouldReturnFalse()
+    {
+        var rule = new ActivityStatusTransitionMustBeValid(
+            ActivityStatus.PendingStatus,
+            ActivityStatus.SubmittedToProviderStatus);
+
+        rule.IsBroken().ShouldBeFalse();
+    }
+
+    [Test]
+    public void IsBroken_WhenTransitionIsNotAllowed_ShouldReturnTrue()
+    {
+        var rule = new ActivityStatusTransitionMustBeValid(
+            ActivityStatus.ApprovedStatus,
+            ActivityStatus.SubmittedToProviderStatus);
+
+        rule.IsBroken().ShouldBeTrue();
+        rule.Message.ShouldBe("Activities cannot transition from Approved to Submitted to Provider");
+    }
+}

--- a/test/Application.UnitTests/Participants/BusinessRules/EnrolmentStatusTransitionMustBeValidTests.cs
+++ b/test/Application.UnitTests/Participants/BusinessRules/EnrolmentStatusTransitionMustBeValidTests.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Cfo.Cats.Domain.Common.Enums;
+using Cfo.Cats.Domain.Entities.Participants.Rules;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Cfo.Cats.Application.UnitTests.Participants.BusinessRules;
+
+public class EnrolmentStatusTransitionMustBeValidTests
+{
+    [Test]
+    public void IsBroken_WhenTransitionIsAllowed_ShouldReturnFalse()
+    {
+        var rule = new EnrolmentStatusTransitionMustBeValid(
+            EnrolmentStatus.IdentifiedStatus,
+            EnrolmentStatus.EnrollingStatus);
+
+        rule.IsBroken().ShouldBeFalse();
+    }
+
+    [Test]
+    public void IsBroken_WhenTransitionIsNotAllowed_ShouldReturnTrue()
+    {
+        var rule = new EnrolmentStatusTransitionMustBeValid(
+            EnrolmentStatus.IdentifiedStatus,
+            EnrolmentStatus.ApprovedStatus);
+
+        rule.IsBroken().ShouldBeTrue();
+        rule.Message.ShouldBe("Participants cannot transition from Identified to Approved");
+    }
+}

--- a/test/Application.UnitTests/Participants/ParticipantTransitionTests.cs
+++ b/test/Application.UnitTests/Participants/ParticipantTransitionTests.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using Cfo.Cats.Domain.Common.Enums;
+using Cfo.Cats.Domain.Common.Exceptions;
+using Cfo.Cats.Domain.Entities.Participants;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Cfo.Cats.Application.UnitTests.Participants;
+
+public class ParticipantTransitionTests
+{
+    private static Participant CreateParticipant() =>
+        Participant.CreateFrom(
+            id: "ABC123",
+            firstName: "Test",
+            middleName: null,
+            lastName: "Participant",
+            gender: "Male",
+            dateOfBirth: new DateTime(1990, 1, 1),
+            registrationDetailsJson: null,
+            referralSource: "Test",
+            referralComments: null,
+            locationId: 1,
+            nationality: null,
+            primaryRecordKeyAtCreation: null,
+            ethnicity: null);
+
+    [Test]
+    public void TransitionTo_WhenTransitionIsValid_ShouldUpdateEnrolmentStatus()
+    {
+        var participant = CreateParticipant();
+        participant.EnrolmentStatus.ShouldBe(EnrolmentStatus.IdentifiedStatus);
+
+        participant.TransitionTo(EnrolmentStatus.EnrollingStatus, null, null);
+
+        participant.EnrolmentStatus.ShouldBe(EnrolmentStatus.EnrollingStatus);
+    }
+
+    [Test]
+    public void TransitionTo_WhenTransitionIsInvalid_ShouldThrowBusinessRuleException()
+    {
+        var participant = CreateParticipant();
+
+        Should.Throw<BusinessRuleValidationException>(() =>
+                participant.TransitionTo(EnrolmentStatus.ApprovedStatus, null, null))
+            .Message.ShouldBe("Participants cannot transition from Identified to Approved");
+    }
+
+    [Test]
+    public void TransitionTo_WhenTransitionIsInvalid_ShouldNotChangeEnrolmentStatus()
+    {
+        var participant = CreateParticipant();
+
+        Should.Throw<BusinessRuleValidationException>(() =>
+            participant.TransitionTo(EnrolmentStatus.ApprovedStatus, null, null));
+
+        participant.EnrolmentStatus.ShouldBe(EnrolmentStatus.IdentifiedStatus);
+    }
+}


### PR DESCRIPTION
This pull request refactors how status transitions are validated for both activities and participants by replacing custom exception classes with business rule objects, aligning the codebase with a domain-driven design approach. It introduces new business rule classes to encapsulate transition logic and updates the corresponding domain entities to use these rules. Additionally, comprehensive unit tests are added to ensure correct behavior of the new rules and transitions.

**Domain Logic Refactoring:**

* Replaced the custom exceptions `InvalidActivityTransition` and `InvalidEnrolmentTransition` with business rule classes `ActivityStatusTransitionMustBeValid` and `EnrolmentStatusTransitionMustBeValid`, removing the old exception files. (`src/Domain/Common/Exceptions/InvalidActivityTransition.cs` [[1]](diffhunk://#diff-304510532a63fa68e05f47d8991cf79b63b43c249bbdbc062ba409d34299ceafL1-L6) `src/Domain/Common/Exceptions/InvalidEnrolmentTransition.cs` [[2]](diffhunk://#diff-f0fcd608b7b1135c3d96e89eff474e0e1040c805cd154afc8cec93ba928a008cL1-L6)
* Updated the `Activity` and `Participant` entities to use the new business rules for status transitions, enforcing validation via `CheckRule()` instead of conditional logic and exceptions. (`src/Domain/Entities/Activities/Activity.cs` [[1]](diffhunk://#diff-385193fa4fd306000f6a6ae40e430f3d0a0744a478822b17872127af6cd30ab8L3-R3) [[2]](diffhunk://#diff-385193fa4fd306000f6a6ae40e430f3d0a0744a478822b17872127af6cd30ab8L88-L97); `src/Domain/Entities/Participants/Participant.cs` [[3]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09R5) [[4]](diffhunk://#diff-72f06aaa52fe2913f0394016be061f51ae8b66991f38127c21861c7303924e09L138-L148)
* Added business rule classes `ActivityStatusTransitionMustBeValid` and `EnrolmentStatusTransitionMustBeValid` to encapsulate transition logic and error messages. (`src/Domain/Entities/Activities/Rules/ActivityStatusTransitionMustBeValid.cs` [[1]](diffhunk://#diff-e3fef98ef5da133dfac8e1983b5c5d54d290c25b706f440d4560ef13ffdad490R1-R11) `src/Domain/Entities/Participants/Rules/EnrolmentStatusTransitionMustBeValid.cs` [[2]](diffhunk://#diff-e3ce16edcf077fda1539102cd081874ec0f7a60a62a2979bb9f9988110879d8fR1-R11)

**Testing Enhancements:**

* Added unit tests for both business rule classes to verify correct detection of valid and invalid transitions, including error messages. (`test/Application.UnitTests/Activities/BusinessRules/ActivityStatusTransitionMustBeValidTests.cs` [[1]](diffhunk://#diff-9474788b170b7f98c22c29c2855c3d06fd45b763c5b8d16b8f224a19e4f2cde8R1-R31) `test/Application.UnitTests/Participants/BusinessRules/EnrolmentStatusTransitionMustBeValidTests.cs` [[2]](diffhunk://#diff-fa0bd742ec27e6e0d7976b20026f2cb554a15ea0a0c2f4ff324c52089ade4b7dR1-R31)
* Added participant transition tests to ensure the `TransitionTo` method updates status correctly on valid transitions, throws the expected exception on invalid transitions, and does not update status when invalid. (`test/Application.UnitTests/Participants/ParticipantTransitionTests.cs` [test/Application.UnitTests/Participants/ParticipantTransitionTests.csR1-R60](diffhunk://#diff-c4e4a96a238c86f8ee2c64d8f96976d4f371aafdc408aab266566d51bbe555edR1-R60))