### PR TITLE
Do not deploy port forward pod for migrate/seeding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,7 @@ jobs:
             --set serviceAccountName="${KUBE_NAMESPACE}" \
             --set migrator.image.repository="${REGISTRY}/${REPOSITORY}" \
             --set migrator.image.tag="migrator-${{ github.sha }}" \
+            --set rdsPortForward.enabled=false \
             --timeout 5m
           kubectl -n "${KUBE_NAMESPACE}" wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s pod -l app=migrator
         env:
@@ -133,6 +134,7 @@ jobs:
             --set serviceAccountName="${KUBE_NAMESPACE}" \
             --set seeder.image.repository="${REGISTRY}/${REPOSITORY}" \
             --set seeder.image.tag="seeder-${{ github.sha }}" \
+            --set rdsPortForward.enabled=false \
             --timeout 5m
           kubectl -n "${KUBE_NAMESPACE}" wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s pod -l app=seeder
         env:


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow by explicitly disabling RDS port forwarding for both the migrator and seeder Helm releases. This prevents the releases from being applied multiple times 