### PR TITLE
CCPM-2: Configure Modsec (inherit HMPPS base rules)

### DIFF
--- a/helm_deploy/cats/values.yaml
+++ b/helm_deploy/cats/values.yaml
@@ -40,12 +40,8 @@ app:
     # ModSecurity WAF. Default class is the non-prod controller; production overrides to "modsec".
     className: modsec-non-prod
     modsecurity_enabled: true
-    # WAF engine: "DetectionOnly" (log only) or "On" (block). Flip per-env in overlays once tuned.
-    modsecurity_mode: DetectionOnly
-    modsecurity_snippet: |
-      SecAuditEngine On
-      SecRuleEngine {{ .Values.ingress.modsecurity_mode }}
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-creating-future-opportunities-devs,tag:namespace={{ .Release.Namespace }}"
+    modsecurity_audit_enabled: false
+    modsecurity_github_team: "hmpps-creating-future-opportunities-devs"
     annotations:
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/session-cookie-name: "http-cookie"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,6 +5,7 @@ app:
   replicaCount: 3
   ingress:
     host: cfocats-preprod.live.cloud-platform.service.justice.gov.uk
+    modsecurity_audit_enabled: true
   env:
     DOTNET_ENVIRONMENT: "PreProduction"
     Sentry__Environment: "PreProduction-CloudPlatform"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,8 +6,7 @@ app:
   ingress:
     host: cfocats-prod.live.cloud-platform.service.justice.gov.uk
     className: modsec
-    # modsecurity_mode: On # Default to modsecurity_mode "DetectionOnly" until staging is tuned, then "On".
-
+    modsecurity_audit_enabled: true
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
## 📝 Description
Drops the current WAF rules, and inherits the base HMPPS rules configured [here](https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/values.yaml#L68-L89).

## 🔗 Jira Ticket
[CCPM-2](https://dsdmoj.atlassian.net/browse/CCPM-2)

## 🚀 How to QA
Once applied:
1. Go to our Cloud Platform environment (dev).
2. Verify that the site is accessible and responsive.


## 📸 Screenshots / Recordings (If applicable)
N/A
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`

[CCPM-2]: https://dsdmoj.atlassian.net/browse/CCPM-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ