### PR TITLE
Add port forwarding for redis (only available in dev)

### DIFF
--- a/helm_deploy/cats/templates/redis-port-forward-deployment.yaml
+++ b/helm_deploy/cats/templates/redis-port-forward-deployment.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.redisPortForward.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-port-forward-deployment
+  labels:
+    app: redis-port-forward
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-port-forward
+  template:
+    metadata:
+      labels:
+        app: redis-port-forward
+    spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      containers:
+        - name: redis-port-forward
+          image: {{ .Values.redisPortForward.image | quote }}
+          ports:
+            - containerPort: {{ .Values.redisPortForward.localPort }}   # this is your LOCAL_PORT inside the pod
+          env:
+            - name: REMOTE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-redis-instance-output
+                  key: primary_endpoint_address
+            - name: LOCAL_PORT
+              value: {{ .Values.redisPortForward.localPort | quote }}    # what the pod listens on
+            - name: REMOTE_PORT
+              value: {{ .Values.redisPortForward.remotePort | quote }}   # Redis in the cloud
+{{- end }}

--- a/helm_deploy/cats/values.yaml
+++ b/helm_deploy/cats/values.yaml
@@ -221,6 +221,17 @@ rdsPortForward:
   localPort: 11433   # port the pod listens on (your LOCAL_PORT)
   remotePort: 1433   # SQL Server port in the cloud
 
+# ---------------------------------------------------------------------------
+# Redis port-forward — an ad-hoc helper Deployment that bridges to the cloud
+# ElastiCache (Redis) so it can be reached via `kubectl port-forward`. Off in
+# non-development environments.
+# ---------------------------------------------------------------------------
+redisPortForward:
+  enabled: false
+  image: "ministryofjustice/port-forward@sha256:eaed873978acf6ccf23f08315f56ef71f0a7ffcd6a0bea821459bfb363b65e76"
+  localPort: 16379   # port the pod listens on (your LOCAL_PORT)
+  remotePort: 6379   # Redis port in the cloud
+
 # todo: enable prometheus alerts
 # generic-prometheus-alerts:
 #   targetApplication: cats

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -43,6 +43,10 @@ worker:
 rdsPortForward:
   enabled: true
 
+# Redis bridge - disabled in non-development environments
+redisPortForward:
+  enabled: true
+
 # todo: enable prometheus alerts
 # generic-prometheus-alerts:
 #   alertSeverity: cfo-alerts-nonprod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -42,6 +42,10 @@ worker:
 rdsPortForward:
   enabled: false
 
+# Redis bridge - disabled in non-development environments
+redisPortForward:
+  enabled: false
+
 # todo: enable prometheus alerts
 # generic-prometheus-alerts:
 #   alertSeverity: cfo-alerts-nonprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -43,6 +43,10 @@ worker:
 rdsPortForward:
   enabled: false
 
+# Redis bridge - disabled in non-development environments
+redisPortForward:
+  enabled: false
+
 # todo: enable prometheus alerts
 # generic-prometheus-alerts:
 #   alertSeverity: cfo-alerts


### PR DESCRIPTION
## 📝 Description

This pull request introduces a new, configurable Redis port-forwarding deployment to the Helm charts, allowing developers to bridge to a remote ElastiCache (Redis) instance via `kubectl port-forward`. This feature is enabled in development and disabled in preprod and production environments by default.

**New Redis port-forwarding deployment:**

* Added a new `redis-port-forward-deployment.yaml` template that creates a deployment for port-forwarding to a remote Redis instance, using environment variables for the remote host and ports.

**Configuration updates:**

* Introduced a new `redisPortForward` section in `values.yaml` to control enabling, image, and port settings for the Redis port-forward deployment.
* Enabled the Redis port-forward deployment in `values-dev.yaml` for development environments.
* Explicitly disabled the Redis port-forward deployment in `values-preprod.yaml` and `values-prod.yaml` for non-development environments. [[1]](diffhunk://#diff-ef0930f686605ac49d9922649053dd1e950bedd1f2752c658e5ea229cfa5b0aeR45-R48) [[2]](diffhunk://#diff-bb4e80ba0a6c43663498b44c19e42c074dcceac3d9564b49801202073b5c87ffR46-R49)

## 🔗 Jira Ticket

https://dsdmoj.atlassian.net/browse/CCPM-34

## 🚀 How to QA

n/a

## 📸 Screenshots / Recordings (If applicable)
## ☑️ Checklist Before Merging
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the Jira ticket status to `In Review`