### PR TITLE
CFODEV-1706: Register payment service as a single active consumer

### DIFF
--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -9,11 +9,16 @@ internal static class AppExtensions
     {
         var replicaCount = int.TryParse(builder.Configuration["Replicas"], out var n) ? n : 1;
         
-        builder.AddProject<Projects.Server_UI>("cats")
-        .WithCatsDatabaseReference(databases.CatsDb)
-        .WithReference(rabbit)
-        .WaitFor(rabbit)
-        .WithReplicas(replicaCount);        
+        var cats = builder.AddProject<Projects.Server_UI>("cats")
+            .WithCatsDatabaseReference(databases.CatsDb)
+            .WithReference(rabbit)
+            .WaitFor(rabbit);
+
+        if(replicaCount > 1)
+        {
+            cats.WithReplicas(replicaCount);        
+        }
+
         return builder;
     }
 

--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -7,10 +7,13 @@ internal static class AppExtensions
         IResourceBuilder<RabbitMQServerResource> rabbit,
         CatsDatabaseResources databases)
     {
+        var replicaCount = int.TryParse(builder.Configuration["Replicas"], out var n) ? n : 1;
+        
         builder.AddProject<Projects.Server_UI>("cats")
         .WithCatsDatabaseReference(databases.CatsDb)
         .WithReference(rabbit)
-        .WaitFor(rabbit);        
+        .WaitFor(rabbit)
+        .WithReplicas(replicaCount);        
         return builder;
     }
 

--- a/src/Aspire/Cats.AppHost/appsettings.json
+++ b/src/Aspire/Cats.AppHost/appsettings.json
@@ -10,5 +10,5 @@
     "sqlPassword": "P@ssword123!"
   },
   "MigrationBehaviour": "WaitFor",
-  "Replicas": 3
+  "Replicas": 1
 }

--- a/src/Aspire/Cats.AppHost/appsettings.json
+++ b/src/Aspire/Cats.AppHost/appsettings.json
@@ -9,5 +9,6 @@
   "Parameters": {
     "sqlPassword": "P@ssword123!"
   },
-  "MigrationBehaviour": "WaitFor"
+  "MigrationBehaviour": "WaitFor",
+  "Replicas": 3
 }

--- a/src/Infrastructure/Services/MessageHandling/PaymentBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/PaymentBackgroundService.cs
@@ -40,7 +40,8 @@ public class PaymentBackgroundService(IServiceProvider provider, IConfiguration 
 
         _bus = Configure.With(_activator)
             .Transport(t => t.UseRabbitMq(configuration.GetConnectionString("rabbit"), options.Value.PaymentService)
-                .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange))
+                .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange)
+                .InputQueueOptions(q => q.AddArgument(RabbitMQ.Client.Headers.XSingleActiveConsumer, true))) // Ensure only one instance of the service processes messages at a time to prevent duplicate payments
             .Options(o =>
             {
                 o.SetNumberOfWorkers(1);


### PR DESCRIPTION
## 🔗 Related Work
- Related: #1104 

---

## 📌 Summary
Configures the `PaymentBackgroundService` RabbitMQ input queue with `x-single-active-consumer: true` to ensure that only one pod actively consumes payment messages at any time when CATS is running with multiple replicas.

---

## 🎯 Purpose / Motivation
To support the cloud platform migration, CATS will run with multiple replicas in production. Without single active consumer enforcement, all replicas would compete to consume from the payment queue simultaneously. This creates a risk of duplicate payment records being written — e.g. the same activity approval triggering two `RecordActivityPayment` handlers across different pods.

The `x-single-active-consumer` RabbitMQ queue argument solves this at the broker level: one consumer is designated active, and all others are held in reserve. If the active consumer disconnects, RabbitMQ promotes a standby automatically, providing failover without duplication.

---

## 🧠 Approach
- Used the `InputQueueOptions` builder on `UseRabbitMq(...)` to set the `x-single-active-consumer` queue argument at declaration time via `RabbitMQ.Client.Headers.XSingleActiveConsumer`.
- The existing `SetNumberOfWorkers(1)` and `SetMaxParallelism(1)` configuration is complementary — it ensures sequential processing within a single consumer, combining with SAC to give strong ordering and exactly-once processing guarantees across replicas.
- No handler logic was changed.

> ⚠️ **Important:** `x-single-active-consumer` is a queue-level argument set at declaration time. If the payment queue already exists in RabbitMQ **without** this argument, the broker will reject the redeclaration with a channel error. The existing queue must be **deleted** before deploying this change so it can be recreated with the correct arguments.

---

## 🔄 Changes
- Updated: `src/Infrastructure/Services/MessageHandling/PaymentBackgroundService.cs`
  - Added `.InputQueueOptions(q => q.AddArgument(RabbitMQ.Client.Headers.XSingleActiveConsumer, true))` to the Rebus transport configuration

---
## 🧪 How to Test

1. In `src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs`, set `WithReplicas` to `3`:
   ```csharp
   builder.AddProject<Projects.Server_UI>("cats")
       .WithCatsDatabaseReference(databases.CatsDb)
       .WithReference(rabbit)
       .WaitFor(rabbit)
       .WithReplicas(3); // <-- Here
   ```

2. **Delete the existing payment queue** in RabbitMQ (via the management UI at `http://localhost:15672`) so it is recreated with the `x-single-active-consumer` argument on next startup. The queue name matches `options.Value.PaymentService` from `RabbitSettings`.

*Alternatively, delete your RabbitMQ container and volume locally, and proceed*

4. Start the solution via Aspire (`Cats.AppHost`). Three CATS replicas will spin up, each starting a `PaymentBackgroundService` connected to the same queue.

5. Open the RabbitMQ management UI (`http://localhost:15672`) → **Queues** → select the payment queue. Under **Consumers**, you should see 3 consumers listed — **1 active** and **2 inactive** (standby).

Expected result:
> Verify only one consumer is active. If the active consumer's pod is killed, RabbitMQ promotes a standby and processing continues without message loss.

---

## 📸 Screenshots / Output (if applicable)
> RabbitMQ management UI should show the payment queue with `x-single-active-consumer: true` in its arguments and a single active consumer.

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> The payment queue **must be deleted and recreated** in every environment (dev, training, pre-production, production) before or during deployment. Deploying without doing this will cause a RabbitMQ channel error and prevent the `PaymentBackgroundService` from starting.

---

## 🙋 Notes for Reviewers
> N/A
