### PR TITLE
Displays unassigned cases with ability to assign

### DIFF
--- a/src/Application/Features/Dashboard/DTOs/RecentlyApprovedActivitiesSummaryDto.cs
+++ b/src/Application/Features/Dashboard/DTOs/RecentlyApprovedActivitiesSummaryDto.cs
@@ -1,0 +1,13 @@
+namespace Cfo.Cats.Application.Features.Dashboard.DTOs;
+
+public class RecentlyApprovedActivitiesSummaryDto
+{
+    public required string ParticipantId { get; set; }
+    public required string Participant { get; set; }
+    public required ActivityDefinition Definition { get; set; }
+    public required DateTime? ApprovedOn { get; set; }
+    public required DateTime? Created { get; set; }
+    public required DateTime? CommencedOn { get; set; }
+    public required string TookPlaceAtLocationName { get; set; }
+    public string? ApprovedBy { get; set; }
+}

--- a/src/Application/Features/Dashboard/Queries/GetRecentlyApprovedActivities.cs
+++ b/src/Application/Features/Dashboard/Queries/GetRecentlyApprovedActivities.cs
@@ -1,0 +1,78 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Dashboard.Queries;
+
+public static class GetRecentlyApprovedActivities
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Query : IRequest<Result<ApprovedActivitiesDto>>
+    {
+        public required DateTime StartDate { get; init; }
+        public required DateTime EndDate { get; init; }
+        public string? UserId { get; init; }
+        public string? TenantId { get; init; }
+        public required UserProfile CurrentUser { get; init; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork)
+        : IRequestHandler<Query, Result<ApprovedActivitiesDto>>
+    {
+        public async Task<Result<ApprovedActivitiesDto>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var context = unitOfWork.DbContext;
+
+            var baseQuery = context.Activities
+                .Where(a => a.Status == ActivityStatus.ApprovedStatus.Value
+                            && a.CompletedOn >= request.StartDate.Date
+                            && a.CompletedOn <= request.EndDate.Date);
+
+            // Checks and applies filter based on UserId or TenantId else throws exception
+            baseQuery = request switch
+            {
+                { UserId: var userId } when !string.IsNullOrWhiteSpace(userId)
+                    => baseQuery.Where(a => a.OwnerId == userId),
+
+                { TenantId: var tenantId } when !string.IsNullOrWhiteSpace(tenantId)
+                    => baseQuery.Where(a => a.TenantId.StartsWith(tenantId)),
+
+                _ => throw new ArgumentException("Invalid request: UserId or TenantId must be provided.")
+            };
+
+            var results = await (from a in baseQuery
+                          orderby a.CompletedOn descending
+                          select new ActivityDetail
+                          {
+                              ParticipantId = a.ParticipantId,
+                              ParticipantName = a.Participant!.FirstName + " " + a.Participant.LastName,
+                              Category = a.Definition.Category.Name,
+                              ActivityType = a.Definition.Type.Name,
+                              ApprovedOn = a.CompletedOn,
+                              AddedOn = a.Created,
+                              TookPlaceOn = a.CommencedOn,
+                              TookPlaceAtLocation = a.TookPlaceAtLocation.Name
+                          })
+                          .AsNoTracking()
+                          .ToArrayAsync(cancellationToken);
+
+            var custody = results.Count(r => r.TookPlaceAtLocation.Contains("HMP") || r.TookPlaceAtLocation.Contains("Wing"));
+            var community = results.Length - custody;
+
+            return new ApprovedActivitiesDto(results, custody, community);
+        }
+    }
+
+    public record ApprovedActivitiesDto(ActivityDetail[] Details, int Custody, int Community);
+
+    public record ActivityDetail
+    {
+        public required string ParticipantId { get; init; }
+        public required string ParticipantName { get; init; }
+        public required string Category { get; init; }
+        public required string ActivityType { get; init; }
+        public DateTime? ApprovedOn { get; init; }
+        public DateTime? AddedOn { get; init; }
+        public DateTime? TookPlaceOn { get; init; }
+        public required string TookPlaceAtLocation { get; init; }
+    }
+}

--- a/src/Application/Features/Participants/Commands/AssignUnassignedCase.cs
+++ b/src/Application/Features/Participants/Commands/AssignUnassignedCase.cs
@@ -114,8 +114,9 @@ public static class AssignUnassignedCase
 
             // Get the participant's tenant from their current location
             var participantTenantId = participant.CurrentLocation!.Tenants
+                .Where(t => t.Id.StartsWith(c.CurrentUser.TenantId!))
                 .Select(t => t.Id)
-                .FirstOrDefault();
+                .FirstOrDefault() ?? c.CurrentUser.TenantId;
 
             if (string.IsNullOrEmpty(participantTenantId))
             {

--- a/src/Application/Features/Participants/Commands/AssignUnassignedCase.cs
+++ b/src/Application/Features/Participants/Commands/AssignUnassignedCase.cs
@@ -1,0 +1,137 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Validators;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Participants.Commands;
+
+public static class AssignUnassignedCase
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Command : IRequest<Result<bool>>
+    {
+        public required string ParticipantId { get; set; }
+
+        public UserProfile? CurrentUser { get; set; }
+
+        public string? AssigneeId { get; set; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Command, Result<bool>>
+    {
+        public async Task<Result<bool>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var participant = await unitOfWork.DbContext.Participants
+                .FirstOrDefaultAsync(x => x.Id == request.ParticipantId, cancellationToken);
+
+            if (participant is null)
+            {
+                return Result<bool>.Failure("Participant not found");
+            }
+
+            if (participant.OwnerId is not null)
+            {
+                return Result<bool>.Failure("Participant already has an owner");
+            }
+
+            participant.AssignTo(request.AssigneeId);
+
+            return Result<bool>.Success(true);
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public Validator(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+
+            RuleFor(x => x.AssigneeId)
+                .NotNull()
+                .MinimumLength(36)
+                .WithMessage("Assignee must be selected");
+
+            RuleFor(x => x.ParticipantId)
+                .NotNull()
+                .Length(9)
+                .WithMessage("Invalid Participant Id")
+                .Matches(ValidationConstants.AlphaNumeric)
+                .WithMessage(string.Format(ValidationConstants.AlphaNumericMessage, "Participant Id"));
+
+            RuleFor(x => x.CurrentUser)
+                .NotNull()
+                .WithMessage("Current user is required");
+
+            RuleSet(ValidationConstants.RuleSet.MediatR, () =>
+            {
+                RuleFor(p => p.ParticipantId)
+                    .MustAsync(ParticipantExists)
+                    .WithMessage("Participant does not exist")
+                    .MustAsync(ParticipantHasNoOwner)
+                    .WithMessage("Participant already has an owner")
+                    .MustAsync(ParticipantNotArchived)
+                    .WithMessage("Participant is archived");
+
+                RuleFor(c => c)
+                    .MustAsync(ValidAssignee)
+                    .WithMessage("Selected assignee is not valid or not within your tenant");
+
+                RuleFor(c => c.ParticipantId)
+                    .Must(NotHaveActiveTransfer)
+                    .WithMessage("Participant has an active incoming transfer. Please process the transfer first.");
+            });
+        }
+
+        private async Task<bool> ParticipantExists(string participantId, CancellationToken cancellationToken)
+            => await _unitOfWork.DbContext.Participants.AnyAsync(p => p.Id == participantId, cancellationToken);
+
+        private async Task<bool> ParticipantHasNoOwner(string participantId, CancellationToken cancellationToken)
+            => await _unitOfWork.DbContext.Participants.AnyAsync(p => p.Id == participantId && p.OwnerId == null, cancellationToken);
+
+        private async Task<bool> ParticipantNotArchived(string participantId, CancellationToken cancellationToken)
+            => await _unitOfWork.DbContext.Participants.AnyAsync(
+                e => e.Id == participantId && e.EnrolmentStatus != EnrolmentStatus.ArchivedStatus.Value, 
+                cancellationToken);
+
+        private async Task<bool> ValidAssignee(Command c, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(c.AssigneeId) || c.CurrentUser is null)
+            {
+                return false;
+            }
+
+            // Get the participant to determine their tenant
+            var participant = await _unitOfWork.DbContext.Participants
+                .Include(p => p.CurrentLocation)
+                    .ThenInclude(l => l.Tenants)
+                .FirstOrDefaultAsync(p => p.Id == c.ParticipantId, cancellationToken);
+
+            if (participant is null)
+            {
+                return false;
+            }
+
+            // Get the participant's tenant from their current location
+            var participantTenantId = participant.CurrentLocation!.Tenants
+                .Select(t => t.Id)
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(participantTenantId))
+            {
+                return false;
+            }
+
+            // Check the assignee is within the participant's tenant
+            return await _unitOfWork.DbContext.Users
+                .Where(x => x.TenantId!.StartsWith(participantTenantId)
+                            && x.Id == c.AssigneeId
+                            && x.IsActive == true)
+                .AnyAsync(cancellationToken);
+        }
+
+        private bool NotHaveActiveTransfer(string participantId)
+            => !_unitOfWork.DbContext.ParticipantIncomingTransferQueue
+                .Any(p => p.ParticipantId == participantId && p.Completed == false);
+    }
+}

--- a/src/Application/Features/Participants/DTOs/UnassignedCaseDto.cs
+++ b/src/Application/Features/Participants/DTOs/UnassignedCaseDto.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using Cfo.Cats.Application.Features.Locations.DTOs;
+using Cfo.Cats.Domain.Entities.Participants;
+
+namespace Cfo.Cats.Application.Features.Participants.DTOs;
+
+[Description("Unassigned Cases")]
+public class UnassignedCaseDto
+{
+    [Description("Participant Id")]
+    public string Id { get; set; } = default!;
+    
+    [Description("Status")]
+    public EnrolmentStatus EnrolmentStatus { get; set; } = default!;
+    
+    [Description("Consent")]
+    public ConsentStatus ConsentStatus { get; set; } = default!;
+
+    public string FirstName { get; set; } = default!;
+
+    public string LastName { get; set; } = default!;
+    
+    [Description("Participant")]
+    public string ParticipantName => $"{FirstName} {LastName}";
+    
+    [Description("Location")]
+    public LocationDto CurrentLocation { get; set; } = default!;
+    
+    [Description("Enrolled At")]
+    public LocationDto? EnrolmentLocation { get; set; }
+    
+    [Description("Tenant")]
+    public string TenantId { get; set; } = default!;
+
+    [Description("Tenant Name")]
+    public string TenantName { get; set; } = default!;
+
+    [Description("Last Modified")]
+    public DateTime? LastModified { get; set; }
+
+    [Description("Has Incoming Transfer")]
+    public bool HasIncomingTransfer { get; set; }
+
+    [Description("Incoming Transfer Id")]
+    public Guid? IncomingTransferId { get; set; }
+
+    private class Mapper : Profile
+    {
+        public Mapper()
+        {
+            CreateMap<Participant, UnassignedCaseDto>()
+                .ForMember(dest => dest.ParticipantName, opt => opt.MapFrom(src => $"{src.FirstName} {src.LastName}"))
+                .ForMember(dest => dest.TenantName, opt => opt.Ignore())
+                .ForMember(dest => dest.HasIncomingTransfer, opt => opt.Ignore())
+                .ForMember(dest => dest.IncomingTransferId, opt => opt.Ignore());
+        }
+    }
+}

--- a/src/Application/Features/Participants/Queries/GetUnassignedCasesSummary.cs
+++ b/src/Application/Features/Participants/Queries/GetUnassignedCasesSummary.cs
@@ -18,22 +18,21 @@ public static class GetUnassignedCasesSummary
             var context = unitOfWork.DbContext;
             var currentTenantId = request.CurrentUser.TenantId!;
 
-            // Get visible locations for the current tenant
-            var visibleLocationIds = await (
-                from l in context.Locations
-                from t in l.Tenants
-                where t.Id.StartsWith(currentTenantId)
-                select l.Id
-            ).Distinct().ToListAsync(cancellationToken);
+            // Base query: unassigned participants at accessible locations without inaccessible incoming transfers
+            var baseQuery = from p in context.Participants
+                            where p.OwnerId == null
+                                && p.CurrentLocation.Tenants.Any(t => t.Id.StartsWith(currentTenantId))
+                                && (!context.ParticipantIncomingTransferQueue.Any(t => 
+                                    t.ParticipantId == p.Id 
+                                    && !t.Completed 
+                                    && !t.ToLocation.Tenants.Any(lt => lt.Id.StartsWith(currentTenantId))))
+                            select p;
 
-            // Query unassigned participants grouped by location and status (for chart - includes all statuses)
-            var groupedQuery = from p in context.Participants
-                               where p.OwnerId == null
-                                   && (visibleLocationIds.Contains(p.CurrentLocation.Id)
-                                       || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+            // Group by location and status for chart data
+            var groupedQuery = from p in baseQuery
                                group p by new
                                {
-                                   LocationId = p.CurrentLocation.Id,  // Group by ID to avoid duplicate names
+                                   LocationId = p.CurrentLocation.Id,
                                    LocationName = p.CurrentLocation.Name,
                                    LocationType = p.CurrentLocation.LocationType,
                                    EnrolmentStatus = p.EnrolmentStatus
@@ -50,12 +49,8 @@ public static class GetUnassignedCasesSummary
                 .AsNoTracking()
                 .ToArrayAsync(cancellationToken);
 
-            // Query for totals including archived (for chips)
-            var totalsQuery = from p in context.Participants
-                              where p.OwnerId == null
-                                  && (visibleLocationIds.Contains(p.CurrentLocation.Id)
-                                      || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
-                                  && !p.CurrentLocation.Name.Contains("Unmapped")  // Exclude unmapped from main totals
+            // Group by location type for chip totals
+            var totalsQuery = from p in baseQuery
                               group p by p.CurrentLocation.LocationType into grp
                               select new { LocationType = grp.Key, Count = grp.Count() };
 
@@ -63,48 +58,28 @@ public static class GetUnassignedCasesSummary
                 .AsNoTracking()
                 .ToArrayAsync(cancellationToken);
 
-            // Also get counts for unmapped locations (for chips)
-            var unmappedCustodyCount = await context.Participants
-                .Where(p => p.OwnerId == null
-                           && (visibleLocationIds.Contains(p.CurrentLocation.Id)
-                               || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
-                           && p.CurrentLocation.Name.Contains("Unmapped Custody"))
-                .CountAsync(cancellationToken);
-
-            var unmappedCommunityCount = await context.Participants
-                .Where(p => p.OwnerId == null
-                           && (visibleLocationIds.Contains(p.CurrentLocation.Id)
-                               || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
-                           && p.CurrentLocation.Name.Contains("Unmapped Community"))
-                .CountAsync(cancellationToken);
-
             var custodyTotal = totals.Where(t => t.LocationType.IsCustody).Sum(t => t.Count);
             var communityTotal = totals.Where(t => t.LocationType.IsCommunity).Sum(t => t.Count);
 
             return Result<UnassignedCasesSummaryDto>.Success(
-                new UnassignedCasesSummaryDto(results, custodyTotal, communityTotal, unmappedCustodyCount, unmappedCommunityCount));
+                new UnassignedCasesSummaryDto(results, custodyTotal, communityTotal));
         }
     }
 
     public record UnassignedCasesSummaryDto
     {
-        public UnassignedCasesSummaryDto(LocationStatusSummary[] summaries, int custodyTotal, int communityTotal, 
-            int unmappedCustodyTotal, int unmappedCommunityTotal)
+        public UnassignedCasesSummaryDto(LocationStatusSummary[] summaries, int custodyTotal, int communityTotal)
         {
             Summaries = summaries;
             TotalCount = summaries.Sum(s => s.Count);
             Custody = custodyTotal;
             Community = communityTotal;
-            UnmappedCustody = unmappedCustodyTotal;
-            UnmappedCommunity = unmappedCommunityTotal;
         }
 
         public LocationStatusSummary[] Summaries { get; }
         public int TotalCount { get; }
         public int Custody { get; }
         public int Community { get; }
-        public int UnmappedCustody { get; }
-        public int UnmappedCommunity { get; }
     }
 
     public record LocationStatusSummary(

--- a/src/Application/Features/Participants/Queries/GetUnassignedCasesSummary.cs
+++ b/src/Application/Features/Participants/Queries/GetUnassignedCasesSummary.cs
@@ -1,0 +1,116 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Participants.Queries;
+
+public static class GetUnassignedCasesSummary
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Query : IRequest<Result<UnassignedCasesSummaryDto>>
+    {
+        public required UserProfile CurrentUser { get; init; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<UnassignedCasesSummaryDto>>
+    {
+        public async Task<Result<UnassignedCasesSummaryDto>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var context = unitOfWork.DbContext;
+            var currentTenantId = request.CurrentUser.TenantId!;
+
+            // Get visible locations for the current tenant
+            var visibleLocationIds = await (
+                from l in context.Locations
+                from t in l.Tenants
+                where t.Id.StartsWith(currentTenantId)
+                select l.Id
+            ).Distinct().ToListAsync(cancellationToken);
+
+            // Query unassigned participants grouped by location and status (for chart - includes all statuses)
+            var groupedQuery = from p in context.Participants
+                               where p.OwnerId == null
+                                   && (visibleLocationIds.Contains(p.CurrentLocation.Id)
+                                       || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                               group p by new
+                               {
+                                   LocationId = p.CurrentLocation.Id,  // Group by ID to avoid duplicate names
+                                   LocationName = p.CurrentLocation.Name,
+                                   LocationType = p.CurrentLocation.LocationType,
+                                   EnrolmentStatus = p.EnrolmentStatus
+                               } into grp
+                               select new LocationStatusSummary
+                               (
+                                   grp.Key.LocationName,
+                                   grp.Key.LocationType,
+                                   grp.Key.EnrolmentStatus,
+                                   grp.Count()
+                               );
+
+            var results = await groupedQuery
+                .AsNoTracking()
+                .ToArrayAsync(cancellationToken);
+
+            // Query for totals including archived (for chips)
+            var totalsQuery = from p in context.Participants
+                              where p.OwnerId == null
+                                  && (visibleLocationIds.Contains(p.CurrentLocation.Id)
+                                      || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                                  && !p.CurrentLocation.Name.Contains("Unmapped")  // Exclude unmapped from main totals
+                              group p by p.CurrentLocation.LocationType into grp
+                              select new { LocationType = grp.Key, Count = grp.Count() };
+
+            var totals = await totalsQuery
+                .AsNoTracking()
+                .ToArrayAsync(cancellationToken);
+
+            // Also get counts for unmapped locations (for chips)
+            var unmappedCustodyCount = await context.Participants
+                .Where(p => p.OwnerId == null
+                           && (visibleLocationIds.Contains(p.CurrentLocation.Id)
+                               || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                           && p.CurrentLocation.Name.Contains("Unmapped Custody"))
+                .CountAsync(cancellationToken);
+
+            var unmappedCommunityCount = await context.Participants
+                .Where(p => p.OwnerId == null
+                           && (visibleLocationIds.Contains(p.CurrentLocation.Id)
+                               || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                           && p.CurrentLocation.Name.Contains("Unmapped Community"))
+                .CountAsync(cancellationToken);
+
+            var custodyTotal = totals.Where(t => t.LocationType.IsCustody).Sum(t => t.Count);
+            var communityTotal = totals.Where(t => t.LocationType.IsCommunity).Sum(t => t.Count);
+
+            return Result<UnassignedCasesSummaryDto>.Success(
+                new UnassignedCasesSummaryDto(results, custodyTotal, communityTotal, unmappedCustodyCount, unmappedCommunityCount));
+        }
+    }
+
+    public record UnassignedCasesSummaryDto
+    {
+        public UnassignedCasesSummaryDto(LocationStatusSummary[] summaries, int custodyTotal, int communityTotal, 
+            int unmappedCustodyTotal, int unmappedCommunityTotal)
+        {
+            Summaries = summaries;
+            TotalCount = summaries.Sum(s => s.Count);
+            Custody = custodyTotal;
+            Community = communityTotal;
+            UnmappedCustody = unmappedCustodyTotal;
+            UnmappedCommunity = unmappedCommunityTotal;
+        }
+
+        public LocationStatusSummary[] Summaries { get; }
+        public int TotalCount { get; }
+        public int Custody { get; }
+        public int Community { get; }
+        public int UnmappedCustody { get; }
+        public int UnmappedCommunity { get; }
+    }
+
+    public record LocationStatusSummary(
+        string LocationName,
+        LocationType LocationType,
+        EnrolmentStatus EnrolmentStatus,
+        int Count
+    );
+}

--- a/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
+++ b/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
@@ -25,6 +25,11 @@ public static class UnassignedCasesWithPagination
         /// Filter by location IDs
         /// </summary>
         public int[] Locations { get; set; } = [];
+
+        /// <summary>
+        /// Include participants with incoming transfers
+        /// </summary>
+        public bool IncludeTransferIn { get; set; }
     }
 
     public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<PaginatedData<UnassignedCaseDto>>>
@@ -33,17 +38,20 @@ public static class UnassignedCasesWithPagination
         {
             var context = unitOfWork.DbContext;
 
-            // Get visible locations for the current user's tenant
-            var visibleLocationIds = context.Locations
-                .Where(l => l.Tenants.Any(t => t.Id.StartsWith(request.CurrentUser!.TenantId!)))
-                .Select(l => l.Id)
-                .ToList();
-
-            // Get participants without owners at locations visible to the current user's tenant
+            // Get participants without owners at locations that have a tenant matching the selected tenant
             var query = from p in context.Participants
                         where p.OwnerId == null
-                              && (visibleLocationIds.Contains(p.CurrentLocation.Id) 
-                                  || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                              && p.CurrentLocation.Tenants.Any(t => t.Id.StartsWith(request.CurrentUser!.TenantId!))
+                              // Only include participants if they don't have an incoming transfer, or if they do,
+                              // the transfer's ToLocation must be accessible to the user
+                              && (!context.ParticipantIncomingTransferQueue.Any(t => 
+                                  t.ParticipantId == p.Id 
+                                  && !t.Completed 
+                                  && !t.ToLocation.Tenants.Any(lt => lt.Id.StartsWith(request.CurrentUser!.TenantId!))))
+                              // Optionally exclude participants with incoming transfers (unless IncludeTransferIn is true)
+                              && (request.IncludeTransferIn || !context.ParticipantIncomingTransferQueue.Any(t =>
+                                  t.ParticipantId == p.Id
+                                  && !t.Completed))
                         select p;
 
             // Apply keyword search
@@ -125,9 +133,11 @@ public static class UnassignedCasesWithPagination
             var locationIds = paginatedParticipants.Select(p => p.CurrentLocationId).Distinct().ToList();
 
             // Fetch tenant info for these locations
+            // Filter to only include tenants within the current user's tenant scope
             var locationTenants = await (from l in context.Locations
                                         where locationIds.Contains(l.Id)
                                         from t in l.Tenants
+                                        where t.Id.StartsWith(request.CurrentUser!.TenantId!)
                                         select new LocationTenantDto
                                         {
                                             LocationId = l.Id,

--- a/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
+++ b/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
@@ -20,6 +20,11 @@ public static class UnassignedCasesWithPagination
         /// Filter by enrolment status
         /// </summary>
         public int? EnrolmentStatus { get; set; }
+
+        /// <summary>
+        /// Filter by location IDs
+        /// </summary>
+        public int[] Locations { get; set; } = [];
     }
 
     public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<PaginatedData<UnassignedCaseDto>>>
@@ -61,6 +66,13 @@ public static class UnassignedCasesWithPagination
             if (request.EnrolmentStatus.HasValue)
             {
                 query = query.Where(p => p.EnrolmentStatus == request.EnrolmentStatus.Value);
+            }
+
+            // Apply location filter
+            if (request.Locations.Length > 0)
+            {
+                query = query.Where(p => request.Locations.Contains(p.CurrentLocation.Id)
+                                         || (p.EnrolmentLocation != null && request.Locations.Contains(p.EnrolmentLocation.Id)));
             }
 
             var count = await query.AsNoTracking().CountAsync(cancellationToken);

--- a/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
+++ b/src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs
@@ -1,0 +1,208 @@
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Application.Common.Validators;
+using Cfo.Cats.Application.Features.Locations.DTOs;
+using Cfo.Cats.Application.Features.Participants.DTOs;
+using Cfo.Cats.Application.SecurityConstants;
+
+namespace Cfo.Cats.Application.Features.Participants.Queries;
+
+public static class UnassignedCasesWithPagination
+{
+    [RequestAuthorize(Policy = SecurityPolicies.AuthorizedUser)]
+    public class Query : PaginationFilter, IRequest<Result<PaginatedData<UnassignedCaseDto>>>
+    {
+        /// <summary>
+        /// The currently logged in user
+        /// </summary>
+        public UserProfile? CurrentUser { get; set; }
+
+        /// <summary>
+        /// Filter by enrolment status
+        /// </summary>
+        public int? EnrolmentStatus { get; set; }
+    }
+
+    public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<PaginatedData<UnassignedCaseDto>>>
+    {
+        public async Task<Result<PaginatedData<UnassignedCaseDto>>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var context = unitOfWork.DbContext;
+
+            // Get visible locations for the current user's tenant
+            var visibleLocationIds = context.Locations
+                .Where(l => l.Tenants.Any(t => t.Id.StartsWith(request.CurrentUser!.TenantId!)))
+                .Select(l => l.Id)
+                .ToList();
+
+            // Get participants without owners at locations visible to the current user's tenant
+            var query = from p in context.Participants
+                        where p.OwnerId == null
+                              && (visibleLocationIds.Contains(p.CurrentLocation.Id) 
+                                  || (p.EnrolmentLocation != null && visibleLocationIds.Contains(p.EnrolmentLocation.Id)))
+                        select p;
+
+            // Apply keyword search
+            if (!string.IsNullOrWhiteSpace(request.Keyword))
+            {
+                if (request.Keyword.Split(" ") is { Length: 2 } segments)
+                {
+                    query = query.Where(p => p.FirstName.Contains(segments[0]) && p.LastName.Contains(segments[1]));
+                }
+                else
+                {
+                    query = query.Where(p => p.FirstName.Contains(request.Keyword)
+                                || p.LastName!.Contains(request.Keyword)
+                                || p.Id.Contains(request.Keyword)
+                                || p.ExternalIdentifiers.Any(ei => ei.Value.Contains(request.Keyword)));
+                }
+            }
+
+            // Apply enrolment status filter
+            if (request.EnrolmentStatus.HasValue)
+            {
+                query = query.Where(p => p.EnrolmentStatus == request.EnrolmentStatus.Value);
+            }
+
+            var count = await query.AsNoTracking().CountAsync(cancellationToken);
+
+            // Apply sorting and pagination first
+            var sortColumn = request.OrderBy.Trim().ToLowerInvariant() switch
+            {
+                "id" => "Id",
+                "firstname" => "FirstName",
+                "lastname" => "LastName",
+                "enrolmentstatus" => "EnrolmentStatus",
+                "consentstatus" => "ConsentStatus",
+                "currentlocation" => "CurrentLocation.Name",
+                "currentlocation.name" => "CurrentLocation.Name",
+                "lastmodified" => "LastModified",
+                _ => "LastModified"
+            };
+
+            var sortDirection = request.SortDirection.Equals("Ascending", StringComparison.OrdinalIgnoreCase)
+                ? "ascending"
+                : "descending";
+
+            var paginatedParticipants = await query
+                .AsNoTracking()
+                .OrderBy($"{sortColumn} {sortDirection}")
+                .Skip((request.PageNumber - 1) * request.PageSize)
+                .Take(request.PageSize)
+                .Select(p => new
+                {
+                    p.Id,
+                    p.FirstName,
+                    p.LastName,
+                    p.EnrolmentStatus,
+                    p.ConsentStatus,
+                    p.LastModified,
+                    CurrentLocationId = p.CurrentLocation!.Id,
+                    CurrentLocationName = p.CurrentLocation.Name,
+                    CurrentLocationGenderProvisionValue = p.CurrentLocation.GenderProvision.Value,
+                    CurrentLocationLocationTypeValue = p.CurrentLocation.LocationType.Value,
+                    CurrentLocationContractDescription = p.CurrentLocation.Contract!.Description,
+                    EnrolmentLocationId = p.EnrolmentLocation != null ? (int?)p.EnrolmentLocation.Id : null,
+                    EnrolmentLocationName = p.EnrolmentLocation != null ? p.EnrolmentLocation.Name : null,
+                    EnrolmentLocationGenderProvisionValue = p.EnrolmentLocation != null ? (int?)p.EnrolmentLocation.GenderProvision.Value : null,
+                    EnrolmentLocationLocationTypeValue = p.EnrolmentLocation != null ? (int?)p.EnrolmentLocation.LocationType.Value : null,
+                    EnrolmentLocationContractDescription = p.EnrolmentLocation != null ? p.EnrolmentLocation.Contract!.Description : null
+                })
+                .ToListAsync(cancellationToken);
+
+            // Get location IDs to fetch tenant info
+            var locationIds = paginatedParticipants.Select(p => p.CurrentLocationId).Distinct().ToList();
+
+            // Fetch tenant info for these locations
+            var locationTenants = await (from l in context.Locations
+                                        where locationIds.Contains(l.Id)
+                                        from t in l.Tenants
+                                        select new LocationTenantDto
+                                        {
+                                            LocationId = l.Id,
+                                            TenantId = t.Id,
+                                            TenantName = t.Name
+                                        })
+                                        .ToListAsync(cancellationToken);
+
+            var locationTenantMap = locationTenants
+                .GroupBy(lt => lt.LocationId)
+                .ToDictionary(g => g.Key, g => g.OrderBy(t => t.TenantId).First());
+
+            // Get incoming transfers
+            var participantIds = paginatedParticipants.Select(p => p.Id).ToList();
+            var incomingTransfers = await context.ParticipantIncomingTransferQueue
+                .Where(t => !t.Completed && participantIds.Contains(t.ParticipantId))
+                .Select(t => new { t.ParticipantId, t.Id })
+                .ToListAsync(cancellationToken);
+
+            var transferMap = incomingTransfers.ToDictionary(t => t.ParticipantId, t => t.Id);
+
+            // Map to DTOs
+            var data = paginatedParticipants.Select(p =>
+            {
+                var tenantInfo = locationTenantMap.GetValueOrDefault(p.CurrentLocationId);
+                var transferId = transferMap.GetValueOrDefault(p.Id);
+                
+                return new UnassignedCaseDto
+                {
+                    Id = p.Id,
+                    FirstName = p.FirstName,
+                    LastName = p.LastName,
+                    EnrolmentStatus = p.EnrolmentStatus!,
+                    ConsentStatus = p.ConsentStatus!,
+                    CurrentLocation = new LocationDto
+                    {
+                        Id = p.CurrentLocationId,
+                        Name = p.CurrentLocationName,
+                        GenderProvision = GenderProvision.FromValue(p.CurrentLocationGenderProvisionValue),
+                        LocationType = LocationType.FromValue(p.CurrentLocationLocationTypeValue),
+                        ContractName = p.CurrentLocationContractDescription
+                    },
+                    EnrolmentLocation = p.EnrolmentLocationId.HasValue
+                        ? new LocationDto
+                        {
+                            Id = p.EnrolmentLocationId.Value,
+                            Name = p.EnrolmentLocationName!,
+                            GenderProvision = GenderProvision.FromValue(p.EnrolmentLocationGenderProvisionValue!.Value),
+                            LocationType = LocationType.FromValue(p.EnrolmentLocationLocationTypeValue!.Value),
+                            ContractName = p.EnrolmentLocationContractDescription!
+                        }
+                        : null,
+                    TenantId = tenantInfo?.TenantId ?? string.Empty,
+                    TenantName = tenantInfo?.TenantName ?? string.Empty,
+                    LastModified = p.LastModified,
+                    HasIncomingTransfer = transferId != default,
+                    IncomingTransferId = transferId != default ? transferId : null
+                };
+            }).ToList();
+
+            return new PaginatedData<UnassignedCaseDto>(data, count, request.PageNumber, request.PageSize);
+        }
+    }
+
+    internal class LocationTenantDto
+    {
+        public int LocationId { get; set; }
+        public string TenantId { get; set; } = default!;
+        public string TenantName { get; set; } = default!;
+    }
+
+    public class Validator : AbstractValidator<Query>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.CurrentUser)
+                .NotNull()
+                .WithMessage("Current user is required");
+
+            RuleFor(x => x.PageNumber)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("Page number must be greater than or equal to 1");
+
+            RuleFor(x => x.PageSize)
+                .GreaterThanOrEqualTo(1)
+                .LessThanOrEqualTo(100)
+                .WithMessage("Page size must be between 1 and 100");
+        }
+    }
+}

--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -7,10 +7,18 @@ internal static class AppExtensions
         IResourceBuilder<RabbitMQServerResource> rabbit,
         CatsDatabaseResources databases)
     {
-        builder.AddProject<Projects.Server_UI>("cats")
-        .WithCatsDatabaseReference(databases.CatsDb)
-        .WithReference(rabbit)
-        .WaitFor(rabbit);        
+        var replicaCount = int.TryParse(builder.Configuration["Replicas"], out var n) ? n : 1;
+        
+        var cats = builder.AddProject<Projects.Server_UI>("cats")
+            .WithCatsDatabaseReference(databases.CatsDb)
+            .WithReference(rabbit)
+            .WaitFor(rabbit);
+
+        if(replicaCount > 1)
+        {
+            cats.WithReplicas(replicaCount);        
+        }
+
         return builder;
     }
 

--- a/src/Aspire/Cats.AppHost/appsettings.json
+++ b/src/Aspire/Cats.AppHost/appsettings.json
@@ -9,5 +9,6 @@
   "Parameters": {
     "sqlPassword": "P@ssword123!"
   },
-  "MigrationBehaviour": "WaitFor"
+  "MigrationBehaviour": "WaitFor",
+  "Replicas": 1
 }

--- a/src/Infrastructure/Services/MessageHandling/PaymentBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/PaymentBackgroundService.cs
@@ -40,7 +40,8 @@ public class PaymentBackgroundService(IServiceProvider provider, IConfiguration 
 
         _bus = Configure.With(_activator)
             .Transport(t => t.UseRabbitMq(configuration.GetConnectionString("rabbit"), options.Value.PaymentService)
-                .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange))
+                .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange)
+                .InputQueueOptions(q => q.AddArgument(RabbitMQ.Client.Headers.XSingleActiveConsumer, true))) // Ensure only one instance of the service processes messages at a time to prevent duplicate payments
             .Options(o =>
             {
                 o.SetNumberOfWorkers(1);

--- a/src/Server.UI/Components/Dashboard/AssignCaseDialog.razor
+++ b/src/Server.UI/Components/Dashboard/AssignCaseDialog.razor
@@ -1,0 +1,108 @@
+@using Cfo.Cats.Application.Features.Participants.Commands
+@using Cfo.Cats.Application.Features.Participants.DTOs
+@using Cfo.Cats.Application.Features.Identity.DTOs
+@using Cfo.Cats.Server.UI.Components.Users
+
+@inherits CatsComponentBase
+
+@inject IValidationService Validator
+
+<MudDialog>
+    <DialogContent>
+        <MudForm Model="@_command" @ref="_form" Validation="@(Validator.ValidateValue(_command))">
+            <MudGrid>
+                <MudItem xs="12">
+                    <MudText Typo="Typo.body2">
+                        Assign <strong>@Participant.ParticipantName</strong> (@Participant.Id)
+                    </MudText>
+                </MudItem>
+                <MudItem xs="12">
+                    <div style="min-width: 600px;">
+                        <UserSelectComponent ValueChanged="OnUserSelectedChanged" TenantId="@TenantId" Required="true" />
+                    </div>
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Secondary" 
+                   Variant="Variant.Filled" 
+                   StartIcon="@Icons.Material.Filled.Cancel" 
+                   OnClick="Cancel">
+            @ConstantString.Cancel
+        </MudButton>
+        <MudLoadingButton Color="Color.Primary" 
+                          Variant="Variant.Filled" 
+                          StartIcon="@Icons.Material.Filled.Save" 
+                          Loading="@_saving" 
+                          OnClick="Submit">
+            @ConstantString.Submit
+        </MudLoadingButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] 
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public UnassignedCaseDto Participant { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public string TenantId { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public UserProfile? CurrentUser { get; set; }
+
+    private MudForm? _form;
+    private bool _saving;
+    private AssignUnassignedCase.Command _command = null!;
+
+    protected override void OnInitialized()
+    {
+        _command = new AssignUnassignedCase.Command
+        {
+            ParticipantId = Participant.Id,
+            CurrentUser = CurrentUser
+        };
+    }
+
+    private void OnUserSelectedChanged(ApplicationUserDto? user)
+    {
+        if (user != null)
+        {
+            _command.AssigneeId = user.Id;
+        }
+    }
+
+    private void Cancel() => MudDialog.Close();
+
+    private async Task Submit()
+    {
+        try
+        {
+            _saving = true;
+
+            await _form!.ValidateAsync();
+
+            if (_form.IsValid)
+            {
+                var result = await GetNewMediator().Send(_command);
+                
+                if (result.Succeeded)
+                {
+                    MudDialog.Close(DialogResult.Ok(true));
+                    Snackbar.Add($"Case assigned successfully", Severity.Success);
+                }
+                else
+                {
+                    Snackbar.Add(result.ErrorMessage, Severity.Error);
+                }
+            }
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/src/Server.UI/Components/Dashboard/AssignCaseDialog.razor
+++ b/src/Server.UI/Components/Dashboard/AssignCaseDialog.razor
@@ -9,7 +9,7 @@
 
 <MudDialog>
     <DialogContent>
-        <MudForm Model="@_command" @ref="_form" Validation="@(Validator.ValidateValue(_command))">
+        <MudForm Model="@Model" @ref="_form" Validation="@(Validator.ValidateValue(Model))">
             <MudGrid>
                 <MudItem xs="12">
                     <MudText Typo="Typo.body2">
@@ -52,26 +52,16 @@
     public string TenantId { get; set; } = default!;
 
     [Parameter, EditorRequired]
-    public UserProfile? CurrentUser { get; set; }
+    public AssignUnassignedCase.Command Model { get; set; } = null!;
 
     private MudForm? _form;
     private bool _saving;
-    private AssignUnassignedCase.Command _command = null!;
-
-    protected override void OnInitialized()
-    {
-        _command = new AssignUnassignedCase.Command
-        {
-            ParticipantId = Participant.Id,
-            CurrentUser = CurrentUser
-        };
-    }
 
     private void OnUserSelectedChanged(ApplicationUserDto? user)
     {
         if (user != null)
         {
-            _command.AssigneeId = user.Id;
+            Model.AssigneeId = user.Id;
         }
     }
 
@@ -87,7 +77,7 @@
 
             if (_form.IsValid)
             {
-                var result = await GetNewMediator().Send(_command);
+                var result = await GetNewMediator().Send(Model);
                 
                 if (result.Succeeded)
                 {

--- a/src/Server.UI/Components/Dashboard/RecentlyApprovedActivitiesComponent.razor
+++ b/src/Server.UI/Components/Dashboard/RecentlyApprovedActivitiesComponent.razor
@@ -1,0 +1,105 @@
+@using Cfo.Cats.Application.Features.Dashboard.Queries
+@inherits CatsComponent<GetRecentlyApprovedActivities.ApprovedActivitiesDto>
+
+@if (Loading)
+{
+    <MudLoading Text="Loading" />
+}
+
+@if (ErrorMessage is not null)
+{
+    <MudAlert Variant="Variant.Filled" Severity="Severity.Error">
+        @ErrorMessage
+    </MudAlert>
+}
+
+@if (Data is not null && Data.Details.Any())
+{
+    <MudGrid Spacing="2">
+        <MudItem>
+            <MudChip T="string">Custody (@Data.Custody)</MudChip>
+            <MudChip T="string">Community (@Data.Community)</MudChip>
+        </MudItem>
+    </MudGrid>
+    @if (VisualMode)
+    {
+        <ApexCharts.ApexChart TItem="GetRecentlyApprovedActivities.ActivityDetail" Options="Options" Height="650" Width="@("100%")">
+            <ApexCharts.ApexPointSeries TItem="GetRecentlyApprovedActivities.ActivityDetail"
+                                        Items="Data.Details"
+                                        Name="@($"Approved Activities ({Data.Details.Length})")"
+                                        SeriesType="ApexCharts.SeriesType.Bar"
+                                        XValue="@(e => e.TookPlaceAtLocation)"
+                                        YAggregate="@(e => e.Count())"
+                                        ShowDataLabels="true">
+            </ApexCharts.ApexPointSeries>
+        </ApexCharts.ApexChart>
+    }
+    else
+    {
+        <MudTable Items="@Data.Details" MultiSelection="false" Striped="true" Hover="true" Dense="true">
+            <HeaderContent>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.ParticipantId)">
+                        Participant ID
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.ParticipantName)">
+                        Participant
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.ActivityType)">
+                        Activity Type
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.Category)">
+                        Category
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.ApprovedOn ?? DateTime.MinValue)">
+                        Approved On
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.AddedOn ?? DateTime.MinValue)">
+                        Added On
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.TookPlaceOn ?? DateTime.MinValue)">
+                        Took Place On
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<GetRecentlyApprovedActivities.ActivityDetail, object>(x => x.TookPlaceAtLocation)">
+                        Location
+                    </MudTableSortLabel>
+                </MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Participant ID">
+                    <MudButton Color="Color.Info" Variant="Variant.Text" Size="Size.Small" OnClick="@(() => EditParticipant(context.ParticipantId))">
+                        @context.ParticipantId
+                    </MudButton>
+                </MudTd>
+                <MudTd DataLabel="Participant">@context.ParticipantName</MudTd>
+                <MudTd DataLabel="Activity Type">@context.ActivityType</MudTd>
+                <MudTd DataLabel="Category">@context.Category</MudTd>
+                <MudTd DataLabel="Approved On">@context.ApprovedOn?.ToString("d")</MudTd>
+                <MudTd DataLabel="Added On">@context.AddedOn?.ToString("d")</MudTd>
+                <MudTd DataLabel="Took Place On">@context.TookPlaceOn?.ToString("d")</MudTd>
+                <MudTd DataLabel="Location">@context.TookPlaceAtLocation</MudTd>
+            </RowTemplate>
+            <PagerContent>
+                <MudTablePager PageSizeOptions="[10, 20, 50]" />
+            </PagerContent>
+        </MudTable>
+    }
+}
+else
+{
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center">No data available</MudText>
+}

--- a/src/Server.UI/Components/Dashboard/RecentlyApprovedActivitiesComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/RecentlyApprovedActivitiesComponent.razor.cs
@@ -1,0 +1,74 @@
+using ApexCharts;
+using Cfo.Cats.Application.Features.Dashboard.Queries;
+
+namespace Cfo.Cats.Server.UI.Components.Dashboard;
+
+public partial class RecentlyApprovedActivitiesComponent : CatsComponent<GetRecentlyApprovedActivities.ApprovedActivitiesDto>
+{
+    [EditorRequired, Parameter]
+    public DateRange? DateRange { get; set; }
+
+    [Parameter]
+    public string UserId { get; set; } = null!;
+
+    [Parameter]
+    public string TenantId { get; set; } = null!;
+
+    [EditorRequired, Parameter]
+    public bool VisualMode { get; set; }
+
+    [CascadingParameter(Name = "IsDarkMode")]
+    public bool IsDarkMode { get; set; }
+
+    protected override IRequest<Result<GetRecentlyApprovedActivities.ApprovedActivitiesDto>> CreateQuery()
+        => new GetRecentlyApprovedActivities.Query()
+        {
+            CurrentUser = CurrentUser,
+            UserId = UserId,
+            TenantId = TenantId,
+            StartDate = DateRange?.Start ?? throw new InvalidOperationException("DateRange not set"),
+            EndDate = DateRange?.End ?? throw new InvalidOperationException("DateRange not set")
+        };
+
+    private ApexChartOptions<GetRecentlyApprovedActivities.ActivityDetail> Options => new()
+    {
+        Chart = new Chart
+        {
+            Stacked = false
+        },
+        PlotOptions = new PlotOptions
+        {
+            Bar = new PlotOptionsBar
+            {
+                Horizontal = false,
+                DataLabels = new PlotOptionsBarDataLabels
+                {
+                    Total = new BarTotalDataLabels
+                    {
+                        Enabled = true,
+                        Style = new BarDataLabelsStyle
+                        {
+                            FontWeight = "800",
+                            Color = IsDarkMode ? "#FFFFFF" : "#000000",
+                        }
+                    }
+                },
+            },
+        },
+        Yaxis =
+        [
+            new YAxis
+            {
+                Min = 0,
+                ForceNiceScale = true
+            }
+        ],
+        Theme = new Theme
+        {
+            Mode = IsDarkMode ? Mode.Dark : Mode.Light
+        },
+        Colors = ["#5cb85c", "#d9534f"]
+    };
+
+    private void EditParticipant(string participantId) => Navigation.NavigateTo($"/pages/participants/{participantId}");
+}

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
@@ -1,0 +1,228 @@
+@using ApexCharts
+@using Cfo.Cats.Application.Features.Participants.DTOs
+@using Cfo.Cats.Application.Features.Participants.Queries
+@using Cfo.Cats.Application.Features.Participants.Commands
+@using Cfo.Cats.Server.UI.Pages.Participants.Components
+@using Cfo.Cats.Application.SecurityConstants
+@using Cfo.Cats.Domain.Identity
+@using Cfo.Cats.Domain.Common.Enums
+@using Microsoft.AspNetCore.Identity
+@using MudSize = MudBlazor.Size
+@using MudAlign = MudBlazor.Align
+
+@inherits CatsComponentBase
+
+@if (VisualMode)
+{
+    <!-- Chart View -->
+    <MudStack Class="mb-4">
+        <div class="d-flex align-start flex-grow-1">
+            <div class="d-flex gap-4">
+                <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Large" />
+                <div class="d-flex flex-column">
+                    <MudText Typo="Typo.caption">Unassigned Cases</MudText>
+                    <MudText Typo="Typo.body2">Cases without an assigned owner</MudText>
+                </div>
+            </div>
+        </div>
+    </MudStack>
+
+    @if (_summaryData is not null)
+    {
+        <MudGrid Spacing="2">
+            <MudItem>
+                <MudChip T="string">Total (@_summaryData.TotalCount)</MudChip>
+                <MudChip T="string">Custody (@_summaryData.Custody)</MudChip>
+                <MudChip T="string">Community (@_summaryData.Community)</MudChip>
+                <MudChip T="string" Color="Color.Warning">Unmapped Custody (@_summaryData.UnmappedCustody)</MudChip>
+                <MudChip T="string" Color="Color.Warning">Unmapped Community (@_summaryData.UnmappedCommunity)</MudChip>
+            </MudItem>
+        </MudGrid>
+    }
+
+    @if (_loading)
+    {
+        <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-4" />
+    }
+    else if (_chartData != null && _chartData.Any())
+    {
+        <ApexChart TItem="ChartDataPoint" Options="ChartOptions" Height="700">
+            @{
+                var chartData = ChartData();
+                var statuses = chartData
+                    .Select(x => x.Status)
+                    .DistinctBy(x => x.Value)
+                    .OrderBy(x => x.LogicalOrder);
+            }
+            
+            @foreach (var status in statuses)
+            {
+                <ApexPointSeries TItem="ChartDataPoint"
+                                Name="@status.Name"
+                                Items="@chartData.Where(x => x.Status == status).ToList()"
+                                XValue="@(x => x.LocationName)"
+                                YValue="@(x => x.Count)"
+                                SeriesType="SeriesType.Bar"
+                                ShowDataLabels
+                                Color="@status.Colour" />
+            }
+        </ApexChart>
+    }
+    else
+    {
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Align="MudAlign.Center">No unassigned cases found</MudText>
+    }
+}
+else
+{
+    <!-- Tabular View -->
+<MudDataGrid T="UnassignedCaseDto"
+             ServerData="@(ServerReload)"
+             FixedHeader="true"
+             FixedFooter="true"
+             Virtualize="true"
+             @bind-RowsPerPage="_defaultPageSize"
+             Height="calc(100vh - 400px)"
+             Loading="@_loading"
+             Hover="true"
+             @ref="_table"
+             BreakPoint="Breakpoint.Sm">
+    <ToolBarContent>
+        <div class="d-flex align-start flex-grow-1">
+            <div class="d-flex gap-4">
+                <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Large" />
+                <div class="d-flex flex-column">
+                    <MudText Typo="Typo.caption">Unassigned Cases</MudText>
+                    <MudText Typo="Typo.body2">Cases without an assigned owner</MudText>
+                </div>
+            </div>
+        </div>
+        <div class="d-flex gap-2 align-center">
+            <MudMenu Size="MudSize.Small" 
+                     Label="@(Query.EnrolmentStatus.HasValue ? EnrolmentStatus.FromValue(Query.EnrolmentStatus.Value).Name : "All Statuses")" 
+                     EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                <MudMenuItem Label="All Statuses" OnClick="@(() => EnrolmentStatusChanged(null))" />
+                @foreach (var status in EnrolmentStatus.List)
+                {
+                    <MudMenuItem Label="@status.Name" OnClick="@(() => EnrolmentStatusChanged(status.Value))" />
+                }
+            </MudMenu>
+        </div>
+        @if (_canSearch)
+        {
+            <MudTextField T="string" 
+                          ValueChanged="@OnSearch" 
+                          Value="@Query.Keyword" 
+                          Placeholder="Search by name or ID" 
+                          Clearable="true"
+                          Adornment="Adornment.End"
+                          AdornmentIcon="@Icons.Material.Filled.Search" 
+                          IconSize="MudSize.Small">
+            </MudTextField>
+        }
+    </ToolBarContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Id" Title="Actions">
+            <CellTemplate>
+                <MudMenu Icon="@Icons.Material.Filled.Edit" 
+                         Variant="Variant.Filled" 
+                         Size="MudSize.Small" 
+                         Dense="true" 
+                         EndIcon="@Icons.Material.Filled.KeyboardArrowDown" 
+                         IconColor="Color.Info" 
+                         AnchorOrigin="Origin.CenterLeft">
+                    @if (context.Item.HasIncomingTransfer)
+                    {
+                        <MudMenuItem OnClick="@(() => NavigateToTransfers())">
+                            <MudIcon Icon="@Icons.Material.Filled.Input" Size="MudSize.Small" Class="mr-2" />
+                            Process Transfer First
+                        </MudMenuItem>
+                    }
+                    else
+                    {
+                        <MudMenuItem OnClick="@(() => AssignToSelf(context.Item))">
+                            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Size="MudSize.Small" Class="mr-2" />
+                            Assign to Me
+                        </MudMenuItem>
+                        <MudMenuItem OnClick="@(() => AssignToOther(context.Item))">
+                            <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Small" Class="mr-2" />
+                            Assign to Another User
+                        </MudMenuItem>
+                    }
+                    <MudMenuItem OnClick="@(() => ViewParticipant(context.Item.Id))">
+                        <MudIcon Icon="@Icons.Material.Filled.Visibility" Size="MudSize.Small" Class="mr-2" />
+                        View Participant
+                    </MudMenuItem>
+                </MudMenu>
+            </CellTemplate>
+        </PropertyColumn>
+        
+        <PropertyColumn Property="x => x.Id" Title="ID" />
+        
+        <PropertyColumn Property="x => x.ParticipantName" Title="Participant">
+            <CellTemplate>
+                <div class="d-flex flex-column">
+                    <MudText Typo="Typo.body2">@context.Item.ParticipantName</MudText>
+                    @if (context.Item.HasIncomingTransfer)
+                    {
+                        <MudChip T="string" Size="MudSize.Small" Color="Color.Warning" Icon="@Icons.Material.Filled.Input">
+                            Transfer In
+                        </MudChip>
+                    }
+                </div>
+            </CellTemplate>
+        </PropertyColumn>
+        
+        <PropertyColumn Property="x => x.EnrolmentStatus" Title="Status">
+            <CellTemplate>
+                <EnrolmentStatusChip Status="@context.Item.EnrolmentStatus" />
+            </CellTemplate>
+        </PropertyColumn>
+        
+        <PropertyColumn Property="x => x.ConsentStatus" Title="Consent">
+            <CellTemplate>
+                <ConsentStatusChip Status="@context.Item.ConsentStatus" />
+            </CellTemplate>
+        </PropertyColumn>
+        
+        <PropertyColumn Property="x => x.CurrentLocation" Title="Location" SortBy="x => x.CurrentLocation.Name">
+            <CellTemplate>
+                <div class="d-flex align-items-center">
+                    @if (context.Item.CurrentLocation.LocationType.IsCustody)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Castle" Title="Custody" Size="MudSize.Small" Class="mr-2" />
+                    }
+                    else
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.MapsHomeWork" Title="Community" Size="MudSize.Small" Class="mr-2" />
+                    }
+                    <span>@context.Item.CurrentLocation.Name</span>
+                </div>
+            </CellTemplate>
+        </PropertyColumn>
+        
+        <PropertyColumn Property="x => x.TenantName" Title="Tenant" />
+        
+        <PropertyColumn Property="x => x.LastModified" Title="Last Modified">
+            <CellTemplate>
+                @if (context.Item.LastModified.HasValue)
+                {
+                    <MudText Typo="Typo.body2">@context.Item.LastModified.Value.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</MudText>
+                }
+            </CellTemplate>
+        </PropertyColumn>
+    </Columns>
+    
+    <NoRecordsContent>
+        <MudText>No unassigned cases found</MudText>
+    </NoRecordsContent>
+    
+    <LoadingContent>
+        <MudText>Loading...</MudText>
+    </LoadingContent>
+    
+    <PagerContent>
+        <MudDataGridPager PageSizeOptions="@(new[] { 10, 15, 30, 50 })" />
+    </PagerContent>
+</MudDataGrid>
+}

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
@@ -1,17 +1,19 @@
 @using ApexCharts
 @using Cfo.Cats.Application.Features.Participants.DTOs
-@using Cfo.Cats.Application.Features.Participants.Queries
-@using Cfo.Cats.Application.Features.Participants.Commands
 @using Cfo.Cats.Server.UI.Pages.Participants.Components
-@using Cfo.Cats.Application.SecurityConstants
-@using Cfo.Cats.Domain.Identity
 @using Cfo.Cats.Domain.Common.Enums
-@using Microsoft.AspNetCore.Identity
 @using MudSize = MudBlazor.Size
 @using MudAlign = MudBlazor.Align
 
 @inherits CatsComponentBase
-
+<style>
+    /* Override for compact toolbars */
+.compact-toolbar .mud-table-toolbar {
+    height: 60px !important;
+    min-height: 60px !important;
+    padding: 8px 16px !important;
+}
+</style>
 @if (VisualMode)
 {
     <!-- Chart View -->
@@ -86,9 +88,10 @@ else
              Loading="@_loading"
              Hover="true"
              @ref="_table"
-             BreakPoint="Breakpoint.Sm">
+             BreakPoint="Breakpoint.Sm"
+             Class="compact-toolbar">
     <ToolBarContent>
-        <div class="d-flex align-start flex-grow-1">
+        <div class="d-flex align-start flex-grow-1" style="padding: 0;">
             <div class="d-flex gap-4">
                 <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Large" />
                 <div class="d-flex flex-column">
@@ -98,6 +101,19 @@ else
             </div>
         </div>
         <div class="d-flex gap-2 align-center">
+            @if (_canSearch)
+            {
+                <MudTextField T="string" 
+                              ValueChanged="@OnSearch" 
+                              Value="@Query.Keyword" 
+                              Placeholder="Search by name or ID" 
+                              Clearable="true"
+                              Adornment="Adornment.End"
+                              AdornmentIcon="@Icons.Material.Filled.Search" 
+                              IconSize="MudSize.Small"
+                              Style="max-width: 250px;">
+                </MudTextField>
+            }
             <MudMenu Size="MudSize.Small" 
                      Label="@(Query.EnrolmentStatus.HasValue ? EnrolmentStatus.FromValue(Query.EnrolmentStatus.Value).Name : "All Statuses")" 
                      EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
@@ -107,22 +123,30 @@ else
                     <MudMenuItem Label="@status.Name" OnClick="@(() => EnrolmentStatusChanged(status.Value))" />
                 }
             </MudMenu>
+            <MudButton Size="MudSize.Small" Variant="Variant.Text" OnClick="ShowSelectLocationDialog" EndIcon="@Icons.Material.Filled.KeyboardArrowDown">
+                @if(Query.Locations is { Length: 0 })
+                {
+                    @("All Locations")
+                }
+                else
+                {
+                    @_locations[Query.Locations[0]]
+                }
+            </MudButton>
+            @* <MudButton Size="MudSize.Small" 
+                       Variant="Variant.Outlined" 
+                       Color="Color.Default"
+                       StartIcon="@Icons.Material.Filled.Clear" 
+                       OnClick="ClearFilters">
+                Clear Filters
+            </MudButton> *@
+            <MudTooltip Text="Clear Filters">
+                <MudIconButton Size="MudBlazor.Size.Small" Icon="@Icons.Material.Filled.Clear" OnClick="@(() => ClearFilters())" />
+            </MudTooltip>            
         </div>
-        @if (_canSearch)
-        {
-            <MudTextField T="string" 
-                          ValueChanged="@OnSearch" 
-                          Value="@Query.Keyword" 
-                          Placeholder="Search by name or ID" 
-                          Clearable="true"
-                          Adornment="Adornment.End"
-                          AdornmentIcon="@Icons.Material.Filled.Search" 
-                          IconSize="MudSize.Small">
-            </MudTextField>
-        }
     </ToolBarContent>
     <Columns>
-        <PropertyColumn Property="x => x.Id" Title="Actions">
+        <PropertyColumn Property="x => x.Id" Title="Actions" Sortable="false">
             <CellTemplate>
                 <MudMenu Icon="@Icons.Material.Filled.Edit" 
                          Variant="Variant.Filled" 
@@ -157,19 +181,22 @@ else
             </CellTemplate>
         </PropertyColumn>
         
-        <PropertyColumn Property="x => x.Id" Title="ID" />
-        
-        <PropertyColumn Property="x => x.ParticipantName" Title="Participant">
+        <PropertyColumn Property="x => x.ParticipantName" Title="Participant" SortBy="@(x => x.LastName + x.FirstName + x.Id)">
             <CellTemplate>
-                <div class="d-flex flex-column">
-                    <MudText Typo="Typo.body2">@context.Item.ParticipantName</MudText>
-                    @if (context.Item.HasIncomingTransfer)
-                    {
-                        <MudChip T="string" Size="MudSize.Small" Color="Color.Warning" Icon="@Icons.Material.Filled.Input">
-                            Transfer In
-                        </MudChip>
-                    }
-                </div>
+                <MudStack AlignItems="AlignItems.Start" Spacing="0">
+                    <div class="d-flex align-items-center gap-2">
+                        <MudLink Href="@($"/pages/participants/{context.Item.Id}")">
+                            @context.Item.ParticipantName
+                        </MudLink>
+                        @if (context.Item.HasIncomingTransfer)
+                        {
+                            <MudChip T="string" Size="MudSize.Small" Color="Color.Warning" Icon="@Icons.Material.Filled.Input">
+                                Transfer In
+                            </MudChip>
+                        }
+                    </div>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Item.Id</MudText>
+                </MudStack>
             </CellTemplate>
         </PropertyColumn>
         

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
@@ -1,11 +1,25 @@
 @using ApexCharts
 @using Cfo.Cats.Application.Features.Participants.DTOs
+@using Cfo.Cats.Application.Features.Participants.Queries
 @using Cfo.Cats.Server.UI.Pages.Participants.Components
 @using Cfo.Cats.Domain.Common.Enums
 @using MudSize = MudBlazor.Size
 @using MudAlign = MudBlazor.Align
 
-@inherits CatsComponentBase
+@inherits CatsComponent<GetUnassignedCasesSummary.UnassignedCasesSummaryDto>
+
+@if (Loading)
+{
+    <MudLoading Text="Loading" />
+}
+
+@if (ErrorMessage is not null)
+{
+    <MudAlert Variant="Variant.Filled" Severity="Severity.Error">
+        @ErrorMessage
+    </MudAlert>
+}
+
 <style>
     /* Override for compact toolbars */
 .compact-toolbar .mud-table-toolbar {
@@ -29,21 +43,17 @@
         </div>
     </MudStack>
 
-    @if (_summaryData is not null)
+    @if (Data is not null)
     {
         <MudGrid Spacing="2">
             <MudItem>
-                <MudChip T="string">Custody (@_summaryData.Custody)</MudChip>
-                <MudChip T="string">Community (@_summaryData.Community)</MudChip>
+                <MudChip T="string">Custody (@Data.Custody)</MudChip>
+                <MudChip T="string">Community (@Data.Community)</MudChip>
             </MudItem>
         </MudGrid>
     }
 
-    @if (_loading)
-    {
-        <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-4" />
-    }
-    else if (_chartData != null && _chartData.Any())
+    @if (!Loading && Data is not null && Data.Summaries.Any())
     {
         <ApexChart TItem="ChartDataPoint" Options="ChartOptions" Height="700">
             @{
@@ -67,7 +77,7 @@
             }
         </ApexChart>
     }
-    else
+    else if (!Loading)
     {
         <MudText Typo="Typo.body2" Color="Color.Secondary" Align="MudAlign.Center">No unassigned cases found</MudText>
     }
@@ -82,7 +92,7 @@ else
              Virtualize="true"
              @bind-RowsPerPage="_defaultPageSize"
              Height="calc(100vh - 400px)"
-             Loading="@_loading"
+             Loading="@Loading"
              Hover="true"
              @ref="_table"
              BreakPoint="Breakpoint.Sm"
@@ -161,14 +171,17 @@ else
                     }
                     else
                     {
-                        <MudMenuItem OnClick="@(() => AssignToSelf(context.Item))">
-                            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Size="MudSize.Small" Class="mr-2" />
-                            Assign to Me
-                        </MudMenuItem>
-                        <MudMenuItem OnClick="@(() => AssignToOther(context.Item))">
-                            <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Small" Class="mr-2" />
-                            Assign to Another User
-                        </MudMenuItem>
+                        @if (_canReassign)
+                        {
+                            <MudMenuItem OnClick="@(() => AssignToSelf(context.Item))">
+                                <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Size="MudSize.Small" Class="mr-2" />
+                                Assign to Me
+                            </MudMenuItem>
+                            <MudMenuItem OnClick="@(() => AssignToOther(context.Item))">
+                                <MudIcon Icon="@Icons.Material.Filled.AssignmentInd" Size="MudSize.Small" Class="mr-2" />
+                                Assign to Another User
+                            </MudMenuItem>
+                        }
                     }
                     <MudMenuItem OnClick="@(() => ViewParticipant(context.Item.Id))">
                         <MudIcon Icon="@Icons.Material.Filled.Visibility" Size="MudSize.Small" Class="mr-2" />

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor
@@ -33,11 +33,8 @@
     {
         <MudGrid Spacing="2">
             <MudItem>
-                <MudChip T="string">Total (@_summaryData.TotalCount)</MudChip>
                 <MudChip T="string">Custody (@_summaryData.Custody)</MudChip>
                 <MudChip T="string">Community (@_summaryData.Community)</MudChip>
-                <MudChip T="string" Color="Color.Warning">Unmapped Custody (@_summaryData.UnmappedCustody)</MudChip>
-                <MudChip T="string" Color="Color.Warning">Unmapped Community (@_summaryData.UnmappedCommunity)</MudChip>
             </MudItem>
         </MudGrid>
     }
@@ -133,16 +130,16 @@ else
                     @_locations[Query.Locations[0]]
                 }
             </MudButton>
-            @* <MudButton Size="MudSize.Small" 
-                       Variant="Variant.Outlined" 
-                       Color="Color.Default"
-                       StartIcon="@Icons.Material.Filled.Clear" 
-                       OnClick="ClearFilters">
-                Clear Filters
-            </MudButton> *@
+            <MudSwitch Value="_includeTransferIn"
+                       T="bool"
+                       Color="Color.Primary"
+                       Size="MudBlazor.Size.Small"
+                       ValueChanged="@OnIncludeTransferInChanged">
+                Include Transfer In
+            </MudSwitch>   
             <MudTooltip Text="Clear Filters">
                 <MudIconButton Size="MudBlazor.Size.Small" Icon="@Icons.Material.Filled.Clear" OnClick="@(() => ClearFilters())" />
-            </MudTooltip>            
+            </MudTooltip>
         </div>
     </ToolBarContent>
     <Columns>
@@ -225,17 +222,6 @@ else
                     }
                     <span>@context.Item.CurrentLocation.Name</span>
                 </div>
-            </CellTemplate>
-        </PropertyColumn>
-        
-        <PropertyColumn Property="x => x.TenantName" Title="Tenant" />
-        
-        <PropertyColumn Property="x => x.LastModified" Title="Last Modified">
-            <CellTemplate>
-                @if (context.Item.LastModified.HasValue)
-                {
-                    <MudText Typo="Typo.body2">@context.Item.LastModified.Value.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</MudText>
-                }
             </CellTemplate>
         </PropertyColumn>
     </Columns>

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
@@ -1,0 +1,259 @@
+using ApexCharts;
+using Cfo.Cats.Application.Features.Participants.Commands;
+using Cfo.Cats.Application.Features.Participants.DTOs;
+using Cfo.Cats.Application.Features.Participants.Queries;
+using Cfo.Cats.Application.SecurityConstants;
+using Cfo.Cats.Application.Common.Security;
+using Cfo.Cats.Domain.Identity;
+using Cfo.Cats.Domain.Common.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using MudBlazor;
+
+namespace Cfo.Cats.Server.UI.Components.Dashboard;
+
+public partial class UnassignedCasesDashboardComponent
+{
+    [Parameter]
+    public string TenantId { get; set; } = default!;
+
+    [EditorRequired, Parameter]
+    public bool VisualMode { get; set; }
+
+    [CascadingParameter(Name = "IsDarkMode")]
+    public bool IsDarkMode { get; set; }
+
+    [CascadingParameter]
+    protected Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    [CascadingParameter]
+    public UserProfile? UserProfile { get; set; }
+
+    private int _defaultPageSize = 15;
+    private MudDataGrid<UnassignedCaseDto> _table = default!;
+    private bool _loading;
+    private bool _canSearch;
+    private List<ChartDataPoint>? _chartData;
+    private bool _previousVisualMode;
+    private GetUnassignedCasesSummary.UnassignedCasesSummaryDto? _summaryData;
+
+    private UnassignedCasesWithPagination.Query Query { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var state = await AuthState;
+        _canSearch = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.AuthorizedUser)).Succeeded;
+        _previousVisualMode = VisualMode;
+        
+        if (VisualMode && UserProfile != null)
+        {
+            await LoadChartData();
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Reload chart data when switching to visual mode
+        if (VisualMode && (!_previousVisualMode || _chartData == null) && UserProfile != null)
+        {
+            await LoadChartData();
+        }
+        _previousVisualMode = VisualMode;
+    }
+
+    private async Task LoadChartData()
+    {
+        try
+        {
+            _loading = true;
+            
+            var query = new GetUnassignedCasesSummary.Query
+            {
+                CurrentUser = UserProfile!
+            };
+
+            var result = await GetNewMediator().Send(query);
+            
+            if (result.Succeeded && result.Data != null && result.Data.Summaries.Any())
+            {
+                _summaryData = result.Data;
+                _chartData = result.Data.Summaries
+                    .Select(s => new ChartDataPoint(s.LocationName, s.EnrolmentStatus, s.Count))
+                    .ToList();
+            }
+            else
+            {
+                _summaryData = null;
+                _chartData = new List<ChartDataPoint>();
+            }
+        }
+        finally
+        {
+            _loading = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private List<ChartDataPoint> ChartData()
+    {
+        if (_chartData is null || !_chartData.Any())
+        {
+            return new List<ChartDataPoint>();
+        }
+
+        var locations = _chartData.Select(x => x.LocationName).Distinct().ToList();
+        var statuses = _chartData.Select(x => x.Status).Distinct().ToList();
+
+        return locations.SelectMany(location =>
+            statuses.Select(status => new ChartDataPoint(
+                location,
+                status,
+                _chartData
+                    .Where(x => x.LocationName == location && x.Status == status)
+                    .Sum(x => x.Count))))
+            .ToList();
+    }
+
+    private ApexChartOptions<ChartDataPoint> ChartOptions => new()
+    {
+        Chart = new Chart
+        {
+            Stacked = true,
+        },
+        
+        Legend = new Legend
+        {
+            Show = true,
+            ShowForSingleSeries = true
+        },
+        
+        PlotOptions = new PlotOptions
+        {
+            Bar = new PlotOptionsBar
+            {
+                DataLabels = new PlotOptionsBarDataLabels
+                {
+                    Total = new BarTotalDataLabels
+                    {
+                        Style = new BarDataLabelsStyle
+                        {
+                            FontWeight = "800",
+                            Color = IsDarkMode ? "#FFFFFF" : "#000000",
+                        }
+                    }
+                },
+            },
+        },
+        Yaxis =
+        [
+            new YAxis
+            {
+                Min = 0,
+                ForceNiceScale = true
+            }
+        ],
+        Theme = new Theme
+        {
+            Mode = IsDarkMode ? Mode.Dark : Mode.Light
+        }
+    };
+
+    private async Task<GridData<UnassignedCaseDto>> ServerReload(GridState<UnassignedCaseDto> state, CancellationToken cancellationToken)
+    {
+        try
+        {
+            _loading = true;
+            Query.CurrentUser = UserProfile;
+            Query.OrderBy = state.SortDefinitions.FirstOrDefault()?.SortBy ?? "LastModified";
+            Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true 
+                ? SortDirection.Descending.ToString() 
+                : SortDirection.Ascending.ToString();
+            Query.PageNumber = state.Page + 1;
+            Query.PageSize = state.PageSize;
+
+            var result = await GetNewMediator().Send(Query, cancellationToken);
+
+            return new GridData<UnassignedCaseDto>()
+            {
+                Items = result.Data!.Items,
+                TotalItems = result.Data.TotalItems
+            };
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task OnSearch(string text)
+    {
+        Query.Keyword = text;
+        await _table.ReloadServerData();
+    }
+
+    private async Task EnrolmentStatusChanged(int? statusValue)
+    {
+        Query.EnrolmentStatus = statusValue;
+        await _table.ReloadServerData();
+    }
+
+    private async Task AssignToSelf(UnassignedCaseDto participant)
+    {
+        var command = new AssignUnassignedCase.Command
+        {
+            ParticipantId = participant.Id,
+            CurrentUser = UserProfile,
+            AssigneeId = UserProfile!.UserId
+        };
+
+        var result = await GetNewMediator().Send(command);
+        
+        if (result.Succeeded)
+        {
+            Snackbar.Add($"Case {participant.ParticipantName} assigned to you", Severity.Success);
+            await _table.ReloadServerData();
+        }
+        else
+        {
+            Snackbar.Add(result.ErrorMessage, Severity.Error);
+        }
+    }
+
+    private async Task AssignToOther(UnassignedCaseDto participant)
+    {
+        var parameters = new DialogParameters
+        {
+            { "Participant", participant },
+            { "TenantId", UserProfile!.TenantId },
+            { "CurrentUser", UserProfile }
+        };
+
+        var options = new DialogOptions 
+        { 
+            CloseButton = true, 
+            MaxWidth = MaxWidth.Medium, 
+            FullWidth = true 
+        };
+
+        var dialog = await DialogService.ShowAsync<AssignCaseDialog>(
+            $"Assign {participant.ParticipantName}", 
+            parameters, 
+            options);
+        
+        var state = await dialog.Result;
+
+        if (state?.Canceled == false)
+        {
+            await _table.ReloadServerData();
+        }
+    }
+
+    private void ViewParticipant(string participantId) =>
+        Navigation.NavigateTo($"/pages/participants/{participantId}");
+
+    private void NavigateToTransfers() =>
+        Navigation.NavigateTo("/pages/participants/transfers");
+}
+
+public record ChartDataPoint(string LocationName, EnrolmentStatus Status, int Count);

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
@@ -8,7 +8,6 @@ using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Application.Common.Security;
 using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Server.UI.Components.Locations;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using MudBlazor;
@@ -29,20 +28,16 @@ public partial class UnassignedCasesDashboardComponent
     [CascadingParameter]
     protected Task<AuthenticationState> AuthState { get; set; } = default!;
 
-    [CascadingParameter]
-    public UserProfile? UserProfile { get; set; }
-
     [Inject]
     public ILocationService LocationService { get; set; } = default!;
 
     private int _defaultPageSize = 15;
     private MudDataGrid<UnassignedCaseDto> _table = default!;
-    private bool _loading;
     private bool _canSearch;
-    private List<ChartDataPoint>? _chartData;
+    private bool _canReassign;
+    
     private bool _previousVisualMode;
     private string? _previousTenantId;
-    private GetUnassignedCasesSummary.UnassignedCasesSummaryDto? _summaryData;
     private IDictionary<int, string> _locations = null!;
     private bool _includeTransferIn = true;
 
@@ -53,35 +48,30 @@ public partial class UnassignedCasesDashboardComponent
     /// </summary>
     private UserProfile GetEffectiveUserProfile()
     {
-        if (UserProfile == null)
+        // If TenantId parameter matches CurrentUser's TenantId, use it as-is
+        if (TenantId == CurrentUser.TenantId)
         {
-            return null!;
-        }
-
-        // If TenantId parameter matches UserProfile's TenantId, use it as-is
-        if (TenantId == UserProfile.TenantId)
-        {
-            return UserProfile;
+            return CurrentUser;
         }
 
         // Create a copy with the selected TenantId
         return new UserProfile
         {
-            UserId = UserProfile.UserId,
-            UserName = UserProfile.UserName,
-            Email = UserProfile.Email,
-            DisplayName = UserProfile.DisplayName,
-            PhoneNumber = UserProfile.PhoneNumber,
+            UserId = CurrentUser.UserId,
+            UserName = CurrentUser.UserName,
+            Email = CurrentUser.Email,
+            DisplayName = CurrentUser.DisplayName,
+            PhoneNumber = CurrentUser.PhoneNumber,
             TenantId = TenantId,
-            TenantName = UserProfile.TenantName,
-            AssignedRoles = UserProfile.AssignedRoles,
-            DefaultRole = UserProfile.DefaultRole,
-            Contracts = UserProfile.Contracts,
-            IsActive = UserProfile.IsActive,
-            Provider = UserProfile.Provider,
-            SuperiorName = UserProfile.SuperiorName,
-            SuperiorId = UserProfile.SuperiorId,
-            ProfilePictureDataUrl = UserProfile.ProfilePictureDataUrl
+            TenantName = CurrentUser.TenantName,
+            AssignedRoles = CurrentUser.AssignedRoles,
+            DefaultRole = CurrentUser.DefaultRole,
+            Contracts = CurrentUser.Contracts,
+            IsActive = CurrentUser.IsActive,
+            Provider = CurrentUser.Provider,
+            SuperiorName = CurrentUser.SuperiorName,
+            SuperiorId = CurrentUser.SuperiorId,
+            ProfilePictureDataUrl = CurrentUser.ProfilePictureDataUrl
         };
     }
 
@@ -89,22 +79,20 @@ public partial class UnassignedCasesDashboardComponent
     {
         var state = await AuthState;
         _canSearch = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.AuthorizedUser)).Succeeded;
+        _canReassign = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.Reassign)).Succeeded;
         _previousVisualMode = VisualMode;
         _previousTenantId = TenantId;
-        
+
         _locations = LocationService.GetVisibleLocations(TenantId)
                         .ToDictionary(k => k.Id, e => e.Name);
-        
-        if (VisualMode && UserProfile != null)
-        {
-            await LoadChartData();
-        }
+
+        await base.OnInitializedAsync();
     }
 
     protected override async Task OnParametersSetAsync()
     {
         var tenantChanged = _previousTenantId != TenantId;
-        
+
         // Reload locations if tenant changed
         if (tenantChanged)
         {
@@ -112,70 +100,47 @@ public partial class UnassignedCasesDashboardComponent
                 .ToDictionary(k => k.Id, e => e.Name);
             _previousTenantId = TenantId;
         }
-        
-        // Reload chart data when switching to visual mode or tenant changed
-        if (VisualMode && (tenantChanged || !_previousVisualMode || _chartData == null) && UserProfile != null)
+
+        // Reload summary data when switching to visual mode or tenant changed
+        if (VisualMode && (tenantChanged || !_previousVisualMode))
         {
-            await LoadChartData();
+            await LoadDataAsync();
         }
-        
+
         // Reload table data if tenant changed and in tabular mode
         if (!VisualMode && tenantChanged && _table != null)
         {
             await _table.ReloadServerData();
         }
-        
+
         _previousVisualMode = VisualMode;
     }
 
-    private async Task LoadChartData()
-    {
-        try
+    protected override IRequest<Result<GetUnassignedCasesSummary.UnassignedCasesSummaryDto>> CreateQuery()
+        => new GetUnassignedCasesSummary.Query
         {
-            _loading = true;
-            
-            var query = new GetUnassignedCasesSummary.Query
-            {
-                CurrentUser = GetEffectiveUserProfile()
-            };
-
-            var result = await GetNewMediator().Send(query);
-            
-            if (result.Succeeded && result.Data != null && result.Data.Summaries.Any())
-            {
-                _summaryData = result.Data;
-                _chartData = result.Data.Summaries
-                    .Select(s => new ChartDataPoint(s.LocationName, s.EnrolmentStatus, s.Count))
-                    .ToList();
-            }
-            else
-            {
-                _summaryData = null;
-                _chartData = new List<ChartDataPoint>();
-            }
-        }
-        finally
-        {
-            _loading = false;
-            await InvokeAsync(StateHasChanged);
-        }
-    }
+            CurrentUser = GetEffectiveUserProfile()
+        };
 
     private List<ChartDataPoint> ChartData()
     {
-        if (_chartData is null || !_chartData.Any())
+        var chartSource = Data?.Summaries
+            .Select(s => new ChartDataPoint(s.LocationName, s.EnrolmentStatus, s.Count))
+            .ToList() ?? [];
+
+        if (!chartSource.Any())
         {
-            return new List<ChartDataPoint>();
+            return [];
         }
 
-        var locations = _chartData.Select(x => x.LocationName).Distinct().ToList();
-        var statuses = _chartData.Select(x => x.Status).Distinct().ToList();
+        var locations = chartSource.Select(x => x.LocationName).Distinct().ToList();
+        var statuses = chartSource.Select(x => x.Status).Distinct().ToList();
 
         return locations.SelectMany(location =>
             statuses.Select(status => new ChartDataPoint(
                 location,
                 status,
-                _chartData
+                chartSource
                     .Where(x => x.LocationName == location && x.Status == status)
                     .Sum(x => x.Count))))
             .ToList();
@@ -229,7 +194,7 @@ public partial class UnassignedCasesDashboardComponent
     {
         try
         {
-            _loading = true;
+            Loading = true;
             Query.CurrentUser = GetEffectiveUserProfile();
             Query.OrderBy = state.SortDefinitions.FirstOrDefault()?.SortBy ?? "LastModified";
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true 
@@ -239,7 +204,7 @@ public partial class UnassignedCasesDashboardComponent
             Query.PageSize = state.PageSize;
             Query.IncludeTransferIn = _includeTransferIn;
 
-            var result = await GetNewMediator().Send(Query, cancellationToken);
+            var result = await Service.Send(Query, cancellationToken);
 
             return new GridData<UnassignedCaseDto>()
             {
@@ -249,7 +214,7 @@ public partial class UnassignedCasesDashboardComponent
         }
         finally
         {
-            _loading = false;
+            Loading = false;
         }
     }
 
@@ -301,14 +266,16 @@ public partial class UnassignedCasesDashboardComponent
 
     private async Task AssignToSelf(UnassignedCaseDto participant)
     {
+        var effectiveUser = GetEffectiveUserProfile();
+
         var command = new AssignUnassignedCase.Command
         {
             ParticipantId = participant.Id,
-            CurrentUser = UserProfile,
-            AssigneeId = UserProfile!.UserId
+            CurrentUser = effectiveUser,
+            AssigneeId = effectiveUser.UserId
         };
 
-        var result = await GetNewMediator().Send(command);
+        var result = await Service.Send(command);
         
         if (result.Succeeded)
         {
@@ -323,11 +290,26 @@ public partial class UnassignedCasesDashboardComponent
 
     private async Task AssignToOther(UnassignedCaseDto participant)
     {
-        var parameters = new DialogParameters
+        var effectiveUser = GetEffectiveUserProfile();
+
+        var parameters = new DialogParameters<AssignCaseDialog>
         {
-            { "Participant", participant },
-            { "TenantId", TenantId },
-            { "CurrentUser", UserProfile }
+            {
+                x => x.Participant,
+                participant
+            },
+            {
+                x => x.TenantId,
+                TenantId
+            },
+            {
+                x => x.Model,
+                new AssignUnassignedCase.Command
+                {
+                    ParticipantId = participant.Id,
+                    CurrentUser = effectiveUser
+                }
+            }
         };
 
         var options = new DialogOptions 

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
@@ -44,6 +44,7 @@ public partial class UnassignedCasesDashboardComponent
     private string? _previousTenantId;
     private GetUnassignedCasesSummary.UnassignedCasesSummaryDto? _summaryData;
     private IDictionary<int, string> _locations = null!;
+    private bool _includeTransferIn = true;
 
     private UnassignedCasesWithPagination.Query Query { get; set; } = new();
 
@@ -236,6 +237,7 @@ public partial class UnassignedCasesDashboardComponent
                 : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
+            Query.IncludeTransferIn = _includeTransferIn;
 
             var result = await GetNewMediator().Send(Query, cancellationToken);
 
@@ -286,6 +288,14 @@ public partial class UnassignedCasesDashboardComponent
         Query.Keyword = null;
         Query.EnrolmentStatus = null;
         Query.Locations = [];
+        Query.IncludeTransferIn = _includeTransferIn;
+        await _table.ReloadServerData();
+    }
+
+    private async Task OnIncludeTransferInChanged(bool value)
+    {
+        _includeTransferIn = value;
+        Query.IncludeTransferIn = value;
         await _table.ReloadServerData();
     }
 

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
@@ -78,8 +78,8 @@ public partial class UnassignedCasesDashboardComponent
     protected override async Task OnInitializedAsync()
     {
         var state = await AuthState;
-        _canSearch = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.AuthorizedUser)).Succeeded;
-        _canReassign = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.Reassign)).Succeeded;
+        _canSearch = (await AuthService.AuthorizeAsync(state.User, null, SecurityPolicies.AuthorizedUser)).Succeeded;
+        _canReassign = (await AuthService.AuthorizeAsync(state.User, null, SecurityPolicies.Reassign)).Succeeded;
         _previousVisualMode = VisualMode;
         _previousTenantId = TenantId;
 

--- a/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
+++ b/src/Server.UI/Components/Dashboard/UnassignedCasesDashboardComponent.razor.cs
@@ -1,11 +1,13 @@
 using ApexCharts;
+using Cfo.Cats.Application.Common.Interfaces.Locations;
+using Cfo.Cats.Application.Features.Locations.DTOs;
 using Cfo.Cats.Application.Features.Participants.Commands;
 using Cfo.Cats.Application.Features.Participants.DTOs;
 using Cfo.Cats.Application.Features.Participants.Queries;
 using Cfo.Cats.Application.SecurityConstants;
 using Cfo.Cats.Application.Common.Security;
-using Cfo.Cats.Domain.Identity;
 using Cfo.Cats.Domain.Common.Enums;
+using Cfo.Cats.Server.UI.Components.Locations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -30,21 +32,67 @@ public partial class UnassignedCasesDashboardComponent
     [CascadingParameter]
     public UserProfile? UserProfile { get; set; }
 
+    [Inject]
+    public ILocationService LocationService { get; set; } = default!;
+
     private int _defaultPageSize = 15;
     private MudDataGrid<UnassignedCaseDto> _table = default!;
     private bool _loading;
     private bool _canSearch;
     private List<ChartDataPoint>? _chartData;
     private bool _previousVisualMode;
+    private string? _previousTenantId;
     private GetUnassignedCasesSummary.UnassignedCasesSummaryDto? _summaryData;
+    private IDictionary<int, string> _locations = null!;
 
     private UnassignedCasesWithPagination.Query Query { get; set; } = new();
+
+    /// <summary>
+    /// Creates a UserProfile with the selected TenantId for querying data
+    /// </summary>
+    private UserProfile GetEffectiveUserProfile()
+    {
+        if (UserProfile == null)
+        {
+            return null!;
+        }
+
+        // If TenantId parameter matches UserProfile's TenantId, use it as-is
+        if (TenantId == UserProfile.TenantId)
+        {
+            return UserProfile;
+        }
+
+        // Create a copy with the selected TenantId
+        return new UserProfile
+        {
+            UserId = UserProfile.UserId,
+            UserName = UserProfile.UserName,
+            Email = UserProfile.Email,
+            DisplayName = UserProfile.DisplayName,
+            PhoneNumber = UserProfile.PhoneNumber,
+            TenantId = TenantId,
+            TenantName = UserProfile.TenantName,
+            AssignedRoles = UserProfile.AssignedRoles,
+            DefaultRole = UserProfile.DefaultRole,
+            Contracts = UserProfile.Contracts,
+            IsActive = UserProfile.IsActive,
+            Provider = UserProfile.Provider,
+            SuperiorName = UserProfile.SuperiorName,
+            SuperiorId = UserProfile.SuperiorId,
+            ProfilePictureDataUrl = UserProfile.ProfilePictureDataUrl
+        };
+    }
 
     protected override async Task OnInitializedAsync()
     {
         var state = await AuthState;
         _canSearch = (await AuthService.AuthorizeAsync(state.User, SecurityPolicies.AuthorizedUser)).Succeeded;
         _previousVisualMode = VisualMode;
+        _previousTenantId = TenantId;
+        
+        _locations = LocationService.GetVisibleLocations(TenantId)
+                        .ToDictionary(k => k.Id, e => e.Name);
         
         if (VisualMode && UserProfile != null)
         {
@@ -54,11 +102,28 @@ public partial class UnassignedCasesDashboardComponent
 
     protected override async Task OnParametersSetAsync()
     {
-        // Reload chart data when switching to visual mode
-        if (VisualMode && (!_previousVisualMode || _chartData == null) && UserProfile != null)
+        var tenantChanged = _previousTenantId != TenantId;
+        
+        // Reload locations if tenant changed
+        if (tenantChanged)
+        {
+            _locations = LocationService.GetVisibleLocations(TenantId)
+                .ToDictionary(k => k.Id, e => e.Name);
+            _previousTenantId = TenantId;
+        }
+        
+        // Reload chart data when switching to visual mode or tenant changed
+        if (VisualMode && (tenantChanged || !_previousVisualMode || _chartData == null) && UserProfile != null)
         {
             await LoadChartData();
         }
+        
+        // Reload table data if tenant changed and in tabular mode
+        if (!VisualMode && tenantChanged && _table != null)
+        {
+            await _table.ReloadServerData();
+        }
+        
         _previousVisualMode = VisualMode;
     }
 
@@ -70,7 +135,7 @@ public partial class UnassignedCasesDashboardComponent
             
             var query = new GetUnassignedCasesSummary.Query
             {
-                CurrentUser = UserProfile!
+                CurrentUser = GetEffectiveUserProfile()
             };
 
             var result = await GetNewMediator().Send(query);
@@ -164,7 +229,7 @@ public partial class UnassignedCasesDashboardComponent
         try
         {
             _loading = true;
-            Query.CurrentUser = UserProfile;
+            Query.CurrentUser = GetEffectiveUserProfile();
             Query.OrderBy = state.SortDefinitions.FirstOrDefault()?.SortBy ?? "LastModified";
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true 
                 ? SortDirection.Descending.ToString() 
@@ -198,6 +263,32 @@ public partial class UnassignedCasesDashboardComponent
         await _table.ReloadServerData();
     }
 
+    private async Task ShowSelectLocationDialog()
+    {
+        var parameters = new DialogParameters<SelectLocationDialog>
+        {
+            { "CurrentUser", GetEffectiveUserProfile() }
+        };
+
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.Large, FullWidth = false };
+        var dialog = await DialogService.ShowAsync<SelectLocationDialog>("Select a location", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: LocationDto location })
+        {
+            Query.Locations = [location.Id];
+            await _table.ReloadServerData();
+        }
+    }
+
+    private async Task ClearFilters()
+    {
+        Query.Keyword = null;
+        Query.EnrolmentStatus = null;
+        Query.Locations = [];
+        await _table.ReloadServerData();
+    }
+
     private async Task AssignToSelf(UnassignedCaseDto participant)
     {
         var command = new AssignUnassignedCase.Command
@@ -225,7 +316,7 @@ public partial class UnassignedCasesDashboardComponent
         var parameters = new DialogParameters
         {
             { "Participant", participant },
-            { "TenantId", UserProfile!.TenantId },
+            { "TenantId", TenantId },
             { "CurrentUser", UserProfile }
         };
 

--- a/src/Server.UI/Pages/Dashboard/Dashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/Dashboard.razor
@@ -94,5 +94,5 @@
     {
         <MyArchivedCases/>
     }
-
+    
 </MudGrid>

--- a/src/Server.UI/Pages/Dashboard/QualityAssuranceDashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/QualityAssuranceDashboard.razor
@@ -81,7 +81,7 @@
                         VisualMode="@_visualMode" 
                         UserId="@CurrentUser.UserId" />
                 </MudTabPanel>
-
+             
             </MudTabs>
         </MudTabPanel>
         

--- a/src/Server.UI/Pages/Dashboard/SupportWorkerDashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/SupportWorkerDashboard.razor
@@ -1,8 +1,4 @@
-@using Cfo.Cats.Application.Features.Identity.DTOs
-@using Cfo.Cats.Application.SecurityConstants
 @using Cfo.Cats.Server.UI.Components.Dashboard
-@using Cfo.Cats.Server.UI.Components.Users
-@using Cfo.Cats.Server.UI.Pages.Dashboard.Components
 
 @page "/pages/dashboard/supportworker"
 @attribute [Authorize(Policy = SecurityPolicies.AuthorizedUser)]
@@ -23,7 +19,7 @@
         
 		@if (CurrentUser.AssignedRoles is not [])
 		{
-			<MudLink OnClick="DisplayOptionsDialog" Disabled="@(CurrentUser.AssignedRoles is [])">
+			<MudLink OnClick="@DisplayOptionsDialog" Disabled="@(CurrentUser.AssignedRoles is [])">
 				@SelectedDisplayName
 			</MudLink>
 		}
@@ -94,6 +90,9 @@
                     </MudTabPanel>
                     <MudTabPanel Text="Reassessments" Class="pa-3">
                         <ReassessmentDashboardComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode"/>
+                    </MudTabPanel>
+                    <MudTabPanel Text="Recent Approved Activities" Class="pa-3">
+                        <RecentlyApprovedActivitiesComponent DateRange="@_dateRange" UserId="@SelectedUserId" @key="SelectedUserId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode"/>
                     </MudTabPanel>
                 </MudTabs>
             </MudTabPanel>

--- a/src/Server.UI/Pages/Dashboard/TenantDashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/TenantDashboard.razor
@@ -15,7 +15,7 @@
     <MudStack Row="true" AlignItems="AlignItems.Center">
 		@if (CurrentUser.AssignedRoles is not [])
 		{
-			<MudLink OnClick="DisplayOptionsDialog" Disabled="@(CurrentUser.AssignedRoles is [])">
+			<MudLink OnClick="@DisplayOptionsDialog" Disabled="@(CurrentUser.AssignedRoles is [])">
 				@SelectedDisplayName
 			</MudLink>
 		}
@@ -27,8 +27,6 @@
 		</MudSwitch>
 	</MudStack>
 </MudStack>
-
-
 
 <MudStack>
 	@if(SelectedTenantId is null)
@@ -87,6 +85,10 @@
                     </MudTabPanel>
                     <MudTabPanel Text="Reassessments" Class="pa-3">
                         <ReassessmentDashboardComponent DateRange="@_dateRange" TenantId="@SelectedTenantId" @key="SelectedTenantId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode" />
+                    </MudTabPanel>
+   
+                    <MudTabPanel Text="Recent Approved Activities" Class="pa-3">
+                        <RecentlyApprovedActivitiesComponent DateRange="@_dateRange" TenantId="@SelectedTenantId" @key="SelectedTenantId + (_dateRange.Start?.Ticks ?? 0) + (_dateRange.End?.Ticks ?? 0)" VisualMode="@_visualMode"/>
                     </MudTabPanel>
                 </MudTabs>
             </MudTabPanel>

--- a/src/Server.UI/Pages/Dashboard/TenantDashboard.razor
+++ b/src/Server.UI/Pages/Dashboard/TenantDashboard.razor
@@ -52,6 +52,9 @@
                     <MudTabPanel Text="Initiatives" Class="pa-3">
                         <InitiativeObjectivesDashboardComponent TenantId="@SelectedTenantId" @key="@SelectedTenantId" VisualMode="@_visualMode" />
                     </MudTabPanel>
+                    <MudTabPanel Text="Unassigned Cases" Class="pa-3">
+                        <UnassignedCasesDashboardComponent TenantId="@SelectedTenantId" @key="@SelectedTenantId" VisualMode="@_visualMode" />
+                    </MudTabPanel>
                 </MudTabs>
             </MudTabPanel>
             <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Score">


### PR DESCRIPTION
This pull request introduces a new set of features to support the management and assignment of unassigned participant cases, including backend commands, queries, validation, and a new UI dialog component. The changes provide the ability to query, paginate, and assign unassigned cases, with robust validation and security. The most important changes are grouped below:

**Backend Functionality for Unassigned Cases:**

* Added `AssignUnassignedCase` command, handler, and validator to allow assigning an unassigned participant to a user, with comprehensive validation (e.g., participant existence, ownership, transfer status, and tenant scoping) and authorization enforcement (`RequestAuthorize`) (`src/Application/Features/Participants/Commands/AssignUnassignedCase.cs`).
* Added `GetUnassignedCasesSummary` query and handler to provide a summary of unassigned cases, grouped by location and status, including chip totals for custody and community locations (`src/Application/Features/Participants/Queries/GetUnassignedCasesSummary.cs`).
* Implemented `UnassignedCasesWithPagination` query, handler, and validator to enable paginated, filterable, and sortable retrieval of unassigned cases, with keyword search, location and status filters, and tenant-aware access control (`src/Application/Features/Participants/Queries/UnassignedCasesWithPagination.cs`).

**DTOs and Mapping:**

* Introduced `UnassignedCaseDto` with mapping from `Participant`, encapsulating all relevant participant and location information for unassigned cases, including transfer details and tenant info (`src/Application/Features/Participants/DTOs/UnassignedCaseDto.cs`).

**UI Integration:**

* Added `AssignCaseDialog.razor` component, providing a modal dialog for assigning an unassigned case to a user, with validation, user selection, and feedback on assignment success or failure (`src/Server.UI/Components/Dashboard/AssignCaseDialog.razor`).

## 🔗 Related Work
- Closes: Cfodev 1687 orphaned participants view
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

---Displays unassigned cases with ability to filter on location, status and include/exclude, search and assign

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

---Unassigned cases were not visible anywhere

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

---N/A

## 🔄 Changes
- Added:
- Updated:
- Removed:

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1. Log in as a user with access to Tenant dashboard
2. Navigate to Dashboards>Tenants>Case Summary>Unassigned Cases then switch 'Visual Mode' to tabular data
3. Transfer In cases should have menu item to navigate to Transfer In screen
4. Test if all filters and search is working, should be able to assign non-archived cases to another user within correct location  

Expected result:
> What should happen if everything is correct?

---Should be able to assign a case from this screen except Transfer In cases. If trying to assign Archived cases or to wrong user relevant validation message should appear

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.
<img width="1831" height="446" alt="image" src="https://github.com/user-attachments/assets/90fd3bd0-7d0c-4406-9f2f-d0687fb64232" />

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.
It doesn't include cases associated with Unmapped custody/community location
---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"
