### PR TITLE
Export of user status

### DIFF
--- a/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportUsersIntegrationEventConsumer.cs
+++ b/src/Application/Features/Documents/IntegrationEventHandlers/DocumentExportUsersIntegrationEventConsumer.cs
@@ -1,0 +1,108 @@
+using Cfo.Cats.Application.Features.Documents.IntegrationEvents;
+using Cfo.Cats.Domain.Entities.Documents;
+using Cfo.Cats.Domain.Identity;
+using Microsoft.AspNetCore.Identity;
+using Newtonsoft.Json;
+using Rebus.Handlers;
+
+namespace Cfo.Cats.Application.Features.Documents.IntegrationEventHandlers;
+
+public class DocumentExportUsersIntegrationEventConsumer(
+    IUnitOfWork unitOfWork,
+    IExcelService excelService,
+    IUploadService uploadService,
+    IDomainEventDispatcher domainEventDispatcher,
+    UserManager<ApplicationUser> userManager,
+    ILogger<DocumentExportUsersIntegrationEventConsumer> logger) : IHandleMessages<ExportDocumentIntegrationEvent>
+{
+    public async Task Handle(ExportDocumentIntegrationEvent context)
+    {
+        if (context.Key != DocumentTemplate.Users.Name)
+        {
+            logger.LogDebug("Export document not supported by this handler");
+            return;
+        }
+
+        var document = await unitOfWork.DbContext.GeneratedDocuments.FindAsync(context.DocumentId);
+
+        if (document is null)
+        {
+            logger.LogError("Export users document event raised for a document that does not exist. ({DocumentId})", context.DocumentId);
+            return;
+        }
+
+        try
+        {
+            var request = JsonConvert.DeserializeObject<Identity.Commands.ExportUsers.Command>(context.SearchCriteria!)
+                ?? new Identity.Commands.ExportUsers.Command();
+
+            // Build the query
+            var query = userManager.Users
+                .Where(u => u.TenantId!.StartsWith(context.TenantId));
+
+            // Apply filters
+            if (!string.IsNullOrEmpty(request.SearchString))
+            {
+                var searchLower = request.SearchString.ToLower();
+                query = query.Where(u =>
+                    u.UserName!.Contains(searchLower) ||
+                    u.Email!.Contains(searchLower) ||
+                    u.DisplayName!.Contains(searchLower) ||
+                    (u.PhoneNumber != null && u.PhoneNumber.Contains(searchLower)));
+            }
+
+            if (!string.IsNullOrEmpty(request.Role))
+            {
+                query = query.Where(u => u.UserRoles.Any(ur => ur.Role.Name == request.Role));
+            }
+
+            if (!string.IsNullOrEmpty(request.TenantId))
+            {
+                query = query.Where(u => u.TenantId == request.TenantId);
+            }
+
+            var users = await query
+                .OrderBy(u => u.DisplayName)
+                .ToListAsync();
+
+            var dataToColumnMapper = new Dictionary<string, Func<ApplicationUser, object?>>
+            {
+                { "Name", user => user.DisplayName },
+                { "Email", user => user.Email },
+                { "Status", user => user.IsActive ? "Active" : "Inactive" },
+                { "Lockout Status", user => user.LockoutEnd != null && user.LockoutEnd > DateTimeOffset.UtcNow ? "Locked Out" : "Not Locked" },
+                { "Lockout End Date", user => user.LockoutEnd },
+                { "Last Login", user => user.LastLogin },
+                { "Tenant", user => user.TenantName },
+                { "Created Date", user => user.Created }
+            };
+
+            var results = await excelService.ExportAsync(users, dataToColumnMapper);
+
+            var uploadRequest = new UploadRequest(document.Title!, UploadType.Document, results);
+
+            var result = await uploadService.UploadAsync($"MyDocuments/{context.UserId}", uploadRequest);
+
+            if (result.Succeeded)
+            {
+                document
+                    .WithStatus(DocumentStatus.Available)
+                    .SetURL(result);
+            }
+            else
+            {
+                logger.LogError("Failed to upload users document {DocumentId}: {Errors}", context.DocumentId, string.Join(", ", result.Errors));
+                document.WithStatus(DocumentStatus.Error);
+            }
+
+            await domainEventDispatcher.DispatchEventsAsync(unitOfWork.DbContext, CancellationToken.None);
+            await unitOfWork.CommitTransactionAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error exporting users document {DocumentId}: {ErrorMessage}", context.DocumentId, ex.Message);
+            document.WithStatus(DocumentStatus.Error);
+            await unitOfWork.CommitTransactionAsync();
+        }
+    }
+}

--- a/src/Application/Features/Identity/Commands/ExportUsers.cs
+++ b/src/Application/Features/Identity/Commands/ExportUsers.cs
@@ -1,0 +1,70 @@
+using Cfo.Cats.Application.Common.Interfaces.Serialization;
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Validators;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Entities.Documents;
+using Humanizer;
+
+namespace Cfo.Cats.Application.Features.Identity.Commands;
+
+public static class ExportUsers
+{
+    [RequestAuthorize(Policy = SecurityPolicies.SystemFunctionsRead)]
+    public class Command : IRequest<Result>
+    {
+        public string? TenantId { get; init; }
+        public string? SearchString { get; init; }
+        public string? Role { get; init; }
+    }
+
+    private class Handler(IUnitOfWork unitOfWork, ICurrentUserService currentUserService, ISerializer serializer)
+        : IRequestHandler<Command, Result>
+    {
+        public async Task<Result> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var document = GeneratedDocument
+                .Create(DocumentTemplate.Users, 
+                    "Users Export.xlsx", 
+                    "Users Export",
+                    currentUserService.UserId!,
+                    currentUserService.TenantId!,
+                    searchCriteria: serializer.Serialize(request));
+            
+            await unitOfWork.DbContext.Documents.AddAsync(document, cancellationToken);
+
+            return Result.Success();
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly TimeSpan _cooldown = TimeSpan.FromSeconds(60);
+
+        public Validator(IUnitOfWork unitOfWork, ICurrentUserService currentUserService)
+        {
+            _unitOfWork = unitOfWork;
+            _currentUserService = currentUserService;
+
+            RuleSet(ValidationConstants.RuleSet.MediatR, () =>
+            {
+                RuleFor(c => c)
+                    .Must(WaitBeforeRequestingDocumentAgain)
+                    .WithMessage($"You must wait {_cooldown.Humanize()} between requesting this export.");
+            });
+        }
+
+        private bool WaitBeforeRequestingDocumentAgain(Command c)
+        {
+            var cooldownPeriod = DateTime.UtcNow - _cooldown;
+
+            var hasRecentlyRequestedDocument = _unitOfWork.DbContext.GeneratedDocuments
+                .Any(d => d.CreatedBy == _currentUserService.UserId && d.Created > cooldownPeriod
+                    && d.Template == DocumentTemplate.Users);
+
+            return hasRecentlyRequestedDocument is false;
+        }
+    }
+}
+

--- a/src/Domain/Entities/Documents/GeneratedDocument.cs
+++ b/src/Domain/Entities/Documents/GeneratedDocument.cs
@@ -77,5 +77,5 @@ public class DocumentTemplate : SmartEnum<DocumentTemplate>
     public static readonly DocumentTemplate OutcomeQualityDipSample = new(nameof(OutcomeQualityDipSample), 500);
     public static readonly DocumentTemplate Initiatives = new(nameof(Initiatives), 900);
     public static readonly DocumentTemplate InitiativeObjectivesDashboard = new(nameof(InitiativeObjectivesDashboard), 1300);
-
+    public static readonly DocumentTemplate Users = new(nameof(Users), 1400);
 }

--- a/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/DocumentsBackgroundService.cs
@@ -39,7 +39,8 @@ internal class DocumentsBackgroundService(IServiceProvider provider, IConfigurat
        _activator.Handle<DocumentExportPerformanceDashboardIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportInitiativeObjectivesDashboardIntegrationEventConsumer>(provider);
        _activator.Handle<DocumentExportInitiativesIntegrationEventConsumer>(provider);
-
+       _activator.Handle<DocumentExportUsersIntegrationEventConsumer>(provider);
+       
         _bus = Configure.With(_activator)
             .Transport(t => t.UseRabbitMq(configuration.GetConnectionString("rabbit"), options.Value.DocumentService)
                 .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange))

--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -1,20 +1,10 @@
 ﻿@page "/identity/users"
 
 @using Cfo.Cats.Application.Features.Identity.DTOs
-@using Cfo.Cats.Application.Features.Identity.Notifications.IdentityEvents
-@using Cfo.Cats.Domain.Identity
 @using Cfo.Cats.Server.UI.Pages.Identity.Roles.Components
-@using Cfo.Cats.Server.UI.Pages.Identity.Users.Components
 @using Cfo.Cats.Application.Common.Interfaces.Identity
 @using Cfo.Cats.Application.Common.Interfaces.MultiTenant
-@using Cfo.Cats.Application.SecurityConstants
-@using System.Security.Claims
-@using BlazorDownloadFile
-@using System.Linq.Expressions
-@using ActualLab.Fusion.Extensions
-@using AutoMapper.QueryableExtensions;
 @using Cfo.Cats.Infrastructure.Services
-@using Cfo.Cats.Infrastructure.Services.MultiTenant
 @using Cfo.Cats.Server.UI.Services.Fusion
 @using ZiggyCreatures.Caching.Fusion
 
@@ -25,13 +15,11 @@
 
 @inject IUsersStateContainer UsersStateContainer
 @inject IOnlineUserTracker OnlineUserTracker
-@inject IBlazorDownloadFileService BlazorDownloadFileService
 @inject IUserService UserService
 @inject ITenantService TenantsService
 @inject IFusionCache FusionCache;
-@inject IExcelService ExcelService
 @inject INetworkIpProvider NetworkIpProvider
-@inject IFusionCache cache;
+@inject IFusionCache Cache;
 
 @inject IStringLocalizer<Users> L
 @inject ILogger<Users> Logger
@@ -58,22 +46,22 @@
             <MudStack Row="true">
                 @if (_canSearch)
                 {
-                    <MudSelect T="string" ValueChanged="OnChangedListView" Value="@_selectedTenantId" Dense="false" Label="Tenant" Clearable="true"
+                    <MudSelect T="string" ValueChanged="@OnChangedListView" Value="@_selectedTenantId" Dense="false" Label="Tenant" Clearable="true"
                                Style="min-width: 300px;" Placeholder="Select a tenant">
-                        @foreach (var item in TenantsService.DataSource.Where(x => x.Id.StartsWith(CurrentUser!.TenantId!)).OrderBy(t => t.Id))
+                        @foreach (var item in TenantsService.DataSource.Where(x => x.Id.StartsWith(_currentUser!.TenantId!)).OrderBy(t => t.Id))
                         {
                             <MudSelectItem T="string" Value="@item.Id">
                                 @item.Name  
                             </MudSelectItem>
                         }
                     </MudSelect>
-                    <MudSelect T="string" Placeholder="Select a role" Value="@_searchRole" Clearable="true" ValueChanged="@(OnSearchRole)" Dense="false" Label="Role">
+                    <MudSelect T="string" Placeholder="Select a role" Value="@_searchRole" Clearable="true" ValueChanged="@OnSearchRole" Dense="false" Label="Role">
                         @foreach (var str in _roles.OrderBy(x => x.Name).Select(x => x.Name) )
                         {
                             <MudSelectItem Value="@str">@str</MudSelectItem>
                         }
                     </MudSelect>
-                    <MudTextField T="string" Immediate="false" ValueChanged="@(OnSearch)" Value="@_searchString" Placeholder="@ConstantString.Search" Adornment="Adornment.End" Label="Search"
+                    <MudTextField T="string" Immediate="false" ValueChanged="@OnSearch" Value="@_searchString" Placeholder="@ConstantString.Search" Adornment="Adornment.End" Label="Search"
                                   AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Small">
                     </MudTextField>
                 }
@@ -93,7 +81,7 @@
                                 Color="Color.Primary"
                                    StartIcon="@Icons.Material.Filled.Add"
                                    Size="Size.Small"
-                                   OnClick="OnCreate">
+                                   OnClick="@OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
@@ -165,7 +153,7 @@
             <PropertyColumn Property="x => x.UserName" Title="@L[_currentDto.GetMemberDescription(x => x.UserName)]">
                 <CellTemplate>
                     <div class="d-flex align-items-center">
-                        <MudBadge Color="@(IsOnline(context.Item.DisplayName??context.Item.UserName) ? Color.Success : Color.Error)" Overlap="false" Dot="true" Bordered="true">
+                        <MudBadge Color="@(IsOnline(context.Item.DisplayName) ? Color.Success : Color.Error)" Overlap="false" Dot="true" Bordered="true">
                             <MudAvatar>
                                 @if (string.IsNullOrEmpty(context.Item.ProfilePictureDataUrl))
                                 {
@@ -275,534 +263,9 @@
             </MudCard>
         </ChildRowContent>
         <PagerContent>
-            <MudDataGridPager PageSizeOptions="@(new[] { 10, 15, 30, 50, 100, 500, 1000 })"/>
+            <MudDataGridPager PageSizeOptions="@([10, 15, 30, 50, 100, 500, 1000])"/>
         </PagerContent>
     </MudDataGrid>
 }
 
 <PermissionsDrawer OnAssignAllChanged="OnAssignAllChangedHandler" Waiting="@_processing" OnOpenChanged="OnOpenChangedHandler" Open="_showPermissionsDrawer" Permissions="_permissions" OnAssignChanged="OnAssignChangedHandler"></PermissionsDrawer>
-
-
-@code {
-    [CascadingParameter] 
-    private Task<AuthenticationState> AuthState { get; set; } = default!;
-
-    private UserManager<ApplicationUser> UserManager = null!;
-    private RoleManager<ApplicationRole> RoleManager = null!;
-
-
-
-
-    [CascadingParameter] 
-    public UserProfile UserProfile { get; set; } = default!;
-
-    private ApplicationUser? CurrentUser = default;
-    private IEnumerable<string> CurrentRoles = [];
-
-    private int _defaultPageSize = 15;
-    private readonly ApplicationUserDto _currentDto = new();
-    private string _searchString = string.Empty;
-    private string? _selectedTenantId = null;
-    private string Title { get; set; } = "Users";
-    private List<PermissionModel> _permissions = new();
-    private IList<Claim> _assignedClaims = default!;
-
-    private TimeSpan RefreshInterval => TimeSpan.FromHours(2);
-
-    private MudDataGrid<ApplicationUserDto> _table = null!;
-    private bool _initialised;
-    private bool _processing;
-    private bool _showPermissionsDrawer;
-    private bool _canCreate;
-    private bool _canSearch;
-    private bool _canEdit;
-    private bool _canArchive;
-    private bool _canToggleActiveStatus;
-    private bool _canUnlock;
-    private bool _canManageRoles;
-    private bool _canResetPassword;
-    private bool _canManagePermissions;
-    private bool _loading;
-    private List<ApplicationRoleDto> _roles = new();
-    private string? _searchRole;
-    private Dictionary<string, bool>? policies;
-
-    protected override async Task OnInitializedAsync()
-    {
-        _initialised = false;
-
-        Title = L[_currentDto.GetClassDescription()];
-        RoleManager = ScopedServices.GetRequiredService<RoleManager<ApplicationRole>>();
-        UserManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
-
-        var state = await AuthState;
-        CurrentUser = await UserManager.GetUserAsync(state.User);
-        CurrentRoles = await UserManager.GetRolesAsync(CurrentUser!);
-
-        policies ??= new()
-        {
-            { SecurityPolicies.SystemFunctionsWrite, (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.SystemFunctionsWrite)).Succeeded }
-        };
-
-        _canCreate = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canSearch = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canEdit = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canArchive = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canToggleActiveStatus = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canUnlock = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canManageRoles = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canResetPassword = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-        _canManagePermissions = policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
-
-        _roles = await RoleManager.Roles
-            .ProjectTo<ApplicationRoleDto>(Mapper.ConfigurationProvider)
-            .ToListAsync();
-
-        _initialised = true;
-    }
-
-    private bool CanResetPassword(string[] affectedUserRoles)
-    {
-        if(affectedUserRoles is { Length: 0 })
-        {
-            return _canResetPassword;
-        }
-
-        var userRole = _roles.Where(role => affectedUserRoles.Contains(role.Name)).MinBy(role => role.RoleRank);
-        var currentUserRole = _roles.Where(role => CurrentRoles.Contains(role.Name)).MinBy(role => role.RoleRank);
-        return _canResetPassword && currentUserRole?.RoleRank <= userRole?.RoleRank;
-    }
-
-    private bool IsOnline(string username)
-    {
-        return UsersStateContainer.UsersByConnectionId.Any(x => x.Value.Equals(username, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private Expression<Func<ApplicationUser, bool>> CreateSearchPredicate()
-    {
-        return x =>
-            (x.UserName!.Contains(_searchString) || x.Email!.Contains(_searchString) || x.DisplayName!.Contains(_searchString) || x.PhoneNumber!.Contains(_searchString)) 
-            && (_searchRole == null || (_searchRole != null && x.UserRoles.Any(x => x.Role.Name == _searchRole))) 
-            && (_selectedTenantId == null || (_selectedTenantId != null && x.TenantId == _selectedTenantId));
-    }
-
-    private async Task<GridData<ApplicationUserDto>> ServerReload(GridState<ApplicationUserDto> state, CancellationToken cancellationToken)
-    {
-        try
-        {
-            _loading = true;
-
-            if (state.SortDefinitions.Count == 0)
-            { 
-                state.SortDefinitions.Add(new SortDefinition<ApplicationUserDto>("Email", false, 1, x => x.Email));
-            }
-
-            var query = UserManager.Users.Where(CreateSearchPredicate()) ;
-            var items = await query
-                .Where(x => x.TenantId!.StartsWith(CurrentUser!.TenantId!))
-                .Include(x => x.UserRoles)
-                .Include(x => x.Superior)                
-                .EfOrderBySortDefinitions(state)
-                .Skip(state.Page * state.PageSize).Take(state.PageSize)
-                .ProjectTo<ApplicationUserDto>(Mapper.ConfigurationProvider).ToListAsync();
-            var total = await UserManager.Users.CountAsync(CreateSearchPredicate());
-            return new GridData<ApplicationUserDto> { TotalItems = total, Items = items };
-        }
-        finally
-        {
-            _loading = false;
-        }
-    }
-
-    private async Task OnChangedListView(string tenantId)
-    {
-        _selectedTenantId = tenantId;
-        await _table.ReloadServerData();
-    }
-
-    private async Task OnSearch(string text)
-    {
-        if (_loading)
-        {
-            return;
-        }
-        _searchString = text.ToLower();
-        await _table.ReloadServerData();
-    }
-
-    private async Task OnSearchRole(string role)
-    {
-        if (_loading)
-        {
-            return;
-        }
-        _searchRole = role;
-        await _table.ReloadServerData();
-    }
-
-    private async Task OnRefresh()
-    {
-        TenantsService.Refresh();
-        await _table.ReloadServerData();
-    }
-
-    private async Task ShowCreateUserDialog(ApplicationUserDto model, string title)
-    {
-        var parameters = new DialogParameters<UserFormDialog>
-        {
-            { x => x.Model, model }
-        };
-        var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
-        var dialog = await DialogService.ShowAsync<UserFormDialog>(title, parameters, options);
-        var result = await dialog.Result;
-
-        if (!result!.Canceled)
-        {
-            await ProcessUserCreation(model);
-        }
-        else
-        {
-            await OnRefresh();
-        }
-    }
-
-    private async Task ShowIdentityAuditDialog(ApplicationUserDto model, string title)
-    {
-        var parameters = new DialogParameters<UserAuditDialog>
-        {
-            { x => x.UserName, model.UserName }
-        };
-        var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Large, FullWidth = true };
-        await DialogService.ShowAsync<UserAuditDialog>(title, parameters, options);
-    }
-
-    private async Task ShowEditUserDialog(ApplicationUserDto model, string title)
-    {
-        var parameters = new DialogParameters<UserFormDialog>
-        {
-            { x => x.Model, model }
-        };
-        var options = new DialogOptions { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
-        var dialog = await DialogService.ShowAsync<UserFormDialog>(title, parameters, options);
-        var result = await dialog.Result;
-
-        if (!result!.Canceled)
-        {
-            await ProcessUserUpdate(model);
-        }
-        else
-        {
-            await OnRefresh();
-        }
-    }
-
-    private async Task ProcessUserCreation(ApplicationUserDto model)
-    {
-        var applicationUser = Mapper.Map<ApplicationUser>(model);
-        applicationUser.EmailConfirmed = true;
-        applicationUser.IsActive = true;
-        applicationUser.TwoFactorEnabled = true;
-        applicationUser.PhoneNumberConfirmed = string.IsNullOrWhiteSpace(applicationUser.PhoneNumber) == false;
-
-        var identityResult = await UserManager.CreateAsync(applicationUser);
-        if (!identityResult.Succeeded)
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-            return;
-        }
-
-        Snackbar.Add($"{L["New user created successfully."]}", Severity.Info);
-        await AssignRolesToUser(applicationUser, model.AssignedRoles);
-
-        Logger.LogInformation("Create a user succeeded. Username: {@UserName:l}, UserId: {@UserId}", applicationUser.UserName, applicationUser.Id);
-        UserService.Refresh();
-        await OnRefresh();
-    }
-
-    private async Task ProcessUserUpdate(ApplicationUserDto model)
-    {
-        var user = await UserManager.FindByIdAsync(model.Id!) ?? throw new NotFoundException($"The application user [{model.Id}] was not found.");
-        var state = await AuthState;
-
-        Mapper.Map(model, user);
-
-        user.PhoneNumberConfirmed = string.IsNullOrWhiteSpace(user.PhoneNumber) == false;
-
-        var identityResult = await UserManager.UpdateAsync(user);
-        if (identityResult.Succeeded)
-        {
-            var roles = await UserManager.GetRolesAsync(user!);
-            if (roles.Count > 0)
-            {
-                await UserManager.RemoveFromRolesAsync(user, roles);
-            }
-
-            if (model.AssignedRoles is not null && model.AssignedRoles.Length > 0)
-            {
-                await UserManager.AddToRolesAsync(user, model.AssignedRoles);
-            }
-
-            Snackbar.Add($"{L["The user updated successfully."]}", Severity.Info);
-            await OnRefresh();
-            UserService.Refresh();
-
-            var userInfo = new UserInfo(
-                model.Id,
-                model.UserName,
-                model.Email,
-                model.DisplayName ?? string.Empty,
-                model.ProfilePictureDataUrl ?? string.Empty,
-                model.SuperiorName ?? string.Empty,
-                model.SuperiorId ?? string.Empty,
-                model.TenantId ?? string.Empty,
-                model.TenantName ?? string.Empty,
-                model.PhoneNumber,
-                model.AssignedRoles ?? Array.Empty<string>(),
-                UserPresence.Available);
-
-            await OnlineUserTracker.UpdateUser(userInfo);
-
-            await cache.RemoveAsync(ApplicationUserClaimsPrincipalFactory.GetCacheKey(user.Id));
-
-
-        }
-        else
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-        }
-    }
-
-    private async Task AssignRolesToUser(ApplicationUser user, string[]? roles)
-    {
-        if (roles is not null && roles.Length > 0)
-        {
-            await UserManager.AddToRolesAsync(user, roles);
-        }
-    }
-
-    private async Task OnCreate()
-    {
-        var model = new ApplicationUserDto { AssignedRoles = [] };
-        await ShowCreateUserDialog(model, L["Create a new user"]);
-    }
-
-    private async Task OnEdit(ApplicationUserDto item)
-    {
-        await ShowEditUserDialog(item, L["Edit the user"]);
-    }
-
-    private async Task OnUnlock(ApplicationUserDto item)
-    {
-        var user = await UserManager.FindByIdAsync(item.Id!) ?? throw new NotFoundException($"Application user not found {item.Id}.");
-
-        user.LockoutEnd = null;
-        var identityResult = await UserManager.UpdateAsync(user);
-
-        if (identityResult.Succeeded)
-        {
-            item.LockoutEnd = null;
-            Snackbar.Add($"{L["The user has been unlocked."]}", Severity.Info);
-        }
-        else
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-        }
-    }
-
-    private async Task OnLock(ApplicationUserDto item)
-    {
-        var user = await UserManager.FindByIdAsync(item.Id!) ?? throw new NotFoundException($"Application user not found {item.Id}.");
-
-        user.LockoutEnd = DateTimeOffset.MaxValue;
-        var identityResult = await UserManager.UpdateAsync(user);
-
-        if (identityResult.Succeeded)
-        {
-            item.LockoutEnd = DateTimeOffset.MaxValue;
-            Snackbar.Add($"{L["The user has been locked."]}", Severity.Info);
-        }
-        else
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-        }
-    }
-
-    private async Task OnSetActive(ApplicationUserDto item)
-    {
-        var user = await UserManager.FindByIdAsync(item.Id!) ?? throw new NotFoundException($"Application user not found {item.Id}.");
-        await ToggleUserActiveState(user, item);
-    }
-
-    private async Task ToggleUserActiveState(ApplicationUser user, ApplicationUserDto item)
-    {
-        var mediator = GetNewMediator();
-        if (user.IsActive)
-        {
-            await DeactivateUser(user, item);
-            await mediator.Publish(IdentityAuditNotification.DeactivateAccount(item.UserName, NetworkIpProvider.IpAddress, CurrentUser!.UserName!));
-        }
-        else
-        {
-            await ActivateUser(user, item);
-            await mediator.Publish(IdentityAuditNotification.ActivateAccount(item.UserName, NetworkIpProvider.IpAddress , CurrentUser!.UserName!));
-        }
-    }
-
-    private async Task ActivateUser(ApplicationUser user, ApplicationUserDto item)
-    {
-        user.IsActive = true;
-        user.EmailConfirmed = true;
-        user.LockoutEnd = null;
-        var identityResult = await UserManager.UpdateAsync(user);
-
-        if (identityResult.Succeeded)
-        {
-            item.IsActive = true;
-            item.LockoutEnd = null;
-            Snackbar.Add($"{L["The user has been activated."]}", Severity.Info);
-        }
-        else
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-        }
-    }
-
-    private async Task DeactivateUser(ApplicationUser user, ApplicationUserDto item)
-    {
-        user.IsActive = false;
-        user.LockoutEnd = DateTimeOffset.MaxValue;
-        var identityResult = await UserManager.UpdateAsync(user);
-
-        if (identityResult.Succeeded)
-        {
-            item.IsActive = false;
-            item.LockoutEnd = DateTimeOffset.MaxValue;
-            Snackbar.Add($"{L["The user has been deactivated."]}", Severity.Info);
-        }
-        else
-        {
-            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}", Severity.Error);
-        }
-    }
-
-    private async Task OnResetPassword(ApplicationUserDto item)
-    {
-        var model = new ResetPasswordFormModel { UserId = item.Id };
-        
-        var parameters = new DialogParameters<ResetPasswordDialog>
-        {
-            { x => x.Model, model }
-        };
-
-        var options = new DialogOptions { CloseOnEscapeKey = true, CloseButton = true, MaxWidth = MaxWidth.Small };
-        var dialog = await DialogService.ShowAsync<ResetPasswordDialog>(L[$"Reset Password for {item.DisplayName}"], parameters, options);
-
-        var result = await dialog.Result;
-
-        if (!result!.Canceled)
-        {
-            await GetNewMediator().Publish(IdentityAuditNotification.PasswordReset(item.UserName, NetworkIpProvider.IpAddress, UserProfile.Email));
-            Snackbar.Add($"{L["Reset password successfully"]}", Severity.Info);
-        }
-    }
-
-    private Task OnOpenChangedHandler(bool state)
-    {
-        _showPermissionsDrawer = state;
-        return Task.CompletedTask;
-    }
-
-    private async Task<IList<Claim>> GetUserClaims(string userId)
-    {
-        var key = $"get-claims-by-{userId}";
-        return await FusionCache.GetOrSetAsync(key, async _ =>
-        {
-            var user = await UserManager.FindByIdAsync(userId) ?? throw new NotFoundException($"not found application user: {userId}");
-            return await UserManager.GetClaimsAsync(user);
-        }, RefreshInterval);
-    }
-
-    private async Task OnAssignAllChangedHandler(List<PermissionModel> models)
-    {
-        try
-        {
-            _processing = true;
-            var userId = models.First().UserId;
-            var user = await UserManager.FindByIdAsync(userId!) ?? throw new NotFoundException($"not found application user: {userId}");
-
-            foreach (var model in models)
-            {
-                await ProcessPermissionChange(user, model);
-            }
-
-            Snackbar.Add($"{L["Authorization has been changed"]}", Severity.Info);
-            await ClearClaimsCache(user.Id);
-        }
-        finally
-        {
-            _processing = false;
-        }
-    }
-
-    private async Task ProcessPermissionChange(ApplicationUser user, PermissionModel model)
-    {
-        if (model.Assigned)
-        {
-            if (model.ClaimType is not null && model.ClaimValue is not null)
-            {
-                await UserManager.AddClaimAsync(user, new Claim(model.ClaimType, model.ClaimValue));
-            }
-        }
-        else
-        {
-            var removed = _assignedClaims.FirstOrDefault(x => x.Value == model.ClaimValue);
-            if (removed is not null)
-            {
-                await UserManager.RemoveClaimAsync(user, removed);
-            }
-        }
-    }
-
-    private async Task ClearClaimsCache(string userId)
-    {
-        var key = $"get-claims-by-{userId}";
-        FusionCache.Remove(key);
-        await Task.Delay(300);
-    }
-
-    private async Task OnAssignChangedHandler(PermissionModel model)
-    {
-        try
-        {
-            _processing = true;
-            var userId = model.UserId!;
-            var user = await UserManager.FindByIdAsync(userId) ?? throw new NotFoundException($"Application user Not Found {userId}.");
-
-            model.Assigned = !model.Assigned;
-            if (model.Assigned)
-            {
-                if (model.ClaimType is not null && model.ClaimValue is not null)
-                {
-                    await UserManager.AddClaimAsync(user, new Claim(model.ClaimType, model.ClaimValue));
-                    Snackbar.Add($"{L["Permission assigned successfully"]}", Severity.Info);
-                }
-            }
-            else
-            {
-                var removed = _assignedClaims.FirstOrDefault(x => x.Value == model.ClaimValue);
-                if (removed is not null)
-                {
-                    await UserManager.RemoveClaimAsync(user, removed);
-                }
-
-                Snackbar.Add($"{L["Permission removed successfully"]}", Severity.Info);
-            }
-
-            await ClearClaimsCache(user.Id);
-        }
-        finally
-        {
-            _processing = false;
-        }
-    }
-}

--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -8,7 +8,6 @@
 @using Cfo.Cats.Server.UI.Services.Fusion
 @using ZiggyCreatures.Caching.Fusion
 
-
 @attribute [Authorize(Policy = SecurityPolicies.SystemFunctionsRead)]
 @inherits CatsComponentBase
 @implements IDisposable
@@ -70,11 +69,23 @@
                      <MudButton Variant="Variant.Filled"
                                Size="Size.Small"
                                Disabled="@_loading"
-                               OnClick="@(OnRefresh)"
+                               OnClick="@OnRefresh"
                                StartIcon="@Icons.Material.Filled.Refresh" 
                                Color="Color.Secondary">
                         @ConstantString.Refresh
                     </MudButton>
+                    @if (_canSearch)
+                    {
+                        <MudLoadingButton 
+                            Loading="@_downloading"
+                            Variant="Variant.Filled"
+                            Color="Color.Secondary"
+                            StartIcon="@Icons.Material.Filled.CloudDownload"
+                            Size="Size.Small"
+                            OnClick="@OnExport">
+                            @ConstantString.Export
+                        </MudLoadingButton>
+                    }
                     @if (_canCreate)
                     {
                         <MudButton Variant="Variant.Filled" 

--- a/src/Server.UI/Pages/Identity/Users/Users.razor.cs
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor.cs
@@ -1,0 +1,525 @@
+using System.Linq.Expressions;
+using System.Security.Claims;
+using Cfo.Cats.Application.Common.Exceptions;
+using Cfo.Cats.Application.Common.Extensions;
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Features.Identity.DTOs;
+using Cfo.Cats.Application.Features.Identity.Notifications.IdentityEvents;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Domain.Identity;
+using Cfo.Cats.Infrastructure.Services;
+using Cfo.Cats.Server.UI.Extensions;
+using Cfo.Cats.Server.UI.Pages.Identity.Users.Components;
+using Cfo.Cats.Server.UI.Services.Fusion;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cfo.Cats.Server.UI.Pages.Identity.Users;
+
+public partial class Users
+{
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = null!;
+
+    private UserManager<ApplicationUser> _userManager = null!;
+    private RoleManager<ApplicationRole> _roleManager = null!;
+
+    [CascadingParameter] public UserProfile UserProfile { get; set; } = null!;
+
+    private ApplicationUser? _currentUser;
+    private IEnumerable<string> _currentRoles = [];
+    private int _defaultPageSize = 15;
+    private readonly ApplicationUserDto _currentDto = new();
+    private string _searchString = string.Empty;
+    private string? _selectedTenantId;
+    private string Title { get; set; } = "Users";
+    private readonly List<PermissionModel> _permissions = new();
+    private readonly IList<Claim> _assignedClaims = null!;
+    private MudDataGrid<ApplicationUserDto> _table = null!;
+    private bool _initialised;
+    private bool _processing;
+    private bool _showPermissionsDrawer;
+    private bool _canCreate;
+    private bool _canSearch;
+    private bool _canEdit;
+    private bool _canArchive;
+    private bool _canToggleActiveStatus;
+    private bool _canUnlock;
+    private bool _canManageRoles;
+    private bool _canResetPassword;
+    private bool _canManagePermissions;
+    private bool _loading;
+    private List<ApplicationRoleDto> _roles = new();
+    private string? _searchRole;
+    private Dictionary<string, bool>? _policies;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _initialised = false;
+
+        Title = L[_currentDto.GetClassDescription()];
+        _roleManager = ScopedServices.GetRequiredService<RoleManager<ApplicationRole>>();
+        _userManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var state = await AuthState;
+        _currentUser = await _userManager.GetUserAsync(state.User);
+        _currentRoles = await _userManager.GetRolesAsync(_currentUser!);
+
+        _policies ??= new()
+        {
+            {
+                SecurityPolicies.SystemFunctionsWrite,
+                (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.SystemFunctionsWrite)).Succeeded
+            }
+        };
+
+        _canCreate = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canSearch = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canEdit = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canArchive = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canToggleActiveStatus = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canUnlock = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canManageRoles = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canResetPassword = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+        _canManagePermissions = _policies.GetValueOrDefault(SecurityPolicies.SystemFunctionsWrite);
+
+        _roles = await _roleManager.Roles
+            .ProjectTo<ApplicationRoleDto>(Mapper.ConfigurationProvider)
+            .ToListAsync();
+
+        _initialised = true;
+    }
+
+    private bool CanResetPassword(string[] affectedUserRoles)
+    {
+        if (affectedUserRoles is { Length: 0 })
+        {
+            return _canResetPassword;
+        }
+
+        var userRole = _roles.Where(role => affectedUserRoles.Contains(role.Name)).MinBy(role => role.RoleRank);
+        var currentUserRole = _roles.Where(role => _currentRoles.Contains(role.Name)).MinBy(role => role.RoleRank);
+        return _canResetPassword && currentUserRole?.RoleRank <= userRole?.RoleRank;
+    }
+
+    private bool IsOnline(string username) => UsersStateContainer.UsersByConnectionId.Any(x =>
+                                                       x.Value.Equals(username, StringComparison.OrdinalIgnoreCase));
+
+    private Expression<Func<ApplicationUser, bool>> CreateSearchPredicate() =>
+        x =>
+            (x.UserName!.Contains(_searchString) || x.Email!.Contains(_searchString) ||
+             x.DisplayName!.Contains(_searchString) || x.PhoneNumber!.Contains(_searchString))
+            && (_searchRole == null ||
+                (_searchRole != null && x.UserRoles.Any(userRole => userRole.Role.Name == _searchRole)))
+            && (_selectedTenantId == null || (_selectedTenantId != null && x.TenantId == _selectedTenantId));
+
+    private async Task<GridData<ApplicationUserDto>> ServerReload(GridState<ApplicationUserDto> state,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            _loading = true;
+
+            if (state.SortDefinitions.Count == 0)
+            {
+                state.SortDefinitions.Add(new SortDefinition<ApplicationUserDto>("Email", false, 1, x => x.Email));
+            }
+
+            var query = _userManager.Users.Where(CreateSearchPredicate());
+            var items = await query
+                .Where(x => x.TenantId!.StartsWith(_currentUser!.TenantId!))
+                .Include(x => x.UserRoles)
+                .Include(x => x.Superior)
+                .EfOrderBySortDefinitions(state)
+                .Skip(state.Page * state.PageSize).Take(state.PageSize)
+                .ProjectTo<ApplicationUserDto>(Mapper.ConfigurationProvider).ToListAsync(cancellationToken);
+            var total = await _userManager.Users.CountAsync(CreateSearchPredicate(), cancellationToken);
+            return new GridData<ApplicationUserDto> { TotalItems = total, Items = items };
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task OnChangedListView(string tenantId)
+    {
+        _selectedTenantId = tenantId;
+        await _table.ReloadServerData();
+    }
+
+    private async Task OnSearch(string text)
+    {
+        if (_loading)
+        {
+            return;
+        }
+
+        _searchString = text.ToLower();
+        await _table.ReloadServerData();
+    }
+
+    private async Task OnSearchRole(string role)
+    {
+        if (_loading)
+        {
+            return;
+        }
+
+        _searchRole = role;
+        await _table.ReloadServerData();
+    }
+
+    private async Task OnRefresh()
+    {
+        TenantsService.Refresh();
+        await _table.ReloadServerData();
+    }
+
+    private async Task ShowCreateUserDialog(ApplicationUserDto model, string title)
+    {
+        var parameters = new DialogParameters<UserFormDialog>
+        {
+            { x => x.Model, model }
+        };
+        var options = new DialogOptions
+            { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<UserFormDialog>(title, parameters, options);
+        var result = await dialog.Result;
+
+        if (!result!.Canceled)
+        {
+            await ProcessUserCreation(model);
+        }
+        else
+        {
+            await OnRefresh();
+        }
+    }
+
+    private async Task ShowIdentityAuditDialog(ApplicationUserDto model, string title)
+    {
+        var parameters = new DialogParameters<UserAuditDialog>
+        {
+            { x => x.UserName, model.UserName }
+        };
+        var options = new DialogOptions
+            { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Large, FullWidth = true };
+        await DialogService.ShowAsync<UserAuditDialog>(title, parameters, options);
+    }
+
+    private async Task ShowEditUserDialog(ApplicationUserDto model, string title)
+    {
+        var parameters = new DialogParameters<UserFormDialog>
+        {
+            { x => x.Model, model }
+        };
+        var options = new DialogOptions
+            { CloseButton = true, CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<UserFormDialog>(title, parameters, options);
+        var result = await dialog.Result;
+
+        if (!result!.Canceled)
+        {
+            await ProcessUserUpdate(model);
+        }
+        else
+        {
+            await OnRefresh();
+        }
+    }
+
+    private async Task ProcessUserCreation(ApplicationUserDto model)
+    {
+        var applicationUser = Mapper.Map<ApplicationUser>(model);
+        applicationUser.EmailConfirmed = true;
+        applicationUser.IsActive = true;
+        applicationUser.TwoFactorEnabled = true;
+        applicationUser.PhoneNumberConfirmed = string.IsNullOrWhiteSpace(applicationUser.PhoneNumber) == false;
+
+        var identityResult = await _userManager.CreateAsync(applicationUser);
+        if (!identityResult.Succeeded)
+        {
+            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}",
+                Severity.Error);
+            return;
+        }
+
+        Snackbar.Add($"{L["New user created successfully."]}", Severity.Info);
+        await AssignRolesToUser(applicationUser, model.AssignedRoles);
+
+        Logger.LogInformation("Create a user succeeded. Username: {@UserName:l}, UserId: {@UserId}",
+            applicationUser.UserName, applicationUser.Id);
+        UserService.Refresh();
+        await OnRefresh();
+    }
+
+    private async Task ProcessUserUpdate(ApplicationUserDto model)
+    {
+        var user = await _userManager.FindByIdAsync(model.Id) ??
+                   throw new NotFoundException($"The application user [{model.Id}] was not found.");
+
+        Mapper.Map(model, user);
+
+        user.PhoneNumberConfirmed = string.IsNullOrWhiteSpace(user.PhoneNumber) == false;
+
+        var identityResult = await _userManager.UpdateAsync(user);
+        if (identityResult.Succeeded)
+        {
+            var roles = await _userManager.GetRolesAsync(user);
+            if (roles.Count > 0)
+            {
+                await _userManager.RemoveFromRolesAsync(user, roles);
+            }
+
+            if (model.AssignedRoles.Length > 0)
+            {
+                await _userManager.AddToRolesAsync(user, model.AssignedRoles);
+            }
+
+            Snackbar.Add($"{L["The user updated successfully."]}", Severity.Info);
+            await OnRefresh();
+            UserService.Refresh();
+
+            var userInfo = new UserInfo(
+                model.Id,
+                model.UserName,
+                model.Email,
+                model.DisplayName,
+                model.ProfilePictureDataUrl ?? string.Empty,
+                model.SuperiorName ?? string.Empty,
+                model.SuperiorId ?? string.Empty,
+                model.TenantId ?? string.Empty,
+                model.TenantName ?? string.Empty,
+                model.PhoneNumber,
+                model.AssignedRoles,
+                UserPresence.Available);
+
+            await OnlineUserTracker.UpdateUser(userInfo);
+
+            await Cache.RemoveAsync(ApplicationUserClaimsPrincipalFactory.GetCacheKey(user.Id));
+        }
+        else
+        {
+            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}",
+                Severity.Error);
+        }
+    }
+
+    private async Task AssignRolesToUser(ApplicationUser user, string[]? roles)
+    {
+        if (roles is not null && roles.Length > 0)
+        {
+            await _userManager.AddToRolesAsync(user, roles);
+        }
+    }
+
+    private async Task OnCreate()
+    {
+        var model = new ApplicationUserDto { AssignedRoles = [] };
+        await ShowCreateUserDialog(model, L["Create a new user"]);
+    }
+
+    private async Task OnEdit(ApplicationUserDto item) => await ShowEditUserDialog(item, L["Edit the user"]);
+
+    private async Task OnUnlock(ApplicationUserDto item)
+    {
+        var user = await _userManager.FindByIdAsync(item.Id) ??
+                   throw new NotFoundException($"Application user not found {item.Id}.");
+
+        user.LockoutEnd = null;
+        var identityResult = await _userManager.UpdateAsync(user);
+
+        if (identityResult.Succeeded)
+        {
+            item.LockoutEnd = null;
+            Snackbar.Add($"{L["The user has been unlocked."]}", Severity.Info);
+        }
+        else
+        {
+            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}",
+                Severity.Error);
+        }
+    }
+
+    private async Task OnSetActive(ApplicationUserDto item)
+    {
+        var user = await _userManager.FindByIdAsync(item.Id) ??
+                   throw new NotFoundException($"Application user not found {item.Id}.");
+        await ToggleUserActiveState(user, item);
+    }
+
+    private async Task ToggleUserActiveState(ApplicationUser user, ApplicationUserDto item)
+    {
+        var mediator = GetNewMediator();
+        if (user.IsActive)
+        {
+            await DeactivateUser(user, item);
+            await mediator.Publish(IdentityAuditNotification.DeactivateAccount(item.UserName,
+                NetworkIpProvider.IpAddress, _currentUser!.UserName!));
+        }
+        else
+        {
+            await ActivateUser(user, item);
+            await mediator.Publish(IdentityAuditNotification.ActivateAccount(item.UserName, NetworkIpProvider.IpAddress,
+                _currentUser!.UserName!));
+        }
+    }
+
+    private async Task ActivateUser(ApplicationUser user, ApplicationUserDto item)
+    {
+        user.IsActive = true;
+        user.EmailConfirmed = true;
+        user.LockoutEnd = null;
+        var identityResult = await _userManager.UpdateAsync(user);
+
+        if (identityResult.Succeeded)
+        {
+            item.IsActive = true;
+            item.LockoutEnd = null;
+            Snackbar.Add($"{L["The user has been activated."]}", Severity.Info);
+        }
+        else
+        {
+            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}",
+                Severity.Error);
+        }
+    }
+
+    private async Task DeactivateUser(ApplicationUser user, ApplicationUserDto item)
+    {
+        user.IsActive = false;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+        var identityResult = await _userManager.UpdateAsync(user);
+
+        if (identityResult.Succeeded)
+        {
+            item.IsActive = false;
+            item.LockoutEnd = DateTimeOffset.MaxValue;
+            Snackbar.Add($"{L["The user has been deactivated."]}", Severity.Info);
+        }
+        else
+        {
+            Snackbar.Add($"{string.Join(",", identityResult.Errors.Select(x => x.Description).ToArray())}",
+                Severity.Error);
+        }
+    }
+
+    private async Task OnResetPassword(ApplicationUserDto item)
+    {
+        var model = new ResetPasswordFormModel { UserId = item.Id };
+
+        var parameters = new DialogParameters<ResetPasswordDialog>
+        {
+            { x => x.Model, model }
+        };
+
+        var options = new DialogOptions { CloseOnEscapeKey = true, CloseButton = true, MaxWidth = MaxWidth.Small };
+        var dialog =
+            await DialogService.ShowAsync<ResetPasswordDialog>(L[$"Reset Password for {item.DisplayName}"], parameters,
+                options);
+
+        var result = await dialog.Result;
+
+        if (!result!.Canceled)
+        {
+            await GetNewMediator()
+                .Publish(IdentityAuditNotification.PasswordReset(item.UserName, NetworkIpProvider.IpAddress,
+                    UserProfile.Email));
+            Snackbar.Add($"{L["Reset password successfully"]}", Severity.Info);
+        }
+    }
+
+    private Task OnOpenChangedHandler(bool state)
+    {
+        _showPermissionsDrawer = state;
+        return Task.CompletedTask;
+    }
+
+    private async Task OnAssignAllChangedHandler(List<PermissionModel> models)
+    {
+        try
+        {
+            _processing = true;
+            var userId = models.First().UserId;
+            var user = await _userManager.FindByIdAsync(userId!) ??
+                       throw new NotFoundException($"not found application user: {userId}");
+
+            foreach (var model in models)
+            {
+                await ProcessPermissionChange(user, model);
+            }
+
+            Snackbar.Add($"{L["Authorization has been changed"]}", Severity.Info);
+            await ClearClaimsCache(user.Id);
+        }
+        finally
+        {
+            _processing = false;
+        }
+    }
+
+    private async Task ProcessPermissionChange(ApplicationUser user, PermissionModel model)
+    {
+        if (model.Assigned)
+        {
+            if (model.ClaimType is not null)
+            {
+                await _userManager.AddClaimAsync(user, new Claim(model.ClaimType, model.ClaimValue));
+            }
+        }
+        else
+        {
+            var removed = _assignedClaims.FirstOrDefault(x => x.Value == model.ClaimValue);
+            if (removed is not null)
+            {
+                await _userManager.RemoveClaimAsync(user, removed);
+            }
+        }
+    }
+
+    private async Task ClearClaimsCache(string userId)
+    {
+        var key = $"get-claims-by-{userId}";
+        FusionCache.Remove(key);
+        await Task.Delay(300);
+    }
+
+    private async Task OnAssignChangedHandler(PermissionModel model)
+    {
+        try
+        {
+            _processing = true;
+            var userId = model.UserId!;
+            var user = await _userManager.FindByIdAsync(userId) ??
+                       throw new NotFoundException($"Application user Not Found {userId}.");
+
+            model.Assigned = !model.Assigned;
+            if (model.Assigned)
+            {
+                if (model.ClaimType is not null)
+                {
+                    await _userManager.AddClaimAsync(user, new Claim(model.ClaimType, model.ClaimValue));
+                    Snackbar.Add($"{L["Permission assigned successfully"]}", Severity.Info);
+                }
+            }
+            else
+            {
+                var removed = _assignedClaims.FirstOrDefault(x => x.Value == model.ClaimValue);
+                if (removed is not null)
+                {
+                    await _userManager.RemoveClaimAsync(user, removed);
+                }
+
+                Snackbar.Add($"{L["Permission removed successfully"]}", Severity.Info);
+            }
+
+            await ClearClaimsCache(user.Id);
+        }
+        finally
+        {
+            _processing = false;
+        }
+    }
+}

--- a/src/Server.UI/Pages/Identity/Users/Users.razor.cs
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor.cs
@@ -7,6 +7,7 @@ using Cfo.Cats.Application.Features.Identity.DTOs;
 using Cfo.Cats.Application.Features.Identity.Notifications.IdentityEvents;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Domain.Identity;
+using Cfo.Cats.Infrastructure.Constants;
 using Cfo.Cats.Infrastructure.Services;
 using Cfo.Cats.Server.UI.Extensions;
 using Cfo.Cats.Server.UI.Pages.Identity.Users.Components;
@@ -50,6 +51,7 @@ public partial class Users
     private bool _canResetPassword;
     private bool _canManagePermissions;
     private bool _loading;
+    private bool _downloading;
     private List<ApplicationRoleDto> _roles = new();
     private string? _searchRole;
     private Dictionary<string, bool>? _policies;
@@ -143,24 +145,24 @@ public partial class Users
         }
     }
 
-    private async Task OnChangedListView(string tenantId)
+    private async Task OnChangedListView(string? tenantId)
     {
         _selectedTenantId = tenantId;
         await _table.ReloadServerData();
     }
 
-    private async Task OnSearch(string text)
+    private async Task OnSearch(string? text)
     {
         if (_loading)
         {
             return;
         }
 
-        _searchString = text.ToLower();
+        _searchString = text!.ToLower();
         await _table.ReloadServerData();
     }
 
-    private async Task OnSearchRole(string role)
+    private async Task OnSearchRole(string? role)
     {
         if (_loading)
         {
@@ -175,6 +177,36 @@ public partial class Users
     {
         TenantsService.Refresh();
         await _table.ReloadServerData();
+    }
+
+    private async Task OnExport()
+    {
+        try
+        {
+            _downloading = true;
+            var result = await GetNewMediator().Send(new Application.Features.Identity.Commands.ExportUsers.Command()
+            {
+                TenantId = _selectedTenantId,
+                SearchString = _searchString,
+                Role = _searchRole
+            });
+
+            if (result.Succeeded)
+            {
+                Snackbar.Add($"{ConstantString.ExportSuccess}", Severity.Info);
+                return;
+            }
+
+            Snackbar.Add(result.ErrorMessage, Severity.Error);
+        }
+        catch
+        {
+            Snackbar.Add($"An error occurred while generating your document.", Severity.Error);
+        }
+        finally
+        {
+            _downloading = false;
+        }
     }
 
     private async Task ShowCreateUserDialog(ApplicationUserDto model, string title)


### PR DESCRIPTION
## 🔗 Related Work
- Closes: #
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

- Added DocumentTemplate.Users enum value
- Created ExportUsers command with tenant, role, and search filters
- Implemented DocumentExportUsersIntegrationEventConsumer for async export processing
- Added Export button to Users.razor toolbar (visible with SystemFunctionsRead permission)
- Fixed nullability warnings in OnSearch, OnChangedListView, and OnSearchRole methods

Export includes: Name, Email, Status, Lockout Status, Lockout End Date, Last Login, Tenant, and Created Date columns.

Follows existing export pattern with 60-second cooldown between requests.

---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

---

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

---

## 🔄 Changes
- Added:
- Updated:
- Removed:

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1.
2.
3.

Expected result:
> What should happen if everything is correct?

---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.

---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"
