### PR TITLE
Simplify redis / session store / user-cache regisration

### DIFF
--- a/helm_deploy/cats/values.yaml
+++ b/helm_deploy/cats/values.yaml
@@ -101,7 +101,9 @@ app:
     Features__UseWorkerForJobs: "true"
     Features__PresenceHub__Enabled: "true"
     Features__PresenceHub__RelayUserPresenceNotifications: "true"
-    Features__UseSignalRBackplane: "true"
+    Features__Redis__Enabled: "true"
+    Features__Redis__SignalRBackplane: "true"
+    Features__Redis__SessionStore: "true"
     WorkerOptions__BaseUrl: "http://cats-worker:8080"
     Sentry__Release: "0.0.0"                    # overridden by CI
     AppConfigurationSettings__Version: "0.0.0"  # overridden by CI

--- a/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
+++ b/src/Aspire/Cats.AppHost/Extensions/AppExtensions.cs
@@ -8,7 +8,9 @@ internal static class AppExtensions
         CatsDatabaseResources databases)
     {
         var useWorkerForJobs = string.Equals(builder.Configuration["Features:UseWorkerForJobs"], "true", StringComparison.OrdinalIgnoreCase);
-        var useSignalRBackplane = string.Equals(builder.Configuration["Features:UseSignalRBackplane"], "true", StringComparison.OrdinalIgnoreCase);
+        var redisEnabled = string.Equals(builder.Configuration["Features:Redis:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
+        var useRedisSignalRBackplane = string.Equals(builder.Configuration["Features:Redis:SignalRBackplane"], "true", StringComparison.OrdinalIgnoreCase);
+        var useRedisSessionStore = string.Equals(builder.Configuration["Features:Redis:SessionStore"], "true", StringComparison.OrdinalIgnoreCase);
         var enablePresenceHub = string.Equals(builder.Configuration["Features:PresenceHub:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
         var relayUserPresenceNotifications = string.Equals(builder.Configuration["Features:PresenceHub:RelayUserPresenceNotifications"], "true", StringComparison.OrdinalIgnoreCase);
         var replicaCount = int.TryParse(builder.Configuration["Replicas"], out var n) ? n : 1;
@@ -16,7 +18,9 @@ internal static class AppExtensions
         var cats = builder.AddProject<Projects.Server_UI>("cats")
             .WithCatsDatabaseReference(databases.CatsDb)
             .WithEnvironment("Features__UseWorkerForJobs", useWorkerForJobs.ToString().ToLowerInvariant())
-            .WithEnvironment("Features__UseSignalRBackplane", useSignalRBackplane.ToString().ToLowerInvariant())
+            .WithEnvironment("Features__Redis__Enabled", redisEnabled.ToString().ToLowerInvariant())
+            .WithEnvironment("Features__Redis__SignalRBackplane", useRedisSignalRBackplane.ToString().ToLowerInvariant())
+            .WithEnvironment("Features__Redis__SessionStore", useRedisSessionStore.ToString().ToLowerInvariant())
             .WithEnvironment("Features__PresenceHub__Enabled", enablePresenceHub.ToString().ToLowerInvariant())
             .WithEnvironment("Features__PresenceHub__RelayUserPresenceNotifications", relayUserPresenceNotifications.ToString().ToLowerInvariant())
             .WithReference(rabbit)
@@ -27,9 +31,9 @@ internal static class AppExtensions
             cats.WithReplicas(replicaCount);        
         }
 
-        if(useSignalRBackplane)
+        if(redisEnabled)
         {
-            var redis = builder.AddSignalRBackplane();
+            var redis = builder.AddCatsRedis();
             
             cats.WithReference(redis)
                 .WaitFor(redis);
@@ -68,7 +72,7 @@ internal static class AppExtensions
         return rabbit;
     }
 
-    public static IResourceBuilder<RedisResource> AddSignalRBackplane(this IDistributedApplicationBuilder builder)
+    public static IResourceBuilder<RedisResource> AddCatsRedis(this IDistributedApplicationBuilder builder)
     {
         var redis = builder.AddRedis("redis")
             // 7.4-alpine

--- a/src/Aspire/Cats.AppHost/appsettings.Development.json
+++ b/src/Aspire/Cats.AppHost/appsettings.Development.json
@@ -8,7 +8,11 @@
   "MigrationBehaviour": "WaitForCompletion",
   "Features": {
     "UseWorkerForJobs": true,
-    "UseSignalRBackplane": true,
+    "Redis": {
+      "Enabled": true,
+      "SignalRBackplane": true,
+      "SessionStore": true
+    },
     "PresenceHub": {
       "Enabled": true,
       "RelayUserPresenceNotifications": true

--- a/src/Aspire/Cats.AppHost/appsettings.json
+++ b/src/Aspire/Cats.AppHost/appsettings.json
@@ -13,7 +13,11 @@
   "Replicas": 1,
   "Features": {
     "UseWorkerForJobs": false,
-    "UseSignalRBackplane": false,
+    "Redis": {
+      "Enabled": false,
+      "SignalRBackplane": false,
+      "SessionStore": false
+    },
     "PresenceHub": {
       "Enabled": false,
       "RelayUserPresenceNotifications": false

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -614,7 +614,7 @@ public static class DependencyInjection
                 }
             );
 
-        if(configuration.GetValue<bool>("Features:UseSignalRBackplane"))
+        if(configuration.GetValue<bool>("Features:Redis:Enabled") && configuration.GetValue<bool>("Features:Redis:SignalRBackplane"))
         {
             cache.WithSerializer(new FusionCacheSystemTextJsonSerializer(CacheJsonSerializerOptions.Options))
                  .WithDistributedCache(new RedisCache(new RedisCacheOptions { Configuration = configuration.GetConnectionString("redis") }))

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -105,24 +105,42 @@ public static class DependencyInjection
             services.AddScoped<PresenceHubClient>();
         }
 
-        if(config.GetValue<bool>("Features:UseSignalRBackplane") is not true)
-        {
-            services.AddSingleton<IUsersStateContainer, InMemoryUsersStateContainer>();
-        }
-        else
-        {
-            var redisConnectionString = config.GetConnectionString("redis") 
-                ?? throw new InvalidOperationException("Redis connection must be configured to use the SignalR backplane. Please set the 'redis' connection string in your configuration.");
+        // Configure Redis, SignalR backplane, and session store
+        var redisEnabled = config.GetValue<bool>("Features:Redis:Enabled");
+        var useRedisSignalRBackplane = redisEnabled && config.GetValue<bool>("Features:Redis:SignalRBackplane");
+        var useRedisSessionStore = redisEnabled && config.GetValue<bool>("Features:Redis:SessionStore");
 
-            signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
-            {
-                options.Configuration.ChannelPrefix = RedisChannel.Literal("Cats");
-            });
+        if (redisEnabled)
+        {
+            var redisConnectionString = config.GetConnectionString("redis")
+                ?? throw new InvalidOperationException("Redis connection must be configured when Features:Redis:Enabled is true. Please set the 'redis' connection string in your configuration.");
 
             services.AddSingleton<IConnectionMultiplexer>(_ =>
                 ConnectionMultiplexer.Connect(redisConnectionString));
 
+            if (useRedisSignalRBackplane)
+            {
+                signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
+                    options.Configuration.ChannelPrefix = RedisChannel.Literal("Cats"));
+            }
+        }
+
+        if (useRedisSignalRBackplane)
+        {
             services.AddSingleton<IUsersStateContainer, RedisUsersStateContainer>();
+        }
+        else
+        {
+            services.AddSingleton<IUsersStateContainer, InMemoryUsersStateContainer>();
+        }
+
+        if (useRedisSessionStore)
+        {
+            services.AddScoped<ICatsSessionStore, RedisSessionStore>();
+        }
+        else
+        {
+            services.AddScoped<ICatsSessionStore, ProtectedBrowserSessionStore>();
         }
 
         services.AddExceptionHandler<GlobalExceptionHandler>();
@@ -156,21 +174,6 @@ public static class DependencyInjection
             options.ForwardedHeaders =
                 ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
         });
-
-        if (config.GetValue<bool>("Features:UseRedisSessionStore"))
-        {
-            var redisConnectionString = config.GetConnectionString("redis")
-                ?? throw new InvalidOperationException("Redis connection must be configured to use the Redis session store. Please set the 'redis' connection string in your configuration.");
-
-            services.TryAddSingleton<IConnectionMultiplexer>(_ =>
-                ConnectionMultiplexer.Connect(redisConnectionString));
-
-            services.AddScoped<ICatsSessionStore, RedisSessionStore>();
-        }
-        else
-        {
-            services.AddScoped<ICatsSessionStore, ProtectedBrowserSessionStore>();
-        }
 
         services.AddScoped<CatsSessionStorage>();
         

--- a/src/Server.UI/appsettings.Development.json
+++ b/src/Server.UI/appsettings.Development.json
@@ -36,15 +36,5 @@
         "EmailTemplateId": ""
       }
     ]
-  },
-  "Features": {
-    "InMemoryTargetsProviderReprofiled": true,
-    "UseWorkerForJobs": true,
-    "UseSignalRBackplane": true,
-    "UseRedisSessionStore": true,
-    "PresenceHub": {
-      "Enabled": true,
-      "RelayUserPresenceNotifications": true
-    }
   }
 }

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -146,8 +146,11 @@
   "Features": {
     "InMemoryTargetsProviderReprofiled": true,
     "UseWorkerForJobs": false,
-    "UseSignalRBackplane": false,
-    "UseRedisSessionStore": false,
+    "Redis": {
+      "Enabled": false,
+      "SignalRBackplane": false,
+      "SessionStore": false
+    },
     "PresenceHub": {
       "Enabled": false,
       "RelayUserPresenceNotifications": false


### PR DESCRIPTION
## 📝 Description
This pull request refactors the configuration and setup for Redis, SignalR backplane, and session storage features in the Cats application. It replaces the previous single `UseSignalRBackplane` and `UseRedisSessionStore` flags with a more structured `Features:Redis` section, allowing for granular enabling/disabling of Redis, and its dependants: SignalR backplane, and session store. The changes are reflected across configuration files and service registration logic, improving flexibility and maintainability.

These changes provide more granular and future-proof configuration for Redis-related features, improve code clarity, and maintain backwards-compatibility.

## 🔗 Jira Ticket
* [CFODEV-1778](https://dsdmoj.atlassian.net/browse/CFODEV-1778)

## 🚀 How to QA
No change or regression in functionality should be observed.


## 📸 Screenshots / Recordings (If applicable)
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`

[CFODEV-1778]: https://dsdmoj.atlassian.net/browse/CFODEV-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ