### PR TITLE
Assessment Justification might be empty now due to the way it 'remembers' previous entries.

### DIFF
--- a/src/Domain/Entities/Participants/Participant.cs
+++ b/src/Domain/Entities/Participants/Participant.cs
@@ -163,7 +163,11 @@ public class Participant : OwnerPropertyEntity<string>
 
     public Participant SetAssessmentJustification(string? justification)
     {
-        AssessmentJustification = justification;
+        AssessmentJustification = justification switch {
+            null => null,
+            "" => null,
+            _ => justification
+        };
         return this;
     }
 


### PR DESCRIPTION
This pull request makes a small but important change to how assessment justifications are set for a `Participant`. Now, both `null` and empty string values for the justification will be stored as `null`, ensuring consistency in how missing or blank justifications are handled.

- Updated the `SetAssessmentJustification` method in `Participant` so that both `null` and empty string (`""`) values for the justification are stored as `null`, standardizing the representation of missing justifications.