### PR TITLE
Include day in generated app number on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
       
       - name: Generate app version
         id: version
-        run: echo "app_version=$(date +'%Y.%m').${{ github.run_number }}" >> $GITHUB_OUTPUT
+        run: echo "app_version=$(date +'%Y.%m.%d').${{ github.run_number }}" >> $GITHUB_OUTPUT
 
       - name: Generate Kubernetes Manifests
         run: |


### PR DESCRIPTION
Updated the app version generation command to use the format `YYYY.MM.DD.<run_number>` instead of `YYYY.MM.<run_number>`, adding the day to the version string.