### PR TITLE
Update the renovate configuration to point to main now that develop 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "github>ministryofjustice/hmpps-renovate-config:base"
   ],
-  "baseBranches": ["develop"],
+  "baseBranches": ["main"],
   "prCreation": "immediate",
   "packageRules": [
     {


### PR DESCRIPTION
This pull request updates the Renovate configuration to target the `main` branch instead of `develop` for dependency updates.

* Changed the `baseBranches` setting in `renovate.json` to use `main` as the default branch for Renovate pull requests.