### PR TITLE
Hotfix for warning showing on enrolments PQA

### DIFF
--- a/src/Server.UI/Pages/QA/Enrolments/PQA.razor
+++ b/src/Server.UI/Pages/QA/Enrolments/PQA.razor
@@ -63,7 +63,7 @@
                 <MudTabPanel Text="Right To Work" Style="min-width: 210px;" BadgeColor="Color.Info" BadgeData="@_participantDto.RightToWorks.Length" Icon="@_rtwIcon" IconColor="@_rtwIconColor" ToolTip="@_rtwInfo">
                     <RightToWorkTabPanel ParticipantDto="_participantDto" ShowRightToWorkWarning="@_showRightToWorkWarning" />
                 </MudTabPanel>
-                <MudTabPanel Text="Assessment" Icon="@(_participantDto.AssessmentJustification is not null ? Icons.Material.Filled.Warning : string.Empty)" IconColor="Color.Warning">
+                <MudTabPanel Text="Assessment" Icon="@(string.IsNullOrEmpty(_participantDto.AssessmentJustification) is false ? Icons.Material.Filled.Warning : string.Empty)" IconColor="Color.Warning">
                     <AssessmentTabPanel ParticipantDto="_participantDto" ParticipantAssessmentDto="@_latestParticipantAssessmentDto" />
                 </MudTabPanel>
                 <MudTabPanel Text="Submission">


### PR DESCRIPTION
## 🔗 Related Work
- Closes: #
- Related: #

---

## 📌 Summary
> What does this PR do? Keep it short but clear.

Fixes the PQA (Participant QA) Enrolments screen so the "Assessment" tab no longer shows a warning icon when the assessment justification is an empty string.

---

## 🎯 Purpose / Motivation
> Why does this change exist? What problem are we solving?

The Assessment tab was displaying a warning indicator whenever `AssessmentJustification` was non-null. However, an empty string (`""`) is not a meaningful justification and should be treated the same as no justification. This caused a spurious warning to appear during QA, misleading reviewers.

---

## 🧠 Approach
> Key implementation details, trade-offs, or design decisions.
> Mention anything reviewers should pay attention to.

Changed the tab icon condition from a plain null check (`is not null`) to `string.IsNullOrEmpty(...) is false`, so the warning icon only appears when there is an actual, non-empty justification. Reviewers should confirm that an empty justification is a valid, expected state on this screen.

---

## 🔄 Changes
- Added:
- Updated: `src/Server.UI/Pages/QA/Enrolments/PQA.razor` — Assessment tab warning icon now uses `string.IsNullOrEmpty` instead of a null-only check.
- Removed:

---

## 🧪 How to Test
> Step-by-step instructions to verify this works.

1. Open the PQA Enrolments screen for a participant whose `AssessmentJustification` is an empty string.
2. Observe the "Assessment" tab.
3. Repeat for a participant with a populated justification, and one with a null justification.

Expected result:
> What should happen if everything is correct?

The warning icon appears **only** when the justification is a non-empty value. Empty string and null justifications show no warning icon.

---

## 📸 Screenshots / Output (if applicable)
> UI changes, logs, API responses, etc.

_(Add before/after screenshots of the Assessment tab if helpful.)_

---

## ⚠️ Risks & Impact
- [ ] Breaking change
- [ ] Database change
- [ ] Performance impact
- [ ] Security impact

Details:
> Anything reviewers should be cautious about.

Low risk. UI-only change affecting a single tab icon condition on the PQA Enrolments page.

---

## 🙋 Notes for Reviewers
> Anything specific you want feedback on.

Please confirm that treating an empty-string justification as "no justification" is the intended behaviour for QA warnings.
