### PR TITLE
CFODEV-1776: Configure notification service templates

### DIFF
--- a/src/Server.UI/appsettings.Development.json
+++ b/src/Server.UI/appsettings.Development.json
@@ -22,5 +22,19 @@
     "MaxRequestBodySize": "Small",
     "ShutdownTimeout": "00:00:05",
     "CaptureBlockingCalls": true
+  },
+  "Notify": {
+    "ApiKey": "",
+    "Templates": [
+      {
+        "Key": "TwoFactorCode",
+        "EmailTemplateId": "4c74ad94-7af3-486d-ba40-f78c882f2822",
+        "SmsTemplateId": "c5c1053e-6262-4744-959e-4b9903532dc7"
+      },
+      {
+        "Key": "AccountDeactivationReminder",
+        "EmailTemplateId": ""
+      }
+    ]
   }
 }

--- a/src/Server.UI/appsettings.PreProduction.json
+++ b/src/Server.UI/appsettings.PreProduction.json
@@ -22,5 +22,19 @@
     "MaxRequestBodySize": "Small",
     "ShutdownTimeout": "00:00:05",
     "CaptureBlockingCalls": true
+  },
+  "Notify": {
+    "ApiKey": "",
+    "Templates": [
+      {
+        "Key": "TwoFactorCode",
+        "EmailTemplateId": "75c31abc-7741-4831-8616-7ae7382e8404",
+        "SmsTemplateId": "c6a1d19b-c8a0-4192-8823-7f8aa56db942"
+      },
+      {
+        "Key": "AccountDeactivationReminder",
+        "EmailTemplateId": "0b08ef62-ebf6-40a4-a340-32359b0f06d4"
+      }
+    ]
   }
 }

--- a/src/Server.UI/appsettings.Production.json
+++ b/src/Server.UI/appsettings.Production.json
@@ -22,5 +22,19 @@
     "MaxRequestBodySize": "Small",
     "ShutdownTimeout": "00:00:05",
     "CaptureBlockingCalls": true
+  },
+  "Notify": {
+    "ApiKey": "",
+    "Templates": [
+      {
+        "Key": "TwoFactorCode",
+        "EmailTemplateId": "4c74ad94-7af3-486d-ba40-f78c882f2822",
+        "SmsTemplateId": "c5c1053e-6262-4744-959e-4b9903532dc7"
+      },
+      {
+        "Key": "AccountDeactivationReminder",
+        "EmailTemplateId": "23900e26-753d-44ff-b311-0c58177c9846"
+      }
+    ]
   }
 }

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -140,7 +140,7 @@
   "Ordnance": {
     "Places": {
       "ApiKey": "",
-      "ApplicationUrl": ""
+      "ApplicationUrl": "https://api.os.uk/search/places/v1/"
     }
   },
   "Features": {


### PR DESCRIPTION
## 📝 Description

Add environment-specific template IDs for key notification types, including two-factor authentication (2FA) codes and account deactivation reminders. This configuration enables the application to utilize an external notification service for sending these structured messages.

## 🔗 Jira Ticket

https://dsdmoj.atlassian.net/browse/CFODEV-1776 

## 🚀 How to QA

This just records the template Ids of the gov notify system.

## 📸 Screenshots / Recordings (If applicable)
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`