### PR TITLE
Displays participants viewed in last 7 days by currently logged in user

### DIFF
--- a/src/Application/Features/Participants/DTOs/ParticipantPaginationDto.cs
+++ b/src/Application/Features/Participants/DTOs/ParticipantPaginationDto.cs
@@ -50,4 +50,7 @@ public class ParticipantPaginationDto
     [Description("Assigned On")]
     public DateTime? AssignedOn { get; set; }
     
+    [Description("Accessed On")]
+    public DateTime? AccessedOn { get; set; }    
+    
 }

--- a/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
+++ b/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
@@ -38,7 +38,7 @@ public static class ParticipantsWithPagination
         public string? OwnerId { get; set; }
         public string? TenantId { get; set; }
         public DateTime? RiskDue { get; set; }        
-        public RecentlyAssignedFilter RecentlyAssigned { get; set; } = RecentlyAssignedFilter.All;    
+        public RecentParticipantFilter RecentAction { get; set; } = RecentParticipantFilter.All;    
         }
 
     public class Handler(IUnitOfWork unitOfWork) : IRequestHandler<Query, Result<PaginatedData<ParticipantPaginationDto>>>
@@ -132,11 +132,16 @@ public static class ParticipantsWithPagination
                 query = query.Where(p => p.RiskDue <= request.RiskDue);
             }
 
-            // Apply recently assigned filter
-            DateTime? recentlyAssignedCutoff = request.RecentlyAssigned switch
+            DateTime? recentlyAssignedCutoff = request.RecentAction switch
             {
-                RecentlyAssignedFilter.Last10Days => DateTime.UtcNow.Date.AddDays(-10),
-                RecentlyAssignedFilter.Last30Days => DateTime.UtcNow.Date.AddDays(-30),
+                RecentParticipantFilter.AssignedLast10Days => DateTime.UtcNow.Date.AddDays(-10),
+                RecentParticipantFilter.AssignedLast30Days => DateTime.UtcNow.Date.AddDays(-30),
+                _ => null
+            };
+
+            DateTime? recentlyVisitedCutoff = request.RecentAction switch
+            {
+                RecentParticipantFilter.VisitedLast7Days => DateTime.UtcNow.Date.AddDays(-7),
                 _ => null
             };
 
@@ -152,7 +157,19 @@ public static class ParticipantsWithPagination
 
                 query = query.Where(p => participantIdsWithRecentOwnership.Contains(p.Id));
             }
-    
+
+            if (recentlyVisitedCutoff.HasValue)
+            {
+                // Filter participants who have access audit trail within the date range for currently logged in user
+                var participantIdsWithAccessAuditTrail = context.AccessAuditTrails
+                    .Where(oh => oh.UserId == request.CurrentUser!.UserId
+                                 && oh.AccessDate >= recentlyVisitedCutoff.Value)
+                    .Select(oh => oh.ParticipantId)
+                    .Distinct();
+
+                query = query.Where(p => participantIdsWithAccessAuditTrail.Contains(p.Id));
+            }
+
             var count = await query.AsNoTracking().CountAsync(cancellationToken);
 
             // Get the latest ownership assignment date for each participant if recently assigned filter is active
@@ -218,7 +235,69 @@ public static class ParticipantsWithPagination
                               }).ToArray(),
                       ConsentGranted = p.DateOfFirstConsent
                   }
-                : from p in query
+                : 
+                (recentlyVisitedCutoff.HasValue
+                ? from p in query
+                  join oh in (
+                      from h in context.AccessAuditTrails
+                      where h.UserId == request.CurrentUser!.UserId
+                      group h by h.ParticipantId into g
+                      select new
+                      {
+                          ParticipantId = g.Key,
+                          MostRecentAccess = g.Max(x => x.AccessDate)
+                      }
+                  ) on p.Id equals oh.ParticipantId into visitedGroup
+                  from visited in visitedGroup.DefaultIfEmpty()
+                  select new ParticipantPaginationDto()
+                  {
+                      AccessedOn = visited != null ? visited.MostRecentAccess : (DateTime?)null,
+                      EnrolmentStatus = p.EnrolmentStatus!,
+                      Owner = p.Owner!.DisplayName!,
+                      ConsentStatus = p.ConsentStatus!,
+                      CurrentLocation = new LocationDto
+                      {
+                          Id = p.CurrentLocation.Id,
+                          Name = p.CurrentLocation.Name,
+                          GenderProvision = p.CurrentLocation.GenderProvision,
+                          LocationType = p.CurrentLocation.LocationType,
+                          ContractName = p.CurrentLocation.Contract!.Description
+                      },
+                      Id = p.Id,
+                      EnrolmentLocation = p.EnrolmentLocation == null
+                          ? null
+                          : new LocationDto
+                          {
+                              Name = p.EnrolmentLocation.Name,
+                              GenderProvision = p.EnrolmentLocation.GenderProvision,
+                              LocationType = p.EnrolmentLocation.LocationType,
+                              Id = p.EnrolmentLocation.Id,
+                              ContractName = p.EnrolmentLocation.Contract!.Description
+                          },
+                      FirstName = p.FirstName,
+                      LastName = p.LastName,
+                      RiskDue = p.RiskDue,
+                      RiskDueReason = p.RiskDueReason!,
+                      Tenant = p.Owner!.TenantName!,
+                      Labels = (
+                              from pl in context.ParticipantLabels
+                              where EF.Property<string>(pl, "_participantId") == p.Id
+                                  && pl.Lifetime.EndDate > DateTime.UtcNow
+                              orderby pl.Lifetime.StartDate descending
+                              select new LabelDto
+                              {
+                                  Name = pl.Label.Name,
+                                  Description = pl.Label.Description,
+                                  Scope = pl.Label.Scope,
+                                  Contract = pl.Label.ContractId!,
+                                  Id = pl.Label.Id.Value,
+                                  AppIcon = pl.Label.AppIcon,
+                                  Colour = pl.Label.Colour,
+                                  Variant = pl.Label.Variant
+                              }).ToArray(),
+                      ConsentGranted = p.DateOfFirstConsent
+                  }
+                :from p in query
                   select new ParticipantPaginationDto()
                   {
                       EnrolmentStatus = p.EnrolmentStatus!,
@@ -265,7 +344,7 @@ public static class ParticipantsWithPagination
                                   Variant = pl.Label.Variant
                               }).ToArray(),
                       ConsentGranted = p.DateOfFirstConsent
-                  };
+                  });
 
             var sortColumn = request.OrderBy.Trim().ToLowerInvariant() switch
             {
@@ -280,6 +359,7 @@ public static class ParticipantsWithPagination
                 "riskdue" => "RiskDue",
                 "lastname" => "LastName",
                 "assignedon" => "AssignedOn",
+                "accessedon" => "AccessedOn",
                 _ => "Id"
             };
 

--- a/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
+++ b/src/Application/Features/Participants/Queries/ParticipantsWithPaginationQuery.cs
@@ -172,8 +172,8 @@ public static class ParticipantsWithPagination
 
             var count = await query.AsNoTracking().CountAsync(cancellationToken);
 
-            // Get the latest ownership assignment date for each participant if recently assigned filter is active
-            var transformedQuery = recentlyAssignedCutoff.HasValue
+                        // Only join to the extra history tables when the selected filter needs those dates.
+                        var transformedSource = recentlyAssignedCutoff.HasValue
                 ? from p in query
                   join oh in (
                       from h in context.ParticipantOwnershipHistories
@@ -187,56 +187,13 @@ public static class ParticipantsWithPagination
                       }
                   ) on p.Id equals oh.ParticipantId into ownershipGroup
                   from ownership in ownershipGroup.DefaultIfEmpty()
-                  select new ParticipantPaginationDto()
+                  select new
                   {
                       AssignedOn = ownership != null ? ownership.MostRecentFrom : (DateTime?)null,
-                      EnrolmentStatus = p.EnrolmentStatus!,
-                      Owner = p.Owner!.DisplayName!,
-                      ConsentStatus = p.ConsentStatus!,
-                      CurrentLocation = new LocationDto
-                      {
-                          Id = p.CurrentLocation.Id,
-                          Name = p.CurrentLocation.Name,
-                          GenderProvision = p.CurrentLocation.GenderProvision,
-                          LocationType = p.CurrentLocation.LocationType,
-                          ContractName = p.CurrentLocation.Contract!.Description
-                      },
-                      Id = p.Id,
-                      EnrolmentLocation = p.EnrolmentLocation == null
-                          ? null
-                          : new LocationDto
-                          {
-                              Name = p.EnrolmentLocation.Name,
-                              GenderProvision = p.EnrolmentLocation.GenderProvision,
-                              LocationType = p.EnrolmentLocation.LocationType,
-                              Id = p.EnrolmentLocation.Id,
-                              ContractName = p.EnrolmentLocation.Contract!.Description
-                          },
-                      FirstName = p.FirstName,
-                      LastName = p.LastName,
-                      RiskDue = p.RiskDue,
-                      RiskDueReason = p.RiskDueReason!,
-                      Tenant = p.Owner!.TenantName!,
-                      Labels = (
-                              from pl in context.ParticipantLabels
-                              where EF.Property<string>(pl, "_participantId") == p.Id
-                                  && pl.Lifetime.EndDate > DateTime.UtcNow
-                              orderby pl.Lifetime.StartDate descending
-                              select new LabelDto
-                              {
-                                  Name = pl.Label.Name,
-                                  Description = pl.Label.Description,
-                                  Scope = pl.Label.Scope,
-                                  Contract = pl.Label.ContractId!,
-                                  Id = pl.Label.Id.Value,
-                                  AppIcon = pl.Label.AppIcon,
-                                  Colour = pl.Label.Colour,
-                                  Variant = pl.Label.Variant
-                              }).ToArray(),
-                      ConsentGranted = p.DateOfFirstConsent
+                      AccessedOn = (DateTime?)null,
+                      Participant = p
                   }
-                : 
-                (recentlyVisitedCutoff.HasValue
+                : recentlyVisitedCutoff.HasValue
                 ? from p in query
                   join oh in (
                       from h in context.AccessAuditTrails
@@ -249,102 +206,71 @@ public static class ParticipantsWithPagination
                       }
                   ) on p.Id equals oh.ParticipantId into visitedGroup
                   from visited in visitedGroup.DefaultIfEmpty()
-                  select new ParticipantPaginationDto()
+                  select new
                   {
+                      AssignedOn = (DateTime?)null,
                       AccessedOn = visited != null ? visited.MostRecentAccess : (DateTime?)null,
-                      EnrolmentStatus = p.EnrolmentStatus!,
-                      Owner = p.Owner!.DisplayName!,
-                      ConsentStatus = p.ConsentStatus!,
-                      CurrentLocation = new LocationDto
-                      {
-                          Id = p.CurrentLocation.Id,
-                          Name = p.CurrentLocation.Name,
-                          GenderProvision = p.CurrentLocation.GenderProvision,
-                          LocationType = p.CurrentLocation.LocationType,
-                          ContractName = p.CurrentLocation.Contract!.Description
-                      },
-                      Id = p.Id,
-                      EnrolmentLocation = p.EnrolmentLocation == null
-                          ? null
-                          : new LocationDto
-                          {
-                              Name = p.EnrolmentLocation.Name,
-                              GenderProvision = p.EnrolmentLocation.GenderProvision,
-                              LocationType = p.EnrolmentLocation.LocationType,
-                              Id = p.EnrolmentLocation.Id,
-                              ContractName = p.EnrolmentLocation.Contract!.Description
-                          },
-                      FirstName = p.FirstName,
-                      LastName = p.LastName,
-                      RiskDue = p.RiskDue,
-                      RiskDueReason = p.RiskDueReason!,
-                      Tenant = p.Owner!.TenantName!,
-                      Labels = (
-                              from pl in context.ParticipantLabels
-                              where EF.Property<string>(pl, "_participantId") == p.Id
-                                  && pl.Lifetime.EndDate > DateTime.UtcNow
-                              orderby pl.Lifetime.StartDate descending
-                              select new LabelDto
-                              {
-                                  Name = pl.Label.Name,
-                                  Description = pl.Label.Description,
-                                  Scope = pl.Label.Scope,
-                                  Contract = pl.Label.ContractId!,
-                                  Id = pl.Label.Id.Value,
-                                  AppIcon = pl.Label.AppIcon,
-                                  Colour = pl.Label.Colour,
-                                  Variant = pl.Label.Variant
-                              }).ToArray(),
-                      ConsentGranted = p.DateOfFirstConsent
+                      Participant = p
                   }
-                :from p in query
-                  select new ParticipantPaginationDto()
+                : from p in query
+                  select new
                   {
-                      EnrolmentStatus = p.EnrolmentStatus!,
-                      Owner = p.Owner!.DisplayName!,
-                      ConsentStatus = p.ConsentStatus!,
-                      CurrentLocation = new LocationDto
-                      {
-                          Id = p.CurrentLocation.Id,
-                          Name = p.CurrentLocation.Name,
-                          GenderProvision = p.CurrentLocation.GenderProvision,
-                          LocationType = p.CurrentLocation.LocationType,
-                          ContractName = p.CurrentLocation.Contract!.Description
-                      },
-                      Id = p.Id,
-                      EnrolmentLocation = p.EnrolmentLocation == null
-                          ? null
-                          : new LocationDto
-                          {
-                              Name = p.EnrolmentLocation.Name,
-                              GenderProvision = p.EnrolmentLocation.GenderProvision,
-                              LocationType = p.EnrolmentLocation.LocationType,
-                              Id = p.EnrolmentLocation.Id,
-                              ContractName = p.EnrolmentLocation.Contract!.Description
-                          },
-                      FirstName = p.FirstName,
-                      LastName = p.LastName,
-                      RiskDue = p.RiskDue,
-                      RiskDueReason = p.RiskDueReason!,
-                      Tenant = p.Owner!.TenantName!,
-                      Labels = (
-                              from pl in context.ParticipantLabels
-                              where EF.Property<string>(pl, "_participantId") == p.Id
-                                  && pl.Lifetime.EndDate > DateTime.UtcNow
-                              orderby pl.Lifetime.StartDate descending
-                              select new LabelDto
-                              {
-                                  Name = pl.Label.Name,
-                                  Description = pl.Label.Description,
-                                  Scope = pl.Label.Scope,
-                                  Contract = pl.Label.ContractId!,
-                                  Id = pl.Label.Id.Value,
-                                  AppIcon = pl.Label.AppIcon,
-                                  Colour = pl.Label.Colour,
-                                  Variant = pl.Label.Variant
-                              }).ToArray(),
-                      ConsentGranted = p.DateOfFirstConsent
-                  });
+                      AssignedOn = (DateTime?)null,
+                      AccessedOn = (DateTime?)null,
+                      Participant = p
+                  };
+
+            var transformedQuery =
+                from item in transformedSource
+                select new ParticipantPaginationDto()
+                {
+                    AssignedOn = item.AssignedOn,
+                    AccessedOn = item.AccessedOn,
+                    EnrolmentStatus = item.Participant.EnrolmentStatus!,
+                    Owner = item.Participant.Owner!.DisplayName!,
+                    ConsentStatus = item.Participant.ConsentStatus!,
+                    CurrentLocation = new LocationDto
+                    {
+                        Id = item.Participant.CurrentLocation.Id,
+                        Name = item.Participant.CurrentLocation.Name,
+                        GenderProvision = item.Participant.CurrentLocation.GenderProvision,
+                        LocationType = item.Participant.CurrentLocation.LocationType,
+                        ContractName = item.Participant.CurrentLocation.Contract!.Description
+                    },
+                    Id = item.Participant.Id,
+                    EnrolmentLocation = item.Participant.EnrolmentLocation == null
+                        ? null
+                        : new LocationDto
+                        {
+                            Name = item.Participant.EnrolmentLocation.Name,
+                            GenderProvision = item.Participant.EnrolmentLocation.GenderProvision,
+                            LocationType = item.Participant.EnrolmentLocation.LocationType,
+                            Id = item.Participant.EnrolmentLocation.Id,
+                            ContractName = item.Participant.EnrolmentLocation.Contract!.Description
+                        },
+                    FirstName = item.Participant.FirstName,
+                    LastName = item.Participant.LastName,
+                    RiskDue = item.Participant.RiskDue,
+                    RiskDueReason = item.Participant.RiskDueReason!,
+                    Tenant = item.Participant.Owner!.TenantName!,
+                    Labels = (
+                            from pl in context.ParticipantLabels
+                            where EF.Property<string>(pl, "_participantId") == item.Participant.Id
+                                && pl.Lifetime.EndDate > DateTime.UtcNow
+                            orderby pl.Lifetime.StartDate descending
+                            select new LabelDto
+                            {
+                                Name = pl.Label.Name,
+                                Description = pl.Label.Description,
+                                Scope = pl.Label.Scope,
+                                Contract = pl.Label.ContractId!,
+                                Id = pl.Label.Id.Value,
+                                AppIcon = pl.Label.AppIcon,
+                                Colour = pl.Label.Colour,
+                                Variant = pl.Label.Variant
+                            }).ToArray(),
+                    ConsentGranted = item.Participant.DateOfFirstConsent
+                };
 
             var sortColumn = request.OrderBy.Trim().ToLowerInvariant() switch
             {

--- a/src/Application/Features/Participants/Specifications/RecentlyAssignedFilter.cs
+++ b/src/Application/Features/Participants/Specifications/RecentlyAssignedFilter.cs
@@ -1,14 +1,17 @@
 namespace Cfo.Cats.Application.Features.Participants.Specifications;
 
-public enum RecentlyAssignedFilter
+public enum RecentParticipantFilter
 {
     [Description("All")]
     All,
     
-    [Description("Last 10 Days")]
-    Last10Days,
+    [Description("Assigned (Last 10 Days)")]
+    AssignedLast10Days,
     
-    [Description("Last 30 Days")]
-    Last30Days,
+    [Description("Assigned (Last 30 Days)")]
+    AssignedLast30Days,
+    
+    [Description("Visited (Last 7 Days)")]
+    VisitedLast7Days,
 
 }

--- a/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsSessionStorage.cs
@@ -29,7 +29,7 @@ public record ParticipantsSessionData
             LabelId = query.Label,
             OwnerId = query.OwnerId,
             RiskDue = query.RiskDue,
-            RecentlyAssigned = query.RecentlyAssigned,
+            RecentlyAssigned = query.RecentAction,
             Tabular = tabular
         };
 
@@ -43,7 +43,7 @@ public record ParticipantsSessionData
     public required LabelId? LabelId { get; init; }
     public required string? OwnerId { get; init; } 
     public required DateTime? RiskDue { get; init; } 
-    public RecentlyAssignedFilter RecentlyAssigned { get; init; } = RecentlyAssignedFilter.All;
+    public RecentParticipantFilter RecentlyAssigned { get; init; } = RecentParticipantFilter.All;
 
     public bool Tabular {get; init; }
     

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor
@@ -30,8 +30,10 @@
                 <MudMenuItem OnClick="@(() => ClearQuickFilter())">All</MudMenuItem>
                 <MudMenuItem OnClick="@(() => ApplyMyParticipantsFilter())">My Participants</MudMenuItem>
                 <MudMenuItem OnClick="@(() => ApplyOverdueRiskFilter())">Overdue risk</MudMenuItem>
-                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last10Days))">Assigned (Last 10 Days)</MudMenuItem>
-                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentlyAssignedFilter.Last30Days))">Assigned (Last 30 Days)</MudMenuItem>            
+                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentParticipantFilter.AssignedLast10Days))">Assigned (Last 10 Days)</MudMenuItem>
+                <MudMenuItem OnClick="@(() => RecentlyAssignedFilterChanged(RecentParticipantFilter.AssignedLast30Days))">Assigned (Last 30 Days)</MudMenuItem>
+                <MudMenuItem OnClick="@(() => RecentlyVisitedFilterChanged())">Visited (Last 7 Days)</MudMenuItem>
+
             </MudMenu>
             <MudTextField T="string" Value="@Query.Keyword" Placeholder="@ConstantString.Search"
                           ValueChanged="@(OnSearch)" Clearable="true" ShrinkLabel="true"
@@ -155,9 +157,13 @@
                 <MudMenuItem Label="Assignee" OnClick="@(() => SortBy("Owner"))"/>
                 <MudMenuItem Label="Tenant" OnClick="@(() => SortBy("Tenant"))"/>
                 <MudMenuItem Label="Risk Due" OnClick="@(() => SortBy("RiskDue"))"/>
-                @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                @if (Query.RecentAction == RecentParticipantFilter.AssignedLast10Days || Query.RecentAction == RecentParticipantFilter.AssignedLast30Days)
                 {
                     <MudMenuItem Label="Assigned On" OnClick="@(() => SortBy("AssignedOn"))"/>
+                }
+                @if (Query.RecentAction == RecentParticipantFilter.VisitedLast7Days)
+                {
+                    <MudMenuItem Label="Accessed On" OnClick="@(() => SortBy("AccessedOn"))"/>
                 }
                 <MudMenuItem Label="Current Location" OnClick="@(() => SortBy("CurrentLocation"))"/>
                 <MudMenuItem Label="Enrolment Location" OnClick="@(() => SortBy("EnrolmentLocation"))"/>
@@ -187,9 +193,13 @@
                     <MudTh>Location</MudTh>
                     <MudTh>Enrolled At</MudTh>
                     <MudTh>Assignee</MudTh>
-                    @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                    @if (Query.RecentAction == RecentParticipantFilter.AssignedLast10Days || Query.RecentAction == RecentParticipantFilter.AssignedLast30Days)
                     {
                         <MudTh>Assigned On</MudTh>
+                    }
+                    @if (Query.RecentAction == RecentParticipantFilter.VisitedLast7Days)
+                    {
+                        <MudTh>Accessed On</MudTh>
                     }
                     <MudTh>Risk Due</MudTh>
                 </HeaderContent>
@@ -209,9 +219,13 @@
                     <MudTd>@context.CurrentLocation.Name</MudTd>
                     <MudTd>@context.EnrolmentLocation?.Name</MudTd>
                     <MudTd>@context.Owner</MudTd>
-                    @if (Query.RecentlyAssigned != RecentlyAssignedFilter.All)
+                    @if (Query.RecentAction == RecentParticipantFilter.AssignedLast10Days || Query.RecentAction == RecentParticipantFilter.AssignedLast30Days)
                     {
                         <MudTd>@context.AssignedOn?.ToShortDateString()</MudTd>
+                    }
+                    @if (Query.RecentAction == RecentParticipantFilter.VisitedLast7Days)
+                    {
+                        <MudTd>@context.AccessedOn?.ToShortDateString()</MudTd>
                     }
                     <MudTd>
                         @context.RiskDue.ToShortDateOrEmptyString()
@@ -257,9 +271,17 @@
                                     }
                                 <MudSpacer />
                                 <MudText Typo="Typo.body2">
-                                    Assigned to @item.Owner (@item.Tenant)@if (Query.RecentlyAssigned != RecentlyAssignedFilter.All && item.AssignedOn.HasValue)
+                                    Assigned to @item.Owner 
+                                    (@item.Tenant)@if ((Query.RecentAction == RecentParticipantFilter.AssignedLast10Days 
+                                    || Query.RecentAction == RecentParticipantFilter.AssignedLast30Days) 
+                                    && item.AssignedOn.HasValue)
                                     {
                                         @($" on {item.AssignedOn.Value.ToShortDateString()}")
+                                    }
+                                    @if (Query.RecentAction == RecentParticipantFilter.VisitedLast7Days 
+                                    && item.AccessedOn.HasValue)
+                                    {
+                                        @($" last accessed on {item.AccessedOn.Value.ToShortDateString()}")
                                     }
                                 </MudText>
                             </MudStack>

--- a/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
+++ b/src/Server.UI/Pages/Participants/ParticipantsV2.razor.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using ActualLab.Fusion;
 using Cfo.Cats.Application.Common.Interfaces.Identity;
 using Cfo.Cats.Application.Common.Interfaces.Locations;
 using Cfo.Cats.Application.Common.Interfaces.MultiTenant;
@@ -31,8 +29,9 @@ public enum QuickFilter
     All,
     MyParticipants,
     OverdueRisk,
-    Last10Days,
-    Last30Days
+    AssignedLast10Days,
+    AssignedLast30Days,
+    VisitedLast7Days
 }
 
 public partial class ParticipantsV2
@@ -133,14 +132,15 @@ public partial class ParticipantsV2
             Query.OwnerId = sd.OwnerId;
             Query.TenantId = sd.TenantId;
             Query.RiskDue = sd.RiskDue;
-            Query.RecentlyAssigned = sd.RecentlyAssigned;
+            Query.RecentAction = sd.RecentlyAssigned;
             Tabular = sd.Tabular;
             
             // Sync _currentFilter based on restored state
             _currentFilter = sd.RecentlyAssigned switch
             {
-                RecentlyAssignedFilter.Last10Days => QuickFilter.Last10Days,
-                RecentlyAssignedFilter.Last30Days => QuickFilter.Last30Days,
+                RecentParticipantFilter.AssignedLast10Days => QuickFilter.AssignedLast10Days,
+                RecentParticipantFilter.AssignedLast30Days => QuickFilter.AssignedLast30Days,
+                RecentParticipantFilter.VisitedLast7Days => QuickFilter.VisitedLast7Days,
                 _ when sd.RiskDue.HasValue => QuickFilter.OverdueRisk,
                 _ when !string.IsNullOrEmpty(sd.OwnerId) => QuickFilter.MyParticipants,
                 _ => QuickFilter.All
@@ -168,24 +168,35 @@ public partial class ParticipantsV2
         await OnRefresh();
     }
 
-    private async Task RecentlyAssignedFilterChanged(RecentlyAssignedFilter filter)
+    private async Task RecentlyAssignedFilterChanged(RecentParticipantFilter filter)
     {
         // Reset query like other quick filters to avoid unintended filter combinations
         ResetQuery();
         
-        Query.RecentlyAssigned = filter;
+        Query.RecentAction = filter;
         
         // Update the current filter tracking
         _currentFilter = filter switch
         {
-            RecentlyAssignedFilter.Last10Days => QuickFilter.Last10Days,
-            RecentlyAssignedFilter.Last30Days => QuickFilter.Last30Days,
+            RecentParticipantFilter.AssignedLast10Days => QuickFilter.AssignedLast10Days,
+            RecentParticipantFilter.AssignedLast30Days => QuickFilter.AssignedLast30Days,
             _ => QuickFilter.All
         };
         
         await OnRefresh();
     }
 
+    private async Task RecentlyVisitedFilterChanged()
+    {
+        // Reset query like other quick filters to avoid unintended filter combinations
+        ResetQuery();
+        
+        Query.RecentAction = RecentParticipantFilter.VisitedLast7Days;
+        // Update the current filter tracking
+        _currentFilter = QuickFilter.VisitedLast7Days;
+        
+        await OnRefresh();
+    }
     private async Task OnSearch(string text)
     {
         Query.Keyword = text;
@@ -390,7 +401,7 @@ public partial class ParticipantsV2
         Query.Label = null;
         Query.OwnerId = null;
         Query.RiskDue = null;
-        Query.RecentlyAssigned = RecentlyAssignedFilter.All;
+        Query.RecentAction = RecentParticipantFilter.All;
         Query.JustMyCases = false;
         Tabular = false;
     }
@@ -400,8 +411,9 @@ public partial class ParticipantsV2
         {
             QuickFilter.MyParticipants => "My Participants",
             QuickFilter.OverdueRisk => "Overdue Risk",
-            QuickFilter.Last10Days => "Assigned (Last 10 Days)",
-            QuickFilter.Last30Days => "Assigned (Last 30 Days)",
+            QuickFilter.AssignedLast10Days => "Assigned (Last 10 Days)",
+            QuickFilter.AssignedLast30Days => "Assigned (Last 30 Days)",
+            QuickFilter.VisitedLast7Days => "Visited (Last 7 Days)",
             _ => "All"
         };
     


### PR DESCRIPTION
This pull request introduces a new "Recently Visited" filter for participants, allowing users to filter and sort participants by their recent access (last 7 days), in addition to the existing "Recently Assigned" filters. The implementation includes backend and UI changes to support the new filter, refactors the filtering enums and logic for clarity, and updates the data model to expose the last accessed date.

**Key changes:**

### Filtering and Sorting Enhancements

- Added a new `Visited (Last 7 Days)` filter option to the participant filtering logic by introducing `RecentParticipantFilter.VisitedLast7Days` and updating the backend query to support filtering participants by recent access activity. [[1]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecL41-R41) [[2]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecL135-R144) [[3]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR161-R172) [[4]](diffhunk://#diff-9eaffff3f56992ba95325b696654a2bf3df028513664a24c906720d911c1ceebL3-R15)
- Updated participant sorting to allow sorting by the new `AccessedOn` field, in addition to the existing `AssignedOn` field.

### Data Model and DTO Updates

- Added an `AccessedOn` property to `ParticipantPaginationDto` to expose the most recent access date for each participant.
- Modified backend queries to populate `AccessedOn` in the DTO when the "Recently Visited" filter is active. [[1]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecR238-R299) [[2]](diffhunk://#diff-c8a067f467131ebd3ef02a4b6d2536ee557950be8c364b93c9990409f52611ecL268-R347)

### Enum and State Refactoring

- Renamed and expanded the filter enum from `RecentlyAssignedFilter` to `RecentParticipantFilter` to include both assignment and access-based filters, updating usage throughout the codebase for clarity and maintainability. [[1]](diffhunk://#diff-9eaffff3f56992ba95325b696654a2bf3df028513664a24c906720d911c1ceebL3-R15) [[2]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69L32-R32) [[3]](diffhunk://#diff-38032a90432dd90940a025a28ae0f75c598d07e86e0eb033da52c5b102b26c69L46-R46) [[4]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cL136-R143) [[5]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cL171-R199) [[6]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cL393-R404)

### UI Updates

- Updated the Participants page UI to support the new filter, including new menu items, dynamic table columns, and descriptive labels for both assigned and accessed dates. [[1]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L33-R36) [[2]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L158-R167) [[3]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L190-R203) [[4]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L212-R229) [[5]](diffhunk://#diff-3d56e32eaaa599e49778490807981c8147100af2e43f44c8969a33ca2e7bb256L260-R285) [[6]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cL34-R34) [[7]](diffhunk://#diff-f6e96cd36b9075297b43eb2aab2d0a7528447c0ae2bea5877561d45e44d9039cL403-R416)
- Added handler methods for the new filter in the code-behind to ensure correct query state and UI updates.

These changes collectively improve the flexibility and usability of participant filtering, making it easier for users to find participants based on recent activity, not just assignment.
## 🔗 Related Work
- Closes: #
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

---Display cases open/visited in last 7 days by the logged in user

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

---

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

---

## 🔄 Changes
- Added:
- Updated:
- Removed:

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1.
2.
3.

Expected result:
> What should happen if everything is correct?

---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

---
<img width="1825" height="550" alt="image" src="https://github.com/user-attachments/assets/148f3e29-f0de-4e78-b3d6-c6af41691e21" />


## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.

---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"
