### PR TITLE
CCPM-18: Enforce TLS validation + run containers as non-root

### DIFF
--- a/helm_deploy/cats/templates/migrator-pod.yaml
+++ b/helm_deploy/cats/templates/migrator-pod.yaml
@@ -14,8 +14,6 @@ spec:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
-    runAsUser: 1001
-    runAsGroup: 1001
     runAsNonRoot: true
   containers:
     - name: migrator

--- a/helm_deploy/cats/templates/seeder-pod.yaml
+++ b/helm_deploy/cats/templates/seeder-pod.yaml
@@ -14,8 +14,6 @@ spec:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
-    runAsUser: 1001
-    runAsGroup: 1001
     runAsNonRoot: true
   containers:
     - name: seeder

--- a/helm_deploy/cats/values.yaml
+++ b/helm_deploy/cats/values.yaml
@@ -10,7 +10,7 @@ serviceAccountName: ""
 # ---------------------------------------------------------------------------
 
 connectionStrings:
-  catsDb: &catsDb "Server=$(DATABASE_ADDRESS);Database=CatsDb;User Id=$(DATABASE_USERNAME);Password=$(DATABASE_PASSWORD);TrustServerCertificate=True;"
+  catsDb: &catsDb "Server=$(DATABASE_ADDRESS);Database=CatsDb;User Id=$(DATABASE_USERNAME);Password=$(DATABASE_PASSWORD);TrustServerCertificate=False;Encrypt=True;"
   rabbit: &rabbit "amqp://$(RABBIT_USER):$(RABBIT_PASS)@rabbitmq-service:5672"
   redis: &redis "redis-service:6379"
 

--- a/src/Database/Dockerfile
+++ b/src/Database/Dockerfile
@@ -20,6 +20,10 @@ COPY --from=build /opt/sqlpackage /opt/sqlpackage
 RUN chmod -R a+rx /opt/sqlpackage
 ENV PATH="$PATH:/opt/sqlpackage"
 
+# Trust the Amazon RDS eu-west-2 root CAs for TLS to the RDS SQL Server (fetched at build).
+ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
+RUN update-ca-certificates
+
 # Copy DACPAC and entrypoint
 COPY --from=build /src/src/Database/CatsDb/bin/Release/CatsDb.dacpac ./CatsDb.dacpac
 COPY src/Database/entrypoint.sh ./

--- a/src/Database/Dockerfile
+++ b/src/Database/Dockerfile
@@ -29,4 +29,8 @@ COPY --from=build /src/src/Database/CatsDb/bin/Release/CatsDb.dacpac ./CatsDb.da
 COPY src/Database/entrypoint.sh ./
 RUN chmod +x ./entrypoint.sh
 
+# Run as the image's non-root user (Cloud Platform requires non-root).
+# APP_UID is a default set by the Microsoft .NET base image (uid 1654).
+USER $APP_UID
+
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/DatabaseSeeding/Dockerfile
+++ b/src/DatabaseSeeding/Dockerfile
@@ -17,4 +17,8 @@ WORKDIR /app
 
 COPY --from=build /app/publish ./
 
+# Trust the Amazon RDS eu-west-2 root CAs for TLS to the RDS SQL Server (fetched at build).
+ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
+RUN update-ca-certificates
+
 ENTRYPOINT ["dotnet", "DatabaseSeeding.dll"]

--- a/src/DatabaseSeeding/Dockerfile
+++ b/src/DatabaseSeeding/Dockerfile
@@ -21,4 +21,8 @@ COPY --from=build /app/publish ./
 ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
 RUN update-ca-certificates
 
+# Run as the image's non-root user (Cloud Platform requires non-root).
+# APP_UID is a default set by the Microsoft .NET base image (uid 1654).
+USER $APP_UID
+
 ENTRYPOINT ["dotnet", "DatabaseSeeding.dll"]

--- a/src/Server.UI/Dockerfile
+++ b/src/Server.UI/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=build /app/publish ./
 ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
 RUN update-ca-certificates
 
+# Run as the image's non-root user (Cloud Platform requires non-root).
+# APP_UID is a default set by the Microsoft .NET base image (uid 1654).
 USER $APP_UID
 
 EXPOSE 8080

--- a/src/Server.UI/Dockerfile
+++ b/src/Server.UI/Dockerfile
@@ -16,6 +16,11 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0.9@sha256:7644f992230d35cf230017189d403
 WORKDIR /app
 
 COPY --from=build /app/publish ./
+
+# Trust the Amazon RDS eu-west-2 root CAs for TLS to the RDS SQL Server (fetched at build).
+ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
+RUN update-ca-certificates
+
 USER $APP_UID
 
 EXPOSE 8080

--- a/src/Worker/Dockerfile
+++ b/src/Worker/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=build /app/publish ./
 ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
 RUN update-ca-certificates
 
+# Run as the image's non-root user (Cloud Platform requires non-root).
+# APP_UID is a default set by the Microsoft .NET base image (uid 1654).
 USER $APP_UID
 
 EXPOSE 8080

--- a/src/Worker/Dockerfile
+++ b/src/Worker/Dockerfile
@@ -16,6 +16,11 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0.9@sha256:7644f992230d35cf230017189d403
 WORKDIR /app
 
 COPY --from=build /app/publish ./
+
+# Trust the Amazon RDS eu-west-2 root CAs for TLS to the RDS SQL Server (fetched at build).
+ADD https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem /usr/local/share/ca-certificates/rds-eu-west-2-bundle.crt
+RUN update-ca-certificates
+
 USER $APP_UID
 
 EXPOSE 8080


### PR DESCRIPTION
Two security hardening changes to the database-connecting containers:

- **Enforce TLS verification to RDS (primary).** Use`Encrypt=True;TrustServerCertificate=False`, so the client must trust Amazon's RDS root CA. Each image now fetches the Amazon RDS eu-west-2 root CA bundle at build time and adds it to the system trust store, so TLS connections validate the server's certificate chain instead of trusting it blindly. Applied to all four DB-connecting images (Server.UI, Worker, seeder, migrator).

- **Run containers as non-root (secondary).** The seeder and migrator images previously defaulted to root; they now run as the image's non-root app user (uid 1654), matching Server.UI and Worker. The pod securityContext relies on the image user plus `runAsNonRoot: true`, in line with Cloud Platform guidance.
