### PR TITLE
Cfodev 1775 fix breadcrumb on performance management outcome quality

### DIFF
--- a/src/Server.UI/Pages/Workspaces/Participants/Components/ParticipantsPageHeader.razor
+++ b/src/Server.UI/Pages/Workspaces/Participants/Components/ParticipantsPageHeader.razor
@@ -1,6 +1,7 @@
 @using Cfo.Cats.Server.UI.Pages.Workspaces.Participants.Services
 @using Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Services
 @using Cfo.Cats.Server.UI.Pages.Workspaces.ServiceDesk.Services
+@using Cfo.Cats.Server.UI.Pages.Workspaces.Performance.Services
 @using Microsoft.AspNetCore.WebUtilities
 
 <PageHeader Title="Participants" 
@@ -53,11 +54,34 @@
                 "activities-pqa-queue" => [ProviderLinks.Home.AsMudBreadcrumb(), ProviderLinks.ActivitiesPqa.AsMudBreadcrumb(), participant],
                 "enrolments-pqa-queue" => [ProviderLinks.Home.AsMudBreadcrumb(), ProviderLinks.EnrolmentsPqa.AsMudBreadcrumb(), participant],
                 "servicedesk" => [ServiceDeskLinks.Home.AsMudBreadcrumb(), ServiceDeskLinks.ActivitiesQueue.AsMudBreadcrumb(), participant],
+                "dipsample-review-list" => BuildDipSampleParticipantBreadcrumbs(parsedQuery, participant),
                 _ => [home, ParticipantLinks.All.AsMudBreadcrumb(), participant]
             };
         }
 
         return [home, ParticipantLinks.All.AsMudBreadcrumb(), participant];
+    }
+
+    private static IReadOnlyList<BreadcrumbItem> BuildDipSampleParticipantBreadcrumbs(
+        Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery,
+        BreadcrumbItem participant)
+    {
+        var home = PerformanceLinks.Home.AsMudBreadcrumb();
+        var outcomeQuality = PerformanceLinks.OutcomeQualityDipSamples.AsMudBreadcrumb();
+
+        if (parsedQuery.TryGetValue("sampleId", out var sampleIdRaw)
+            && Guid.TryParse(sampleIdRaw.ToString(), out var sampleId))
+        {
+            var sample = PerformanceLinks.OutcomeQualityDipSample(sampleId);
+            var sampleTitle = parsedQuery.TryGetValue("sampleLabel", out var sampleLabel)
+                && !string.IsNullOrWhiteSpace(sampleLabel.ToString())
+                ? sampleLabel.ToString()
+                : sample.Title;
+
+            return [home, outcomeQuality, new BreadcrumbItem(sampleTitle, sample.Href), participant];
+        }
+
+        return [home, outcomeQuality, participant];
     }
 
 }

--- a/src/Server.UI/Pages/Workspaces/Performance/Pages/DipSample.razor
+++ b/src/Server.UI/Pages/Workspaces/Performance/Pages/DipSample.razor
@@ -103,7 +103,7 @@
                         <MudMenuItem Href="@($"/pages/workspace/performance/outcome-quality-dip-sampling/{SampleId}/{context.Item.ParticipantId}")">
                             @ConstantString.Review
                         </MudMenuItem>
-                        <MudMenuItem Href="@($"/pages/workspace/participants/{context.Item.ParticipantId}")">
+                        <MudMenuItem Href="@($"/pages/workspace/participants/{context.Item.ParticipantId}?from=dipsample-review-list&sampleId={SampleId}&sampleLabel={Uri.EscapeDataString(SampleLabel ?? string.Empty)}")">
                             @ConstantString.ViewParticipant
                         </MudMenuItem>
                     </MudMenu>


### PR DESCRIPTION
## 📝 When user clicks on the View Participant button on the Performance>Outcome Quality> dipsample review list, now it retains the breadcrumb while displaying the participant detail page 

## 🔗 Jira Ticket

## 🚀 How to QA
1. Go to Performance Management>Outcome Quality, click View, it should take you the the dipsample review list
2. Click on pencil on a row and click View participant
3. Verify that it retains the breadcrumb while displaying the participant detail page


## 📸 <img width="1629" height="837" alt="image" src="https://github.com/user-attachments/assets/4c8b9dbc-bafc-4e53-8510-0ffa0dfc480e" />
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`