### PR TITLE
Update actual labs to 13

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="ActualLab.Fusion" Version="12.5.2" />
-    <PackageVersion Include="ActualLab.Fusion.Blazor" Version="12.5.2" />
-    <PackageVersion Include="ActualLab.Fusion.Ext.Services" Version="12.5.2" />
-    <PackageVersion Include="ActualLab.Generators" Version="12.5.2" />
+    <PackageVersion Include="ActualLab.Fusion" Version="13.0.12" />
+    <PackageVersion Include="ActualLab.Fusion.Blazor" Version="13.0.12" />
+    <PackageVersion Include="ActualLab.Fusion.Ext.Services" Version="13.0.12" />
+    <PackageVersion Include="ActualLab.Generators" Version="13.0.12" />
     <PackageVersion Include="Ardalis.SmartEnum" Version="8.2.0" />
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />


### PR DESCRIPTION
This pull request updates several package dependencies to newer versions. The main change is upgrading the `ActualLab.Fusion` and related packages from version `12.5.2` to `13.0.12` in the `Directory.Packages.props` file.

Dependency updates:

* Upgraded `ActualLab.Fusion`, `ActualLab.Fusion.Blazor`, `ActualLab.Fusion.Ext.Services`, and `ActualLab.Generators` packages from version `12.5.2` to `13.0.12` to ensure compatibility with the latest features and bug fixes.