### PR TITLE
Feature/cfodev 1778 Cache changes

### DIFF
--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -18,6 +18,7 @@ using ApexCharts;
 using Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Enrolments;
 using Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Activities;
 using StackExchange.Redis;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Cfo.Cats.Application.Common.Interfaces.Identity;
 using Cfo.Cats.Infrastructure.Services.Identity;
 using Cfo.Cats.Server.UI.Pages.Workspaces.Participants.Services;
@@ -156,10 +157,22 @@ public static class DependencyInjection
                 ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
         });
 
-        services.AddScoped<ParticipantsSessionStorage>();
-        services.AddScoped<ActivitiesSessionStorage>();
-        services.AddScoped<PQASessionStorage>();
-        services.AddScoped<ActivityPQASessionStorage>();
+        if (config.GetValue<bool>("Features:UseRedisSessionStore"))
+        {
+            var redisConnectionString = config.GetConnectionString("redis")
+                ?? throw new InvalidOperationException("Redis connection must be configured to use the Redis session store. Please set the 'redis' connection string in your configuration.");
+
+            services.TryAddSingleton<IConnectionMultiplexer>(_ =>
+                ConnectionMultiplexer.Connect(redisConnectionString));
+
+            services.AddScoped<ICatsSessionStore, RedisSessionStore>();
+        }
+        else
+        {
+            services.AddScoped<ICatsSessionStore, ProtectedBrowserSessionStore>();
+        }
+
+        services.AddScoped<CatsSessionStorage>();
         
         return builder;
     }

--- a/src/Server.UI/Pages/Workspaces/Participants/Pages/Activities.razor.cs
+++ b/src/Server.UI/Pages/Workspaces/Participants/Pages/Activities.razor.cs
@@ -13,6 +13,7 @@ using Cfo.Cats.Server.UI.Components.Locations;
 using Cfo.Cats.Server.UI.Pages.Activities;
 using Cfo.Cats.Server.UI.Pages.Activities.Components;
 using Cfo.Cats.Server.UI.Pages.Workspaces.Participants.Services;
+using Cfo.Cats.Server.UI.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
 
@@ -30,7 +31,7 @@ public enum ActivitiesQuickFilter
 public partial class Activities
 {
     [Inject]
-    public ActivitiesSessionStorage SessionStorage { get; set; } = null!;
+    public CatsSessionStorage SessionStorage { get; set; } = null!;
 
     [Inject]
     public IUserService UserService { get; set; } = null!;
@@ -89,7 +90,7 @@ public partial class Activities
             _currentFilter = ActivitiesQuickFilter.MyActivities;
         }
 
-        var cached = await SessionStorage.GetAsync();
+        var cached = await SessionStorage.GetAsync<ActivitiesSessionData>();
 
         if (cached is { Succeeded: true, Data: { } sd })
         {

--- a/src/Server.UI/Pages/Workspaces/Participants/Pages/Participants.razor.cs
+++ b/src/Server.UI/Pages/Workspaces/Participants/Pages/Participants.razor.cs
@@ -48,7 +48,7 @@ public partial class Participants
     public ITenantService TenantService {get;set;} = null!;
 
     [Inject]
-    public ParticipantsSessionStorage SessionStorage { get;set; } = null!;
+    public CatsSessionStorage SessionStorage { get;set; } = null!;
 
     [Inject]
     public IAuthorizationService AuthorizationService { get; set; } = null!;
@@ -127,7 +127,7 @@ public partial class Participants
             _currentFilter = QuickFilter.MyParticipants;
         }
                     
-        var cached = await SessionStorage.GetAsync();
+        var cached = await SessionStorage.GetAsync<ParticipantsSessionData>();
 
         if (cached is { Succeeded: true, Data: { } sd })
         {

--- a/src/Server.UI/Pages/Workspaces/Participants/Services/ActivitiesSessionData.cs
+++ b/src/Server.UI/Pages/Workspaces/Participants/Services/ActivitiesSessionData.cs
@@ -1,13 +1,6 @@
 using Cfo.Cats.Application.Features.Activities.Queries;
-using Cfo.Cats.Server.UI.Services;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Participants.Services;
-
-public class ActivitiesSessionStorage(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService)
-    : CatsSessionStorage<ActivitiesSessionData>(protectedSessionStorage, currentUserService)
-{
-}
 
 public record ActivitiesSessionData
 {

--- a/src/Server.UI/Pages/Workspaces/Participants/Services/ParticipantsSessionData.cs
+++ b/src/Server.UI/Pages/Workspaces/Participants/Services/ParticipantsSessionData.cs
@@ -1,14 +1,8 @@
 using Cfo.Cats.Application.Features.Participants.Queries;
 using Cfo.Cats.Application.Features.Participants.Specifications;
 using Cfo.Cats.Domain.Labels;
-using Cfo.Cats.Server.UI.Services;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Participants.Services;
-
-public class ParticipantsSessionStorage(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService) : CatsSessionStorage<ParticipantsSessionData>(protectedSessionStorage, currentUserService)
-{
-}
 
 public record ParticipantsSessionData
 {

--- a/src/Server.UI/Pages/Workspaces/Provider/Pages/Activities/ActivityPQASessionData.cs
+++ b/src/Server.UI/Pages/Workspaces/Provider/Pages/Activities/ActivityPQASessionData.cs
@@ -1,13 +1,6 @@
 using Cfo.Cats.Application.Features.Activities.Specifications;
-using Cfo.Cats.Server.UI.Services;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Activities;
-
-public class ActivityPQASessionStorage(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService)
-    : CatsSessionStorage<ActivityPQASessionData>(protectedSessionStorage, currentUserService)
-{
-}
 
 public record ActivityPQASessionData
 {

--- a/src/Server.UI/Pages/Workspaces/Provider/Pages/Activities/PqaList.razor.cs
+++ b/src/Server.UI/Pages/Workspaces/Provider/Pages/Activities/PqaList.razor.cs
@@ -7,6 +7,7 @@ using Cfo.Cats.Application.Features.Activities.Queries;
 using Cfo.Cats.Domain.Common.Enums;
 using Cfo.Cats.Infrastructure.Constants;
 using Cfo.Cats.Server.UI.Components.Identity;
+using Cfo.Cats.Server.UI.Services;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Activities;
 
@@ -21,7 +22,7 @@ public partial class PqaList
     public ITenantService TenantService { get; set; } = null!;
 
     [Inject]
-    public ActivityPQASessionStorage SessionStorage { get; set; } = null!;
+    public CatsSessionStorage SessionStorage { get; set; } = null!;
 
     private IDictionary<string, string> _users = null!;
     private IDictionary<string, string> _tenants = null!;
@@ -56,7 +57,7 @@ public partial class PqaList
         _tenants = TenantService.GetVisibleTenants(UserProfile.TenantId!)
             .ToDictionary(k => k.Id, k => k.Name);
 
-        var cached = await SessionStorage.GetAsync();
+        var cached = await SessionStorage.GetAsync<ActivityPQASessionData>();
 
         if (cached is { Succeeded: true, Data: { } sd })
         {

--- a/src/Server.UI/Pages/Workspaces/Provider/Pages/Enrolments/PQASessionData.cs
+++ b/src/Server.UI/Pages/Workspaces/Provider/Pages/Enrolments/PQASessionData.cs
@@ -1,14 +1,6 @@
 using Cfo.Cats.Application.Features.QualityAssurance.Specifications;
-using Cfo.Cats.Server.UI.Services;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Enrolments;
-
-public class PQASessionStorage(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService)
-    : CatsSessionStorage<PQASessionData>(protectedSessionStorage, currentUserService)
-{
-    
-}
 
 public record PQASessionData
 {

--- a/src/Server.UI/Pages/Workspaces/Provider/Pages/Enrolments/PqaList.razor.cs
+++ b/src/Server.UI/Pages/Workspaces/Provider/Pages/Enrolments/PqaList.razor.cs
@@ -6,6 +6,7 @@ using Cfo.Cats.Application.Features.QualityAssurance.DTOs;
 using Cfo.Cats.Application.Features.QualityAssurance.Queries;
 using Cfo.Cats.Infrastructure.Constants;
 using Cfo.Cats.Server.UI.Components.Identity;
+using Cfo.Cats.Server.UI.Services;
 
 namespace Cfo.Cats.Server.UI.Pages.Workspaces.Provider.Pages.Enrolments;
 
@@ -20,7 +21,7 @@ public partial class PqaList
     public ITenantService TenantService { get; set; } = null!;
 
     [Inject]
-    public PQASessionStorage SessionStorage { get; set; } = null!;
+    public CatsSessionStorage SessionStorage { get; set; } = null!;
 
     private IDictionary<string, string> _users = null!;
 
@@ -46,7 +47,7 @@ public partial class PqaList
         _tenants = TenantService.GetVisibleTenants(UserProfile.TenantId!)
                     .ToDictionary(k => k.Id, k => k.Name);
 
-        var cached = await SessionStorage.GetAsync();
+        var cached = await SessionStorage.GetAsync<PQASessionData>();
 
         if(cached is { Succeeded: true, Data: { } sd })
         {

--- a/src/Server.UI/Services/CatsSessionStorage.cs
+++ b/src/Server.UI/Services/CatsSessionStorage.cs
@@ -1,48 +1,66 @@
-using System.Security.Cryptography;
-using ActualLab.Fusion;
-using DocumentFormat.OpenXml.Spreadsheet;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using RabbitMQ.Client;
-
 namespace Cfo.Cats.Server.UI.Services;
 
-public abstract class CatsSessionStorage<TItem>(ProtectedSessionStorage protectedSessionStorage, ICurrentUserService currentUserService)
+/// <summary>
+/// Per-user UI session storage (for example list filters). A single scoped service is
+/// registered for all pages: each consumer chooses its own <c>key</c> and the type of the
+/// object it stores, so there is no need for a bespoke class (or DI registration) per page.
+///
+/// Persistence is delegated to an <see cref="ICatsSessionStore"/> so the backing store
+/// (encrypted browser session storage or a shared Redis cache) can be switched via
+/// configuration without changing consumers. A stored item is stamped with the id of the
+/// user who wrote it and only returned to that same user.
+/// </summary>
+public class CatsSessionStorage(ICatsSessionStore sessionStore, ICurrentUserService currentUserService)
 {
-    protected virtual string Key { get; } = typeof(TItem).Name;
+    /// <summary>
+    /// Persists <paramref name="item"/> under a key derived from its type name.
+    /// </summary>
+    public Task SetAsync<TItem>(TItem item) => SetAsync(typeof(TItem).Name, item);
 
-    public async Task SetAsync(TItem item)
+    /// <summary>
+    /// Persists <paramref name="item"/> under the supplied <paramref name="key"/>.
+    /// </summary>
+    public async Task SetAsync<TItem>(string key, TItem item)
     {
-        var itemToStore = new CatsSessionItem()
+        var itemToStore = new CatsSessionItem<TItem>()
         {
             Item = item,
             SessionUserId = currentUserService.UserId!
         };
-        await protectedSessionStorage.SetAsync(Key, itemToStore);
+        await sessionStore.SetAsync(key, itemToStore);
     }
 
-    public async Task<Result<TItem>> GetAsync()
-    {
-        var result = await protectedSessionStorage.GetAsync<CatsSessionItem>(Key);
+    /// <summary>
+    /// Retrieves the item stored under a key derived from <typeparamref name="TItem"/>'s type name.
+    /// </summary>
+    public Task<Result<TItem>> GetAsync<TItem>() => GetAsync<TItem>(typeof(TItem).Name);
 
-        if (result is { Success: true, Value.Item: not null } )
+    /// <summary>
+    /// Retrieves the item stored under the supplied <paramref name="key"/>.
+    /// Returns a failed <see cref="Result{TItem}"/> when nothing is stored for the current user.
+    /// </summary>
+    public async Task<Result<TItem>> GetAsync<TItem>(string key)
+    {
+        var result = await sessionStore.GetAsync<CatsSessionItem<TItem>>(key);
+
+        if (result is { Succeeded: true, Data.Item: not null })
         {
-            if (result.Value.SessionUserId == currentUserService.UserId)
+            if (result.Data.SessionUserId == currentUserService.UserId)
             {
-                return Result<TItem>.Success(result.Value.Item);
+                return Result<TItem>.Success(result.Data.Item);
             }
         }
 
         return Result<TItem>.Failure();
     }
-    
-    
-    private class CatsSessionItem
+
+    private class CatsSessionItem<TItem>
     {
         /// <summary>
         /// The UserId of the person who is stored this data
         /// </summary>
         public required string SessionUserId { get; set; }
-    
+
         public required TItem Item { get; set; }
     }
 

--- a/src/Server.UI/Services/ICatsSessionStore.cs
+++ b/src/Server.UI/Services/ICatsSessionStore.cs
@@ -1,0 +1,15 @@
+namespace Cfo.Cats.Server.UI.Services;
+
+public interface ICatsSessionStore
+{
+    /// <summary>
+    /// Persists <paramref name="item"/> against <paramref name="key"/> for the current session.
+    /// </summary>
+    Task SetAsync<TItem>(string key, TItem item);
+
+    /// <summary>
+    /// Retrieves the item previously stored against <paramref name="key"/>.
+    /// Returns a failed <see cref="Result{TItem}"/> when nothing is stored.
+    /// </summary>
+    Task<Result<TItem>> GetAsync<TItem>(string key);
+}

--- a/src/Server.UI/Services/ProtectedBrowserSessionStore.cs
+++ b/src/Server.UI/Services/ProtectedBrowserSessionStore.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Cfo.Cats.Server.UI.Services;
+
+public class ProtectedBrowserSessionStore(ProtectedSessionStorage protectedSessionStorage) : ICatsSessionStore
+{
+    public async Task SetAsync<TItem>(string key, TItem item)
+        => await protectedSessionStorage.SetAsync(key, item!);
+
+    public async Task<Result<TItem>> GetAsync<TItem>(string key)
+    {
+        var result = await protectedSessionStorage.GetAsync<TItem>(key);
+
+        return result is { Success: true, Value: not null }
+            ? Result<TItem>.Success(result.Value)
+            : Result<TItem>.Failure();
+    }
+}

--- a/src/Server.UI/Services/RedisSessionStore.cs
+++ b/src/Server.UI/Services/RedisSessionStore.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Cfo.Cats.Application.Common.Interfaces.Serialization;
+using StackExchange.Redis;
+
+namespace Cfo.Cats.Server.UI.Services;
+
+/// <summary>
+/// <see cref="ICatsSessionStore"/> implementation backed by a shared Redis cache.
+/// </summary>
+public class RedisSessionStore(IConnectionMultiplexer multiplexer, ICurrentUserService currentUserService) : ICatsSessionStore
+{
+    /// <summary>
+    /// This is currently fixed to 1 hour, once we are on cloud platform this can become a per consumer setting that is passed 
+    /// in but for now, as ProtectedSessionStorage has no concept of expiry we are hard coding 1 hour.
+    /// </summary>
+    private static readonly TimeSpan Expiry = TimeSpan.FromMinutes(60);
+    private static readonly JsonSerializerOptions SerializerOptions = CacheJsonSerializerOptions.Options;
+
+    private IDatabase Database => multiplexer.GetDatabase();
+
+    private string NamespacedKey(string key) => $"cats:session:{currentUserService.UserId}:{key}";
+
+    public async Task SetAsync<TItem>(string key, TItem item)
+    {
+        var json = JsonSerializer.Serialize(item, SerializerOptions);
+        await Database.StringSetAsync(NamespacedKey(key), json, Expiry);
+    }
+
+    public async Task<Result<TItem>> GetAsync<TItem>(string key)
+    {
+        var value = await Database.StringGetAsync(NamespacedKey(key));
+
+        if (value.IsNullOrEmpty)
+        {
+            return Result<TItem>.Failure();
+        }
+
+        var item = JsonSerializer.Deserialize<TItem>((string)value!, SerializerOptions);
+
+        return item is not null
+            ? Result<TItem>.Success(item)
+            : Result<TItem>.Failure();
+    }
+}

--- a/src/Server.UI/appsettings.Development.json
+++ b/src/Server.UI/appsettings.Development.json
@@ -36,5 +36,15 @@
         "EmailTemplateId": ""
       }
     ]
+  },
+  "Features": {
+    "InMemoryTargetsProviderReprofiled": true,
+    "UseWorkerForJobs": true,
+    "UseSignalRBackplane": true,
+    "UseRedisSessionStore": true,
+    "PresenceHub": {
+      "Enabled": true,
+      "RelayUserPresenceNotifications": true
+    }
   }
 }

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -147,6 +147,7 @@
     "InMemoryTargetsProviderReprofiled": true,
     "UseWorkerForJobs": false,
     "UseSignalRBackplane": false,
+    "UseRedisSessionStore": false,
     "PresenceHub": {
       "Enabled": false,
       "RelayUserPresenceNotifications": false


### PR DESCRIPTION
## 📝 Description

Simplify the caching so you don't need one class per page for storage.
- Adds support for optional redis cache
- Defaults development to work in a "cloud plaform" way

## 🔗 Jira Ticket

https://dsdmoj.atlassian.net/browse/CFODEV-1778

## 🚀 How to QA

Check that the ProtectedSessionStorage is used when the redis option is switched off.
Check that the ProtectedSessionStorage is not used when the redis option is switched on.

Note there is a redis extension for VScode that lets you interrogate the redis database to see what is stored.

> [!IMPORTANT]
> The redis CACHE behaves differently to the ProtectedSessionStorage.
> The ProtectedSessionStorage will remain as long as the Tab is kept open and is Tab specific
> The Redis Cache is a PER USER session store and will time out after 1 hour so will survive browser resets

## 📸 Screenshots / Recordings (If applicable)
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`