### PR TITLE
Address issue in cake.cs where clean wasn't actually doing anything.

### DIFF
--- a/cake.cs
+++ b/cake.cs
@@ -12,8 +12,25 @@ Task("Clean")
         {
             Force = true
         };
-        CleanDirectories("./src/**/bin/{configuration}", settings);
-        CleanDirectory("./artifacts", settings);
+        
+        var dirsToClean = GetDirectories("./**/bin");
+        dirsToClean.Add(GetDirectories("./**/obj"));
+        dirsToClean.Add("./artifacts");
+
+        foreach(var dir in dirsToClean)
+        {
+            Information($"Cleaning directory {dir}");
+            CleanDirectory(dir);    
+        }
+
+        var filesToClean = GetFiles("./*.zip");
+
+        foreach(var file in filesToClean)
+        {
+            Information($"Deleting file {file}");
+            DeleteFile(file);
+        }
+
     });
 
 Task("Restore")


### PR DESCRIPTION
The CleanDirectories method wasn't working with the glob pattern.

This addresses that issue and forces the clean to empty obj and bin folders.
