### PR TITLE
Hide dismiss button for now

### DIFF
--- a/src/Server.UI/Pages/Transfers/Transfers.razor
+++ b/src/Server.UI/Pages/Transfers/Transfers.razor
@@ -46,10 +46,12 @@
         <MudTd DataLabel="@ConstantString.Actions">
             <MudMenu Icon="@Icons.Material.Filled.Edit" Variant="Variant.Filled" Size="Size.Small" Dense="true" EndIcon="@Icons.Material.Filled.KeyboardArrowDown" IconColor="Color.Info" AnchorOrigin="Origin.CenterLeft">
                 <MudMenuItem OnClick="async() => await Process(context)">Process and Assign</MudMenuItem>
-                @if (context.EnrolmentStatus == Cfo.Cats.Domain.Common.Enums.EnrolmentStatus.ArchivedStatus)
-                {
-                    <MudMenuItem OnClick="async () => await Dismiss(context)">Dismiss</MudMenuItem>
-                }
+                <AuthorizeView Policy="@SecurityPolicies.SeniorInternal" Context="ctx">
+                    @if (context.EnrolmentStatus == Cfo.Cats.Domain.Common.Enums.EnrolmentStatus.ArchivedStatus)
+                    {
+                        <MudMenuItem OnClick="async () => await Dismiss(context)">Dismiss</MudMenuItem>
+                    }
+                </AuthorizeView>
                 <MudMenuItem OnClick="() => View(context.ParticipantId)">View Participant</MudMenuItem>
                 <MudMenuItem OnClick="async () => await ViewOffenderManagerSummary(context.ParticipantId)">View Offender Manager Summary</MudMenuItem>
             </MudMenu>            


### PR DESCRIPTION
This pull request introduces an authorization check to the `Transfers.razor` page to restrict access to the "Dismiss" menu item. Now, only users with the `SeniorInternal` policy can see and interact with the "Dismiss" option for transfers with an `ArchivedStatus` enrolment status.

**Authorization changes:**

* Wrapped the "Dismiss" `MudMenuItem` in an `AuthorizeView` with the `SeniorInternal` policy, ensuring only authorized users can access this action.