### PR TITLE
Make deployment manual only, from any branch to develop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,6 @@ name: deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main,develop]
 
 concurrency:
   group: deploy-${{ github.ref }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow configuration. The change removes the automatic trigger for deployments on pushes to the `main` and `develop` branches, so deployments will now only occur when manually triggered.

* Removed the `push` event trigger for the `main` and `develop` branches in `.github/workflows/deploy.yml`, making deployments manual-only.