### PR TITLE
CCPM-31: Add participant created consumer + call /hardlink DMS endpoint

### DIFF
--- a/helm_deploy/cats/values.yaml
+++ b/helm_deploy/cats/values.yaml
@@ -102,6 +102,7 @@ app:
     Features__PresenceHub__Enabled: "true"
     Features__PresenceHub__RelayUserPresenceNotifications: "true"
     Features__UseSignalRBackplane: "true"
+    Features__DmsHardLinkApiEnabled: "true"
     WorkerOptions__BaseUrl: "http://cats-worker:8080"
     Sentry__Release: "0.0.0"                    # overridden by CI
     AppConfigurationSettings__Version: "0.0.0"  # overridden by CI

--- a/src/Application/Common/Interfaces/ICandidateService.cs
+++ b/src/Application/Common/Interfaces/ICandidateService.cs
@@ -9,6 +9,8 @@ public interface ICandidateService
     Task<Result<CandidateDto>> GetByUpciAsync(string upci);
 
     Task<Result<bool>> SetStickyLocation(string upci, string location);
+    
+    Task<Result<bool>> SetHardLink(string participantId, string? primaryRecordKeyAtCreation, DateTime occurredOn);
 }
 
 public record SearchResult(string Upci, int Precedence);

--- a/src/Application/Features/Participants/IntegrationEventHandlers/ParticipantCreatedIntegrationEventConsumer.cs
+++ b/src/Application/Features/Participants/IntegrationEventHandlers/ParticipantCreatedIntegrationEventConsumer.cs
@@ -1,0 +1,34 @@
+using Cfo.Cats.Application.Features.Participants.IntegrationEvents;
+using Microsoft.Extensions.Configuration;
+using Rebus.Handlers;
+
+namespace Cfo.Cats.Application.Features.Participants.IntegrationEventHandlers;
+
+/// <summary>
+/// Consumes <see cref="ParticipantCreatedIntegrationEvent"/> (always published via the outbox when a participant
+/// is created) and, when the "Features:UseDmsHardLinkApi" flag is enabled, calls the DMS hard link API directly
+/// via <see cref="ICandidateService"/>. When the flag is disabled, this is a no-op - DMS is instead expected to
+/// be notified via its own subscription to the published message.
+/// </summary>
+public class ParticipantCreatedIntegrationEventConsumer(
+    ICandidateService candidateService,
+    IConfiguration configuration,
+    ILogger<ParticipantCreatedIntegrationEventConsumer> logger) : IHandleMessages<ParticipantCreatedIntegrationEvent>
+{
+    public async Task Handle(ParticipantCreatedIntegrationEvent message)
+    {
+        if (!configuration.GetValue<bool>("Features:UseDmsHardLinkApi"))
+        {
+            return;
+        }
+
+        try
+        {
+            await candidateService.SetHardLink(message.ParticipantId, message.PrimaryRecordKeyAtCreation, message.OccurredOn);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to call DMS hard link API for participant {ParticipantId}", message.ParticipantId);
+        }
+    }
+}

--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -9,6 +9,7 @@ internal static class AppExtensions
     {
         var useWorkerForJobs = string.Equals(builder.Configuration["Features:UseWorkerForJobs"], "true", StringComparison.OrdinalIgnoreCase);
         var useSignalRBackplane = string.Equals(builder.Configuration["Features:UseSignalRBackplane"], "true", StringComparison.OrdinalIgnoreCase);
+        var useDmsHardLinkApi = string.Equals(builder.Configuration["Features:UseDmsHardLinkApi"], "true", StringComparison.OrdinalIgnoreCase);
         var enablePresenceHub = string.Equals(builder.Configuration["Features:PresenceHub:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
         var relayUserPresenceNotifications = string.Equals(builder.Configuration["Features:PresenceHub:RelayUserPresenceNotifications"], "true", StringComparison.OrdinalIgnoreCase);
         var replicaCount = int.TryParse(builder.Configuration["Replicas"], out var n) ? n : 1;
@@ -17,6 +18,7 @@ internal static class AppExtensions
             .WithCatsDatabaseReference(databases.CatsDb)
             .WithEnvironment("Features__UseWorkerForJobs", useWorkerForJobs.ToString().ToLowerInvariant())
             .WithEnvironment("Features__UseSignalRBackplane", useSignalRBackplane.ToString().ToLowerInvariant())
+            .WithEnvironment("Features__UseDmsHardLinkApi", useDmsHardLinkApi.ToString().ToLowerInvariant())
             .WithEnvironment("Features__PresenceHub__Enabled", enablePresenceHub.ToString().ToLowerInvariant())
             .WithEnvironment("Features__PresenceHub__RelayUserPresenceNotifications", relayUserPresenceNotifications.ToString().ToLowerInvariant())
             .WithReference(rabbit)

--- a/src/Aspire/Cats.AppHost/appsettings.Development.json
+++ b/src/Aspire/Cats.AppHost/appsettings.Development.json
@@ -9,6 +9,7 @@
   "Features": {
     "UseWorkerForJobs": true,
     "UseSignalRBackplane": true,
+    "UseDmsHardLinkApi": true,
     "PresenceHub": {
       "Enabled": true,
       "RelayUserPresenceNotifications": true

--- a/src/Aspire/Cats.AppHost/appsettings.json
+++ b/src/Aspire/Cats.AppHost/appsettings.json
@@ -14,6 +14,7 @@
   "Features": {
     "UseWorkerForJobs": false,
     "UseSignalRBackplane": false,
+    "UseDmsHardLinkApi": false,
     "PresenceHub": {
       "Enabled": false,
       "RelayUserPresenceNotifications": false

--- a/src/Infrastructure/Services/Candidates/CandidateService.cs
+++ b/src/Infrastructure/Services/Candidates/CandidateService.cs
@@ -205,4 +205,38 @@ public class CandidateService(
             return Result<bool>.Failure("An internal error occurred while communicating with the candidate service.");
         }
     }
+
+    public async Task<Result<bool>> SetHardLink(string upci, string? primaryRecordKeyAtCreation, DateTime occurredOn)
+    {
+        try
+        {
+            var result = await client.PostAsJsonAsync($"/clustering/{upci}/hardlink", new
+            {
+                primaryRecordKeyAtCreation,
+                occurredOn
+            });
+        
+            if (result.IsSuccessStatusCode)
+            {
+                return Result<bool>.Success(true);
+            }
+
+            if (result.StatusCode == HttpStatusCode.NotFound)
+            {
+                return Result<bool>.Failure("The hard link endpoint or target participant could not be found.");
+            }
+            
+            return Result<bool>.Failure($"Failed to set hard link. The DMS API returned status: {result.StatusCode}. Please try again or contact support if the issue persists.");
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "DMS Service is unavailable during hard link set for {Upci}", upci);
+            return Result<bool>.Failure("DMS Service is currently unavailable. Please try again later.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected exception calling SetHardLink for {Upci}", upci);
+            return Result<bool>.Failure("An internal error occurred while communicating with the candidate service.");
+        }
+    }
 }

--- a/src/Infrastructure/Services/MessageHandling/TasksBackgroundService.cs
+++ b/src/Infrastructure/Services/MessageHandling/TasksBackgroundService.cs
@@ -1,6 +1,7 @@
 using Cfo.Cats.Application.Features.Bios.IntegrationEvents;
 using Cfo.Cats.Application.Features.ManagementInformation.IntegrationEventHandlers;
 using Cfo.Cats.Application.Features.ParticipantLabels.IntegrationEventHandlers;
+using Cfo.Cats.Application.Features.Participants.IntegrationEventHandlers;
 using Cfo.Cats.Application.Features.Participants.IntegrationEvents;
 using Cfo.Cats.Application.Features.Activities.IntegrationEvents;
 using Cfo.Cats.Application.Features.PathwayPlans.IntegrationEvents;
@@ -31,7 +32,8 @@ internal class TasksBackgroundService(IServiceProvider provider, IConfiguration 
             .Handle<RecordActivityAdvisoryFeedbackConsumer>(provider)
             .Handle<RecordArchivedCaseConsumer>(provider)
             .Handle<CloseOffLastArchivedCaseEntry>(provider)
-            .Handle<RecordVeteranLabelStatusConsumer>(provider);
+            .Handle<RecordVeteranLabelStatusConsumer>(provider)
+            .Handle<ParticipantCreatedIntegrationEventConsumer>(provider);
         _bus = Configure.With(_activator)
             .Transport(t => t.UseRabbitMq(configuration.GetConnectionString("rabbit"), options.Value.TasksService)
                 .ExchangeNames(options.Value.DirectExchange, options.Value.TopicExchange))
@@ -47,6 +49,7 @@ internal class TasksBackgroundService(IServiceProvider provider, IConfiguration 
         await _bus.Subscribe<ParticipantTransitionedIntegrationEvent>();
         await _bus.Subscribe<ActivityTransitionedIntegrationEvent>();
         await _bus.Subscribe<BioSubmittedIntegrationEvent>();
+        await _bus.Subscribe<ParticipantCreatedIntegrationEvent>();
     }
 
     public override Task StopAsync(CancellationToken cancellationToken)

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -147,6 +147,7 @@
     "InMemoryTargetsProviderReprofiled": true,
     "UseWorkerForJobs": false,
     "UseSignalRBackplane": false,
+    "UseDmsHardLinkApi": false,
     "PresenceHub": {
       "Enabled": false,
       "RelayUserPresenceNotifications": false


### PR DESCRIPTION
## 📝 Description
This pull request introduces a new feature flag, `UseDmsHardLinkApi`, and implements logic to call the DMS hard link API when a participant is created, depending on the flag's value. The changes span configuration, service interfaces and implementations, event handling, and background service wiring.

* Added the `UseDmsHardLinkApi` feature flag to configuration files (`appsettings.json`, `appsettings.Development.json`, `helm_deploy/cats/values.yaml`, and `src/Server.UI/appsettings.json`) to control whether the DMS hard link API should be called directly when a participant is created.
* Added a new method `SetHardLink` to the `ICandidateService` interface and implemented it in `CandidateService`, allowing the service to call the DMS API endpoint for setting hard links. 
* Introduced `ParticipantCreatedIntegrationEventConsumer`, which listens for `ParticipantCreatedIntegrationEvent` messages and, if the `UseDmsHardLinkApi` flag is enabled, calls the new `SetHardLink` method on the candidate service.


## 🔗 Jira Ticket
* [CCPM-32](https://dsdmoj.atlassian.net/browse/CCPM-31)

## 🚀 How to QA
With DMS and CATS running:
1. Go to the participants screen
2. Begin and complete the enrolment of a new participant
3. Verify that the `HardLink` has been configured for the participant in DMS:

    ```
    -- Verify 'IdentifiedOn' has a value
    SELECT ClusterId, IdentifiedOn FROM ClusterDb.output.Clusters WHERE UPCI2 = '<ParticipantId>'
    
    -- Verify 'HardLink' is true for one of the records in the cluster
    SELECT HardLink FROM ClusterDb.output.ClusterMembership WHERE ClusterId = '<ClusterId>'
    ```


## 📸 Screenshots / Recordings (If applicable)
N/A

## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`

[CCPM-32]: https://dsdmoj.atlassian.net/browse/CCPM-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ