### PR TITLE
CFODEV-1779: Introduce appsettings for Testing and Training environments

### DIFF
--- a/src/Server.UI/appsettings.PreProduction.json
+++ b/src/Server.UI/appsettings.PreProduction.json
@@ -13,7 +13,7 @@
     "Dsn": "",
     "Environment": "PreProduction",
     "MinimumBreadcrumbLevel": "Debug",
-    "MinimumEventLevel": "Information",
+    "MinimumEventLevel": "Warning",
     "TracesSampleRate": 1.0,
     "ProfilesSampleRate": 1.0,
     "AttachStacktrace": true,

--- a/src/Server.UI/appsettings.Testing.json
+++ b/src/Server.UI/appsettings.Testing.json
@@ -1,8 +1,8 @@
 {
   "DetailedErrors": true,
   "IdleTimeOutMinutes": 10,
-  "PrimaryColour": "#305CDE",
-  "PreLoginMessage": "This is a development environment and must never contain live or real data.",
+  "PrimaryColour": "#004B49",
+  "PreLoginMessage": "This is a testing environment and must never contain live or real data.",
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
@@ -11,7 +11,7 @@
   },
   "Sentry": {
     "Dsn": "",
-    "Environment": "Development",
+    "Environment": "Testing",
     "MinimumBreadcrumbLevel": "Debug",
     "MinimumEventLevel": "Information",
     "TracesSampleRate": 1.0,
@@ -20,7 +20,7 @@
     "SendDefaultPii": false,
     "MaxBreadcrumbs": 50,
     "MaxRequestBodySize": "Small",
-    "ShutdownTimeout": "00:00:05",
+    "ShutdownTimeout": "00:00:10",
     "CaptureBlockingCalls": true
   },
   "Notify": {
@@ -37,14 +37,13 @@
       }
     ]
   },
-  "Features": {
-    "InMemoryTargetsProviderReprofiled": true,
-    "UseWorkerForJobs": true,
-    "UseSignalRBackplane": true,
-    "UseRedisSessionStore": true,
-    "PresenceHub": {
-      "Enabled": true,
-      "RelayUserPresenceNotifications": true
-    }
+  "RabbitSettings": {
+    "TopicExchange": "CatsTestingTopics",
+    "DirectExchange": "CatsTestingDirect",
+    "Retries": 1,
+    "DocumentService": "testing-document-service",
+    "PaymentService": "testing-payment-service",
+    "TasksService": "testing-tasks-service",
+    "OvernightService": "testing-overnight-service"
   }
 }

--- a/src/Server.UI/appsettings.Training.json
+++ b/src/Server.UI/appsettings.Training.json
@@ -1,8 +1,8 @@
 {
   "DetailedErrors": true,
-  "IdleTimeOutMinutes": 10,
-  "PrimaryColour": "#305CDE",
-  "PreLoginMessage": "This is a development environment and must never contain live or real data.",
+  "IdleTimeOutMinutes": 60,
+  "PrimaryColour": "#FF46A2",
+  "PreLoginMessage": "This is a training environment and must never contain live or real data.",
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
@@ -11,16 +11,16 @@
   },
   "Sentry": {
     "Dsn": "",
-    "Environment": "Development",
+    "Environment": "Training",
     "MinimumBreadcrumbLevel": "Debug",
-    "MinimumEventLevel": "Information",
+    "MinimumEventLevel": "Warning",
     "TracesSampleRate": 1.0,
     "ProfilesSampleRate": 1.0,
     "AttachStacktrace": true,
     "SendDefaultPii": false,
     "MaxBreadcrumbs": 50,
     "MaxRequestBodySize": "Small",
-    "ShutdownTimeout": "00:00:05",
+    "ShutdownTimeout": "00:00:10",
     "CaptureBlockingCalls": true
   },
   "Notify": {
@@ -37,14 +37,13 @@
       }
     ]
   },
-  "Features": {
-    "InMemoryTargetsProviderReprofiled": true,
-    "UseWorkerForJobs": true,
-    "UseSignalRBackplane": true,
-    "UseRedisSessionStore": true,
-    "PresenceHub": {
-      "Enabled": true,
-      "RelayUserPresenceNotifications": true
-    }
+  "RabbitSettings": {
+    "TopicExchange": "CatsTrainingTopics",
+    "DirectExchange": "CatsTrainingDirect",
+    "Retries": 1,
+    "DocumentService": "training-document-service",
+    "PaymentService": "training-payment-service",
+    "TasksService": "training-tasks-service",
+    "OvernightService": "training-overnight-service"
   }
 }


### PR DESCRIPTION
## 📝 Description

This pull request updates environment-specific configuration files for the application, mainly by adjusting timeout and logging settings and adding new configuration files for the Testing and Training environments. The most important changes are summarized below:

**New environment configuration files:**

* Added `appsettings.Testing.json` and `appsettings.Training.json` to support the Testing and Training environments, each with their own logging, Sentry, and notification template settings. [[1]](diffhunk://#diff-5dfc8c3fb35cef6ff752b6051bf62d1191c7e40631c1167b52ffe1d7692295b2R1-R40) [[2]](diffhunk://#diff-1c5e1381b0d94d832d8c344852a6c958086cccee7b76ec17eef26d2c176769ddR1-R40)

**Timeout and logging configuration changes:**

* Increased `IdleTimeOutMinutes` from 5 to 10 in `appsettings.Development.json` to allow longer idle sessions during development.
* Changed Sentry logging level from `Information` to `Warning` in `appsettings.PreProduction.json` to reduce log verbosity in the PreProduction environment.

## 🔗 Jira Ticket

https://dsdmoj.atlassian.net/browse/CFODEV-1779

## 🚀 How to QA

When deployed to Testing and UAT colours etc should be set based on these files.

## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`