### PR TITLE
Add .well-known/security.txt redirect to MoJ central file

### DIFF
--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -198,7 +198,13 @@ public static class DependencyInjection
         app.UseExceptionHandler();
         
         app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
-        
+
+        app.MapGet("/.well-known/security.txt", () =>
+            Results.Redirect(
+                "https://security-guidance.service.justice.gov.uk/.well-known/security.txt",
+                permanent: true))
+            .AllowAnonymous();
+
         app.MapAdditionalIdentityEndpoints();
         app.UseForwardedHeaders();
       


### PR DESCRIPTION
## 🔗 Related Work
- Closes: N/A
- Related: N/A

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

Adds an anonymous `HTTP 301` redirect from `/.well-known/security.txt` to the MoJ-maintained central `security.txt` file.

---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

MoJ security guidance requires every service where the MoJ is responsible for cyber security to expose `/.well-known/security.txt` so security researchers can find vulnerability-disclosure contacts (per RFC 9116 / securitytxt.org). Rather than hosting our own copy, the guidance mandates redirecting to the central file so the contacts and the mandatory `Expires` field stay current and never drift per service.

---

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

- Mapped a minimal-API `GET /.well-known/security.txt` endpoint in `ConfigureServer` (Server.UI `DependencyInjection.cs`) that returns `Results.Redirect(..., permanent: true)` — i.e. an `HTTP 301`.
- Target is the canonical MoJ URL `https://security-guidance.service.justice.gov.uk/.well-known/security.txt`, exactly as required by the guidance (not the raw GitHub copy).
- Marked `.AllowAnonymous()` so the path is reachable from the public Internet without authentication, even though the rest of the application requires sign-in. This is an explicit requirement of the guidance.
- Chosen over a static `wwwroot/.well-known/security.txt` file deliberately: a self-hosted copy drifts, and its mandatory `Expires` field goes stale (the central file's had already expired). Redirecting keeps a single source of truth.

Reviewers: please confirm the redirect remains anonymous behind any auth/forwarded-headers/reverse-proxy configuration in deployed environments.

Reference: https://security-guidance.service.justice.gov.uk/implement-security-txt/

---

## 🔄 Changes
- Added: `GET /.well-known/security.txt` 301 redirect endpoint (anonymous) in `src/Server.UI/DependencyInjection.cs`.
- Updated: —
- Removed: —

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1. Run the application (`Cats.AppHost` via Aspire).
2. Without signing in, request `/.well-known/security.txt`, e.g. `curl -I https://localhost:<port>/.well-known/security.txt`.
3. Observe the response status and `Location` header.

Expected result:
> `HTTP/1.1 301` (permanent redirect) with `Location: https://security-guidance.service.justice.gov.uk/.well-known/security.txt`, returned without requiring authentication.

---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

```
$ curl -I https://localhost:<port>/.well-known/security.txt
HTTP/1.1 301 Moved Permanently
Location: https://security-guidance.service.justice.gov.uk/.well-known/security.txt
```

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [x] Security impact

Details:
> Security-positive change: publishes the MoJ vulnerability-disclosure route as required by MoJ guidance. No data, schema or behavioural changes to existing functionality. The new endpoint is intentionally anonymous and read-only (redirect only).

---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.
> e.g. "Unsure about approach in X", "Focus on Y logic"

- Confirm the endpoint placement (after `MapRazorComponents`, before `MapAdditionalIdentityEndpoints`) is appropriate.
- Confirm `AllowAnonymous()` is sufficient to bypass any global authorization/session-timeout middleware in all environments.
